### PR TITLE
Refactor text-align icons

### DIFF
--- a/icons/align-center.svg
+++ b/icons/align-center.svg
@@ -9,8 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="18" y1="10" x2="6" y2="10" />
   <line x1="21" y1="6" x2="3" y2="6" />
-  <line x1="21" y1="14" x2="3" y2="14" />
-  <line x1="18" y1="18" x2="6" y2="18" />
+  <line x1="17" y1="12" x2="7" y2="12" />
+  <line x1="19" y1="18" x2="5" y2="18" />
 </svg>

--- a/icons/align-justify.svg
+++ b/icons/align-justify.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="21" y1="6" x2="3" y2="6" />
-  <line x1="21" y1="12" x2="3" y2="12" />
-  <line x1="17" y1="18" x2="3" y2="18" />
+  <line x1="3" y1="6" x2="21" y2="6" />
+  <line x1="3" y1="12" x2="21" y2="12" />
+  <line x1="3" y1="18" x2="21" y2="18" />
 </svg>

--- a/icons/align-justify.svg
+++ b/icons/align-justify.svg
@@ -9,8 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="21" y1="10" x2="3" y2="10" />
   <line x1="21" y1="6" x2="3" y2="6" />
-  <line x1="21" y1="14" x2="3" y2="14" />
-  <line x1="21" y1="18" x2="3" y2="18" />
+  <line x1="21" y1="12" x2="3" y2="12" />
+  <line x1="17" y1="18" x2="3" y2="18" />
 </svg>

--- a/icons/align-left.svg
+++ b/icons/align-left.svg
@@ -9,8 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="17" y1="10" x2="3" y2="10" />
   <line x1="21" y1="6" x2="3" y2="6" />
-  <line x1="21" y1="14" x2="3" y2="14" />
+  <line x1="15" y1="12" x2="3" y2="12" />
   <line x1="17" y1="18" x2="3" y2="18" />
 </svg>

--- a/icons/align-right.svg
+++ b/icons/align-right.svg
@@ -9,8 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="21" y1="10" x2="7" y2="10" />
   <line x1="21" y1="6" x2="3" y2="6" />
-  <line x1="21" y1="14" x2="3" y2="14" />
+  <line x1="21" y1="12" x2="9" y2="12" />
   <line x1="21" y1="18" x2="7" y2="18" />
 </svg>


### PR DESCRIPTION
According to the thread in #102, the align icons needs an redesign.

I inspired the icons from the figma icons. 
I think these icons are more simplified and fit better with the other icons as wel.
![image](https://user-images.githubusercontent.com/11825403/97118848-a4fca800-170c-11eb-9767-0073a5e6d315.png)
