### PR TITLE
Fix: Bump Chakra-UI and add close button to toast

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -11,7 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@chakra-ui/core": "next",
+    "@chakra-ui/core": "^1.0.0-rc.8",
     "downloadjs": "^1.4.7",
     "framer-motion": "^2.9.4",
     "fuse.js": "^6.0.4",

--- a/site/src/components/IconDetailOverlay.tsx
+++ b/site/src/components/IconDetailOverlay.tsx
@@ -56,6 +56,7 @@ const IconDetailOverlay = ({ isOpen = true, onClose, icon }) => {
       description: `Icon "${name}" copied to clipboard.`,
       status: "success",
       duration: 1500,
+      isClosable: true
     });
   }
 

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -241,7 +241,14 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4":
+"@babel/helper-module-imports@^7.0.0":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
+  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
+  dependencies:
+    "@babel/types" "^7.12.5"
+
+"@babel/helper-module-imports@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
   dependencies:
@@ -1125,10 +1132,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.4", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
   integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1212,478 +1226,479 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chakra-ui/accordion@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-1.0.0-rc.7.tgz#939fcbe46047366753189b1f0612915ee4b03ba2"
-  integrity sha512-NYSRPf1KQhXVg713TnOJ7yyPgfCdmOTwFIqhHQDd+Y0/xHZjOI13ROdaH5xWXol5YLc3HTNKZmTvGHQMuFFa7g==
+"@chakra-ui/accordion@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-1.0.0-rc.8.tgz#474d4448fef0f315575bd924cc86d3fa52b37021"
+  integrity sha512-4carsEN6gJFPc9Acl1zckLxQZgxETKSE2ILOL4M+HCx83BMOER59KdEpOH5qNhB6bWlYUdXaj3metvfQz83pCA==
   dependencies:
-    "@chakra-ui/descendant" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/transition" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/descendant" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/transition" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/alert@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/alert/-/alert-1.0.0-rc.7.tgz#32e81a0ecd3f5439e12d518427bea971190a6a84"
-  integrity sha512-nfSKFPyS7dRzAFdAN84DlaESimdwLsyO2bJgWBDRTzpBWW/YNcrwTDVi/+5Y5W0DGnSxVDDZ4KNAzb9LO1pYlQ==
+"@chakra-ui/alert@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/alert/-/alert-1.0.0-rc.8.tgz#5a689f3dc01e417cbe7b6f8995d16b2881139ee2"
+  integrity sha512-/K6Y3dT14zs7T12/3zYHiECOF/j0OoyLQsqPpOxsDmsaXrmaxhXzsYRFqn5Skurja240Z9O2SXS+ABRVGeo95w==
   dependencies:
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/avatar@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/avatar/-/avatar-1.0.0-rc.7.tgz#edd4df4c05f2b98d95e3c35a3e7869b3d6b5d714"
-  integrity sha512-B1LES9rybthqSFh/b8o+4hV2juihWbCigb/B7DlebDX8hMR1zOnwfNFIo2Ot67VNX31VZ0lJwc8s0y2FDbSK9w==
+"@chakra-ui/avatar@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/avatar/-/avatar-1.0.0-rc.8.tgz#326fd1fa86744882cbb0befe173180f8ee6ce094"
+  integrity sha512-gDj/dtFIpNyILJ7EMHENnadrTcRd97mvvhe2uty/9FkPOhPALqofIKkUKvIKbsm9IVg2TDnttS5tylzLRyceQg==
   dependencies:
-    "@chakra-ui/image" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/image" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/breadcrumb@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/breadcrumb/-/breadcrumb-1.0.0-rc.7.tgz#9c7aa0f4d6b8aa6b2b05d80bd9e45b63de12dd33"
-  integrity sha512-56wHUfqsXCWXvWGC4u2gVwcZXQ50lZfK1BBnlJXeaIweMC04FGE8Ji9iiVGrcps1p8xq/2uFsdXv7LpapC5OVw==
+"@chakra-ui/breadcrumb@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/breadcrumb/-/breadcrumb-1.0.0-rc.8.tgz#cc1da4ea1fbcc1ea206c254c83f0f0363bf41294"
+  integrity sha512-6vUDDAaEQvQPBOqkvhtfQPFOh0CsCLYnrjqDPofQpd+UqVMDINembuHCVpAunswo73GCym5vagVe56QvXt7jow==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/button@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/button/-/button-1.0.0-rc.7.tgz#0ea77c297a4b082f855fc5fbbc0f53bf3ff74a17"
-  integrity sha512-bYqWMe95IzM6ESCQsMVA+95X9BD4KSNc4erlyJdm0DiK9BiEBffM5fO5pCkf6Jnz2PugQ4U99rXC/u6lAICiow==
+"@chakra-ui/button@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/button/-/button-1.0.0-rc.8.tgz#61a185907c7be30332917a963ccfdecc888836e7"
+  integrity sha512-qX9Duvio01XEWWFAn3f+SQ/qr5TRX4HxTuBEuF1kIw8RqKCnP5a5pS7g+7KS3Uxx+bIbZ/q/ADuChn0AgXpCsA==
   dependencies:
-    "@chakra-ui/spinner" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/spinner" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/checkbox@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/checkbox/-/checkbox-1.0.0-rc.7.tgz#815b1ab42dd22bc9e6a7aee4d370c9d03468ca36"
-  integrity sha512-LWL6PkDy74KZ44JoQeBLvg/HzvKp0M8nPRJqIOk6sSINSV4me08QKV93kAPOBsKI4DuHVzQQAzh2PP950yPqBg==
+"@chakra-ui/checkbox@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/checkbox/-/checkbox-1.0.0-rc.8.tgz#1dc81c79e7a4269989a55b7bb1a1a7ce5cd25778"
+  integrity sha512-BW8g3pO2bp5YPl1udGnAZeQ3YEuHCplX7iDWFsSREJLstJOrC1mb9VyGyWHuEsq/KXjjfaWAfPDqy9CNlf6aTg==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
-    "@chakra-ui/visually-hidden" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
+    "@chakra-ui/visually-hidden" "1.0.0-rc.8"
 
-"@chakra-ui/clickable@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/clickable/-/clickable-1.0.0-rc.7.tgz#e157c3a2c63baaf98585c5fe90da15918b7046bc"
-  integrity sha512-bsu0+WzEVWKuTJNtGTuwT4J+f52t3nn5zv+JhKuwOmFjPxnBHnX1qfrGRN5kucnZbtJYv/YkW8VrmQSFqnZFIA==
+"@chakra-ui/clickable@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/clickable/-/clickable-1.0.0-rc.8.tgz#3e9d2708d28d55496b1de5b34b532f7d99266672"
+  integrity sha512-45mMSfpKami4/NQk+QKXgfnkPyQ57yXQc2LFHx35m6ErXAe2m450Qv40Hj5lxJgrzmETms/SgskJ6GAhdajjtg==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/close-button@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/close-button/-/close-button-1.0.0-rc.7.tgz#ed9c99d20ef1523ddd5fd2e39e703109906e42e0"
-  integrity sha512-vDtvAtGr6TWGqG00xxmUXAYOIATSjS98ShONA76D85fhucBN7cRnD4+bYWyXjatrHSPXFv81yvebc5Q7wrSlkQ==
+"@chakra-ui/close-button@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/close-button/-/close-button-1.0.0-rc.8.tgz#0b4c7926c6de3a6d8f889b0a0afb8e91b557bac2"
+  integrity sha512-jELCVjMaDbrP6YnAj/fTG7hhItc1HK23LxaLZ2Fug82Tb04+8Y5097Sszvn9U0JI46oxhqoUSPPo6UxKHCZrZQ==
   dependencies:
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/color-mode@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/color-mode/-/color-mode-1.0.0-rc.7.tgz#8c642d836dbd78c082a383d19f674ca46bd3ac39"
-  integrity sha512-7X3cFElUONF+W14PNneqPAdWH6V2WHVGucjXlbM1+UjQZkVU7jMVTu/n0yqeo1BCAhZxDELEU5cgikl5wAgu8w==
+"@chakra-ui/color-mode@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/color-mode/-/color-mode-1.0.0-rc.8.tgz#c0c59851d6ea7965b68dba74bd4ba9fb6a345cc4"
+  integrity sha512-NLanjgYN/rzHzWZ9KLGWsaTDmrlGR4PlS9ngXPQW9K0dy8d362wDVuag8IDx435aovXt6tOkbwmNZ1HGNPzAfw==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/control-box@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/control-box/-/control-box-1.0.0-rc.7.tgz#ba932acf088c29437071b026acc5506d8f7edd3d"
-  integrity sha512-X6Q+ZU4DLusz1USvxvAxi1uu4yxbueFhpIDQb1aQovWW5IfszzoVU6aoLUYTr79KgrjNLsg2I+MLyZNA+XQdnw==
+"@chakra-ui/control-box@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/control-box/-/control-box-1.0.0-rc.8.tgz#365ba31f44fe91a6fc14fee87c02fc469d48026b"
+  integrity sha512-fg/9tfUqaFHjn6JGnHytoGX6W3DUjBxkzcNJtrYX+LNb7CFuC94EOV8d1XkXAMxUVxA901SIOionAU/cTRDkEQ==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/core@next":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/core/-/core-1.0.0-rc.7.tgz#19ddadfcf2f0a4c6bd5fb163a71a099ba16b292f"
-  integrity sha512-VZ/1COKWTYvfWqjOjnWyhdA4sQiYi+8w3mojS7kOSouQENBEdKNbN1TB2YfRqOZpWUYQ/XlSSyRLjIW84KemZA==
+"@chakra-ui/core@^1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/core/-/core-1.0.0-rc.8.tgz#2a2e7105b18488762edf479cc7cd77185503c760"
+  integrity sha512-ZPGjTwy5QrYG/sYuGhrYeBNfWNIfQMSI4spHkNusd+qmNwPJMXR/WO0M8FwTdSnLc0ZVubUpvqdY4e9fp+xT+g==
   dependencies:
-    "@chakra-ui/accordion" "1.0.0-rc.7"
-    "@chakra-ui/alert" "1.0.0-rc.7"
-    "@chakra-ui/avatar" "1.0.0-rc.7"
-    "@chakra-ui/breadcrumb" "1.0.0-rc.7"
-    "@chakra-ui/button" "1.0.0-rc.7"
-    "@chakra-ui/checkbox" "1.0.0-rc.7"
-    "@chakra-ui/close-button" "1.0.0-rc.7"
-    "@chakra-ui/control-box" "1.0.0-rc.7"
-    "@chakra-ui/counter" "1.0.0-rc.7"
-    "@chakra-ui/css-reset" "1.0.0-rc.7"
-    "@chakra-ui/editable" "1.0.0-rc.7"
-    "@chakra-ui/form-control" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/image" "1.0.0-rc.7"
-    "@chakra-ui/input" "1.0.0-rc.7"
-    "@chakra-ui/layout" "1.0.0-rc.7"
-    "@chakra-ui/live-region" "1.0.0-rc.7"
-    "@chakra-ui/media-query" "1.0.0-rc.7"
-    "@chakra-ui/menu" "1.0.0-rc.7"
-    "@chakra-ui/modal" "1.0.0-rc.7"
-    "@chakra-ui/number-input" "1.0.0-rc.7"
-    "@chakra-ui/pin-input" "1.0.0-rc.7"
-    "@chakra-ui/popover" "1.0.0-rc.7"
-    "@chakra-ui/popper" "1.0.0-rc.7"
-    "@chakra-ui/portal" "1.0.0-rc.7"
-    "@chakra-ui/progress" "1.0.0-rc.7"
-    "@chakra-ui/radio" "1.0.0-rc.7"
-    "@chakra-ui/select" "1.0.0-rc.7"
-    "@chakra-ui/skeleton" "1.0.0-rc.7"
-    "@chakra-ui/slider" "1.0.0-rc.7"
-    "@chakra-ui/spinner" "1.0.0-rc.7"
-    "@chakra-ui/stat" "1.0.0-rc.7"
-    "@chakra-ui/switch" "1.0.0-rc.7"
-    "@chakra-ui/system" "1.0.0-rc.7"
-    "@chakra-ui/tabs" "1.0.0-rc.7"
-    "@chakra-ui/tag" "1.0.0-rc.7"
-    "@chakra-ui/textarea" "1.0.0-rc.7"
-    "@chakra-ui/theme" "1.0.0-rc.7"
-    "@chakra-ui/toast" "1.0.0-rc.7"
-    "@chakra-ui/tooltip" "1.0.0-rc.7"
-    "@chakra-ui/transition" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
-    "@chakra-ui/visually-hidden" "1.0.0-rc.7"
+    "@chakra-ui/accordion" "1.0.0-rc.8"
+    "@chakra-ui/alert" "1.0.0-rc.8"
+    "@chakra-ui/avatar" "1.0.0-rc.8"
+    "@chakra-ui/breadcrumb" "1.0.0-rc.8"
+    "@chakra-ui/button" "1.0.0-rc.8"
+    "@chakra-ui/checkbox" "1.0.0-rc.8"
+    "@chakra-ui/close-button" "1.0.0-rc.8"
+    "@chakra-ui/control-box" "1.0.0-rc.8"
+    "@chakra-ui/counter" "1.0.0-rc.8"
+    "@chakra-ui/css-reset" "1.0.0-rc.8"
+    "@chakra-ui/editable" "1.0.0-rc.8"
+    "@chakra-ui/form-control" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/image" "1.0.0-rc.8"
+    "@chakra-ui/input" "1.0.0-rc.8"
+    "@chakra-ui/layout" "1.0.0-rc.8"
+    "@chakra-ui/live-region" "1.0.0-rc.8"
+    "@chakra-ui/media-query" "1.0.0-rc.8"
+    "@chakra-ui/menu" "1.0.0-rc.8"
+    "@chakra-ui/modal" "1.0.0-rc.8"
+    "@chakra-ui/number-input" "1.0.0-rc.8"
+    "@chakra-ui/pin-input" "1.0.0-rc.8"
+    "@chakra-ui/popover" "1.0.0-rc.8"
+    "@chakra-ui/popper" "1.0.0-rc.8"
+    "@chakra-ui/portal" "1.0.0-rc.8"
+    "@chakra-ui/progress" "1.0.0-rc.8"
+    "@chakra-ui/radio" "1.0.0-rc.8"
+    "@chakra-ui/select" "1.0.0-rc.8"
+    "@chakra-ui/skeleton" "1.0.0-rc.8"
+    "@chakra-ui/slider" "1.0.0-rc.8"
+    "@chakra-ui/spinner" "1.0.0-rc.8"
+    "@chakra-ui/stat" "1.0.0-rc.8"
+    "@chakra-ui/switch" "1.0.0-rc.8"
+    "@chakra-ui/system" "1.0.0-rc.8"
+    "@chakra-ui/tabs" "1.0.0-rc.8"
+    "@chakra-ui/tag" "1.0.0-rc.8"
+    "@chakra-ui/textarea" "1.0.0-rc.8"
+    "@chakra-ui/theme" "1.0.0-rc.8"
+    "@chakra-ui/toast" "1.0.0-rc.8"
+    "@chakra-ui/tooltip" "1.0.0-rc.8"
+    "@chakra-ui/transition" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
+    "@chakra-ui/visually-hidden" "1.0.0-rc.8"
 
-"@chakra-ui/counter@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/counter/-/counter-1.0.0-rc.7.tgz#a7a590061772b2e3b4c103883c544c121e8df39e"
-  integrity sha512-KHUDODa8Bp1MFBFjM1Gdo1oqCmJq0w+BXglSjzB6O5Z0QxB9Y2gEmjGm0FHIiF1/XT2RVcO/iW/qiu3ZyQM77Q==
+"@chakra-ui/counter@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/counter/-/counter-1.0.0-rc.8.tgz#507875b14c7de6f048e50edd7b0145670e39ef98"
+  integrity sha512-Ry+U48Z8wATdclxQ3eLmRcSCKScUT7hO71QPd8k8HOexftXowMHi2Iv5XjBBJReb9wCagSc4P5einAUWUAUbnQ==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/css-reset@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/css-reset/-/css-reset-1.0.0-rc.7.tgz#8f79a06e3ca237b167ce9c62162adfdb46185e79"
-  integrity sha512-Om/ipNLc3b43ALcwMLLK6j2ET4jhipm1npl2z37zPdHvBGsutI2gC/pHqiNBX6Yy6iOFMleTs8MNHyQF4D0BYg==
+"@chakra-ui/css-reset@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/css-reset/-/css-reset-1.0.0-rc.8.tgz#98eeec5e813244917ecbe1545a75d5632cb3480b"
+  integrity sha512-s/V28H0W324OYRL8yxpBT1u0rTe+D0R9AmmUjMDmUV+ETxZ77zQMa3DykutbD+Kem3fJv8bpgVuM/uB2utfXSw==
 
-"@chakra-ui/descendant@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/descendant/-/descendant-1.0.0-rc.7.tgz#a01e31c92527772be4d5053abbc80768618b90a6"
-  integrity sha512-z8G1nL1wbw3/aHdS6NSOvoMfcn2i5eA+r+XJuibN9GMc1+7PlNW4pq1Tej/mMUCFwtwrtdL1otKeuDwHrbIDNA==
+"@chakra-ui/descendant@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/descendant/-/descendant-1.0.0-rc.8.tgz#463f5e1379cd6a93b8a8de22775e4c44c9c4fc2e"
+  integrity sha512-JK40BihvaNZBlEss8Ez58Ccub0XlOyJVJkGm9xPva7p5MygeTlqwXu8dE8IhJfDI99AFheMNPY1r24n1yoYOMQ==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
 
-"@chakra-ui/editable@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/editable/-/editable-1.0.0-rc.7.tgz#21a065584b9b787bd763d54ddedcd0625ae3e283"
-  integrity sha512-frWVgsDNtPTSFKfSaAvYq14ieUIH22x5EZNkYukoODXGlYW3vcbN/WeOon66AcpP/KY5V/3+7vdbdvdyJmwmBw==
+"@chakra-ui/editable@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/editable/-/editable-1.0.0-rc.8.tgz#8938c8cb9d7f0af71aa2afb76dc7671ba301a74a"
+  integrity sha512-9kiJk4QVzgv9yVKiTCsYcSbdVcWPq3btj5gHfKDvKgwevD5Wv2sWW8gHklpT5oGNpIxEZB8lcJLpywG+p2Ct/g==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/focus-lock@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/focus-lock/-/focus-lock-1.0.0-rc.7.tgz#fdbe241d85f2a3b004057ee9b8e1b0d713de4172"
-  integrity sha512-imkxFh/ltcq8uOEfLzcKrlr0sTABcTcGxQPgx5X3ZzAlNUggXtIIXAHhGmTiZNFBTAAFEIIaWyl0/KD9Hv9kHw==
+"@chakra-ui/focus-lock@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/focus-lock/-/focus-lock-1.0.0-rc.8.tgz#4de1647d7825a6e40a26261e25ae55a639d9eec2"
+  integrity sha512-a53KsV/i5bII2jaHDU8LbvkNkJKIiqETiWMxhetUSQ5kevY2XLLGyCQibj814f9awsnUXD7ydo0nW3B8DaRYPw==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
     react-focus-lock "2.4.1"
 
-"@chakra-ui/form-control@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/form-control/-/form-control-1.0.0-rc.7.tgz#baa8aa64cbd82e1348c3af59ce83de3b5bc5857f"
-  integrity sha512-bPjXo6tHSKAiRHFF0u6HYL2SSzPKsK3mZjZwmdhA8eCpwiMnyF4FvjaMQuicOpA/yejfBXSkN7rBoB4bVxmexg==
+"@chakra-ui/form-control@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/form-control/-/form-control-1.0.0-rc.8.tgz#ea23b1867a80282b110fab8c5c8523d00422e91f"
+  integrity sha512-aoQWl7QMg+RJ51s/NkuxldCPGVtN5gaQLASAXXaUbrwyLCPFyEpgk541096laRB+h5uKytIzRcEvVv7Ox5Gtdw==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/hooks@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/hooks/-/hooks-1.0.0-rc.7.tgz#1236e2199abeb3beef32897466ccb63c6ac442e7"
-  integrity sha512-7zOI3eHe2+TB6RpUGzm0AZo0WyopKP6aSfjRox3N6tku4F5KWGmWjGpalSYp4TsGkKM8YBrp5la89YckQVMoXQ==
+"@chakra-ui/hooks@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/hooks/-/hooks-1.0.0-rc.8.tgz#745942a1736d31cac487e7cd38069d3e74b89085"
+  integrity sha512-4B1WBsAU47ZKUyvgTvu5vo1d2aczGHDv7YAcuNQdLF7Bwpk5geWvYf8iO5rz15Bfu9NuBOwU76VoG95b+TBzUA==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
     "@reach/auto-id" "0.11.0"
     compute-scroll-into-view "1.0.14"
     copy-to-clipboard "3.3.1"
 
-"@chakra-ui/icon@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.0.0-rc.7.tgz#bd283d4d5a85b24fea5d17fbc4bec03c818abc2f"
-  integrity sha512-v263Q2nnOtqn2QOiC5QDeKatedr98XL+OlPj5GmI0c1I9KOORoHDFjTJuEFvkddUpoj62Rto1Fd4cVqWevRFQQ==
+"@chakra-ui/icon@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.0.0-rc.8.tgz#9c5763ee96c7c9e7458b53ddcd099b605847ba95"
+  integrity sha512-kWcetk7d7iKd8Ht5+c+065UWKYHbCSJl3EYnNXLpGr/UJh/Saq/qHhftJASm1lcxjy6lVVTlnP6qm8kVvcvpAw==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/image@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.0.0-rc.7.tgz#fb3fd0be226d7c2b685adbc44ce7df7f384e3da0"
-  integrity sha512-XgAF2FsHp4E/aNDE43ZSKrghrgZCdb2ZIAiT8s6eH+xFeIVowSsiUjAsEwajEFA7fmdQ3xdt8/GKituTM2a8ZQ==
+"@chakra-ui/image@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.0.0-rc.8.tgz#fb9f25f93617b82d1e91ed48e5f24e2e1e342085"
+  integrity sha512-u+el3/RS7JOlPbu1xUNzfhNsMYFWVdcaSGEDPCrRI2m4/8Egik2uWEplNxakZYCfvhu2Orx3GO6JyEnaWJvvkw==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/input@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/input/-/input-1.0.0-rc.7.tgz#0559111bcbc52efbe6ae0c719ceb096564e7d9a5"
-  integrity sha512-4khOk5Kt+wpERzXZvhbAnvkOQcNFtldOJ6xdOzKXg1+45+xvVWNyjRYBP/exGqc7wKkzE1THpyN5BBPclWBeXQ==
+"@chakra-ui/input@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/input/-/input-1.0.0-rc.8.tgz#b3f93ac64fdb56ce6fa9925dee446656c77b4e43"
+  integrity sha512-FJtB9zwOf38GuhS5VGyLlCUFXHSl0OrCQbrwdKakIZz986o+6DGEShIczoifs0QniGKSsNXcLu3m2FX0QxWQmw==
   dependencies:
-    "@chakra-ui/form-control" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/form-control" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/layout@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/layout/-/layout-1.0.0-rc.7.tgz#d4728dad9576093238ad149af4f301b2d6f96277"
-  integrity sha512-DuFHgj7fbPkoLn2MSCaUEap9oDvcMSYIyovJYY2MDw0/xl7v1Nbp4DaPSWTJxLz7Bohv43ViNFwrYaPkSOO5EQ==
+"@chakra-ui/layout@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/layout/-/layout-1.0.0-rc.8.tgz#62b3eb050d476d8cd4c87efbda48221d4c1b7c61"
+  integrity sha512-nDocS9eW0f/dnSFtkMYa9aOSUkawbUSOJHmEMRmd696NW/cf8jYWifZPcSWJHqw1V8NR6MYgGLYJ/fgdlT/OGA==
   dependencies:
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/live-region@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/live-region/-/live-region-1.0.0-rc.7.tgz#c3beaf95b5f1562f1cebcc5a2e0285c56ad4de4b"
-  integrity sha512-xeBD2lOWjhOXKRvhCInAJOgswc8QPytIMePkRnBMATc3Tamc5ZgLa+a4FQpzRGr/ydRjbqLD3d0+w5zAkUh8vA==
+"@chakra-ui/live-region@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/live-region/-/live-region-1.0.0-rc.8.tgz#deb74adb91514cf384e7790aeca371363a74e988"
+  integrity sha512-QFOokqJJ5BrvaMG9EsyzKG/O4xIcGDk+P5+Otuuu8dtBV01e+lb/mXts4lTi+eXVgSOONMZNuLuhkZ0tYVNvmA==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/media-query@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/media-query/-/media-query-1.0.0-rc.7.tgz#703afe66919d9bca36f4d18003af71e45a24ac86"
-  integrity sha512-OjuKTr1SmCvB/Lb0DXoFsXUG4V8Nk/68pBg4RInBDIxM8prrtgkbgV6hRCVGp+VXOHLfFmfZgd4emeHONZmxQA==
+"@chakra-ui/media-query@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/media-query/-/media-query-1.0.0-rc.8.tgz#0c816a57cacd3d9813be1813bd7aacf4aa0f8866"
+  integrity sha512-q8pmT4kgxc9pHZ7qtKRxfdQbMLbZ14Z8AEEbTGy4oD7eZutmWn77zkx5cC4MN02pRFghndEqFKIh5Wr+X1KjCg==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/menu@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/menu/-/menu-1.0.0-rc.7.tgz#9621ab876246b132cd5e1fbd3c1baef91f83b1ef"
-  integrity sha512-DoAEC8D78a5XWn919BtDCGjEsabz1OrTLVvItqZ3F1toQI+0IGW9k78KOYQPkEwJpkX5mJlW9azvHUoimeOLaQ==
+"@chakra-ui/menu@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/menu/-/menu-1.0.0-rc.8.tgz#56720913eda2a6585b96fa6c358a17668533a02b"
+  integrity sha512-uIxetUTY9SoTihQqNJUpX4WnrRKBAAFbx7FqUjuASsTa8NRWEtp9DCFrrL3hQt2XJxkmxN29Y02cGdrJoymYJg==
   dependencies:
-    "@chakra-ui/clickable" "1.0.0-rc.7"
-    "@chakra-ui/descendant" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/popper" "1.0.0-rc.7"
-    "@chakra-ui/transition" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/clickable" "1.0.0-rc.8"
+    "@chakra-ui/descendant" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/popper" "1.0.0-rc.8"
+    "@chakra-ui/transition" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/modal@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/modal/-/modal-1.0.0-rc.7.tgz#df61e9a0692424ff5e21a49c6ca0f3c52936597e"
-  integrity sha512-chvBs9wGGPajAD27YbC39YLLtYJ4CSb55VpWI4TeT6EK7V+vEDBrQQ5YsF/HMa/Fpwp2WIvljFHZw41SGAfU4A==
+"@chakra-ui/modal@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/modal/-/modal-1.0.0-rc.8.tgz#73cc5f4f5dd54dab6fe41de98d795ea0b119eef8"
+  integrity sha512-qiRjRkYYl/ycfBKMCrXtbi0lZcjIzVdIVO2/HQluMg+N1XrfiRKLU5CQPUot6RO4DWUlUEA+i+7YtH8VrItoMg==
   dependencies:
-    "@chakra-ui/close-button" "1.0.0-rc.7"
-    "@chakra-ui/focus-lock" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/portal" "1.0.0-rc.7"
-    "@chakra-ui/transition" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/close-button" "1.0.0-rc.8"
+    "@chakra-ui/focus-lock" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/portal" "1.0.0-rc.8"
+    "@chakra-ui/transition" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
     aria-hidden "^1.1.1"
     react-remove-scroll "2.4.0"
 
-"@chakra-ui/number-input@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/number-input/-/number-input-1.0.0-rc.7.tgz#0c5acf4e23622e3e5cf843baf1c87ffe592246d2"
-  integrity sha512-o473aCJ50KRgp2L/EY+iBZoZI3D+Dwhy4RdCDxGve+Nu1VSpAsaSK475h3o/WgATNFPjrWXJZftiUJMTbc6Nrg==
+"@chakra-ui/number-input@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/number-input/-/number-input-1.0.0-rc.8.tgz#f664b912c66f3e7819cdbeacca4e98591a9f1318"
+  integrity sha512-kWo43cD2aj2svUXObbdzcfeR1d+7S9hbm6WOnrWVkxWaOgl+zQ+Lb++ZAaFiE9eul8nJqHxz+b1chfy8Ix+EjQ==
   dependencies:
-    "@chakra-ui/counter" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/counter" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/pin-input@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/pin-input/-/pin-input-1.0.0-rc.7.tgz#d02abae9fc3a2c2ce8f2ec5ccc8bd1ee55479129"
-  integrity sha512-gWTZBTaRpMY0s5nGndiv11sAnr4FBSqOHm0jwp41sKpU+et9ZKXATKeyFrYwskwaS0eoUD6kap3cX7y8Ag2GJQ==
+"@chakra-ui/pin-input@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/pin-input/-/pin-input-1.0.0-rc.8.tgz#1097c73b6ee58adc0fe18624ffd17ec119e0912a"
+  integrity sha512-nJivIHAyptM4A+pgjq6ros/gern4VlbGTr+9x2D2aA6ullS3/W25TW0VR2+eI46ODfCtqitqwtiZuSUGYLJHWg==
   dependencies:
-    "@chakra-ui/descendant" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/descendant" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/popover@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/popover/-/popover-1.0.0-rc.7.tgz#a9ea24c13450f173469349d988add6ca8064d44b"
-  integrity sha512-C7Ct7Reoh2M1+jaAmwHegoHvWzprAaVp2q8qZy+bXlXwXq/KqLAEAlB/RV8nyiOPlgpLRp8ugySDKv1ySh+yHA==
+"@chakra-ui/popover@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/popover/-/popover-1.0.0-rc.8.tgz#496b84e496f0bcde57cae3a7e7b1505c588f22df"
+  integrity sha512-wl7AOisR3JyHWo4kkAJvT9no4rEYFrSHsOrrf/0YM3P6vks5ajEDu5XVc4UAf+JAUatp1pqovuis/Fae20ds4Q==
   dependencies:
-    "@chakra-ui/close-button" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/popper" "1.0.0-rc.7"
-    "@chakra-ui/portal" "1.0.0-rc.7"
-    "@chakra-ui/transition" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/close-button" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/popper" "1.0.0-rc.8"
+    "@chakra-ui/portal" "1.0.0-rc.8"
+    "@chakra-ui/transition" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/popper@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/popper/-/popper-1.0.0-rc.7.tgz#bf5c2514b255d0d78a3bee6ed4a35108e765ded2"
-  integrity sha512-YarG13UVEB10gfEDfZdpSlxGdEjlhNsjGtd1CP6czRsw1Ksro4uNy5J79QIyBC88qB7/fq180XU+jiPh0tZ3bg==
+"@chakra-ui/popper@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/popper/-/popper-1.0.0-rc.8.tgz#b388b5a07b02f62c2ac27e1c75acf663c5de4ab4"
+  integrity sha512-MAqCdf6/vLaJZr+YnRr9b1iceOdViM6TUnNKejLVQBEVunWxFQAqAlTWnatmqcjNaYO/pcd95lQ71TVqQdKmIw==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
     "@popperjs/core" "2.4.4"
-    react-popper "2.2.3"
+    dequal "2.0.2"
 
-"@chakra-ui/portal@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/portal/-/portal-1.0.0-rc.7.tgz#896f4511e4ada77118ecef0673d0083022e2ea40"
-  integrity sha512-4D/ZoJfXJWEu1onixd/ofSqV5yMTyE+9kvyXj+P0bkgecKevjKq2AVa2JEStG8PZnlhKnmtC8y53wsiYeVAWEw==
+"@chakra-ui/portal@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/portal/-/portal-1.0.0-rc.8.tgz#5745038c411e5aa2a9e1588e6283f7716a4c0912"
+  integrity sha512-jkDY7BawoupgIgEcYNS2X/wO7gSRappzqOfvAj0VxPMREvrQOclIBWoTLad5UAQJp+OP1BzAwPzpo79OC8IaYQ==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/progress@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/progress/-/progress-1.0.0-rc.7.tgz#d519869cfbde73f58ab1b294dc8ae98bfa37c5e0"
-  integrity sha512-iGwjT7VitBmR4DERuDokC9RlPMXDULAg1TMn3U+gDSsd/JyrBpXtlMWNJRjSEKzWc79PyC39Z5kKGCv6g/tfxw==
+"@chakra-ui/progress@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/progress/-/progress-1.0.0-rc.8.tgz#a88c7385318bb16982371a38816782e0ea217366"
+  integrity sha512-rgo1A34tEAErzRTnmv8E+4bf2PVfka+Rm7nInBL/hptIa2JeC7YtwuiV20yBITJhwBYP2NTgF1S0KmINzpi61g==
   dependencies:
-    "@chakra-ui/theme-tools" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/theme-tools" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/radio@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/radio/-/radio-1.0.0-rc.7.tgz#3b72cd368ce7bcc5a85381436b99324fb9948cda"
-  integrity sha512-ixpxxzO7ejUe3lzdww0FB7mNeDolLfH3fEsbxH6lhVHCHKDRmuq/6jVEKOBjxXGLhqOZnl/JnkXv+79li5KtcQ==
+"@chakra-ui/radio@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/radio/-/radio-1.0.0-rc.8.tgz#f177a12a7534abc22d013b5df8d5b1d8c9f170c7"
+  integrity sha512-ecsUP7rcUgVIlUHhkWmHYYe0DKymuOpEPKuzJkagDl425vKyg4Z9hPtHC0aFLesWD+wLcHwbpDUQTyrtuK7qow==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
-    "@chakra-ui/visually-hidden" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
+    "@chakra-ui/visually-hidden" "1.0.0-rc.8"
 
-"@chakra-ui/select@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/select/-/select-1.0.0-rc.7.tgz#20dd098437cf31e26cd443275e101106edb81730"
-  integrity sha512-c1XPOMyfu90G5Q8fEyXu4xa99ymeP9GkiTzEhnMc3TKdUJ/RrUlssUchMuRXEgiEPwKRtQCce6OjjXqJuXA98Q==
+"@chakra-ui/select@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/select/-/select-1.0.0-rc.8.tgz#148cb907513019cd9e150403ad58b3936fc5362d"
+  integrity sha512-Tig2DGhkkwxUuJRnDNW5DwBRkt1kJN3uVL3NKV87MSMXSzhtWz2/CceaLmfaFa+gY5ehr5HG36cYWXStrph8Zw==
   dependencies:
-    "@chakra-ui/form-control" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/form-control" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/skeleton@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/skeleton/-/skeleton-1.0.0-rc.7.tgz#99ff63e65e8261f2aa5b9fbb6ccff0b70c67ad2d"
-  integrity sha512-YeX1MglXywyVMat7uCBztzbkkivbD8f1nmpnP7ue+ucOB2wVo9oNfVH5T2Q2K36AR+QAuLzyociw95+3lIJkZA==
+"@chakra-ui/skeleton@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/skeleton/-/skeleton-1.0.0-rc.8.tgz#0441919e823748b75594eab05d80bc9e97b3d525"
+  integrity sha512-AmSEyzC5eROn6WHE6xTTSy4i2HJKRI4ET0T7k20fZOsaraul/KnmKFE11K/Mf4q3vsqSNLjLu8Z+NRRwvpLSOg==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/media-query" "1.0.0-rc.7"
-    "@chakra-ui/system" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/media-query" "1.0.0-rc.8"
+    "@chakra-ui/system" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/slider@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/slider/-/slider-1.0.0-rc.7.tgz#1de68bf63dc67c5ccd09a514dce4cf361eb2670f"
-  integrity sha512-XiNATBV0h3yOPv6fJ93Wbz0sGLcOzyjbh/1TrtZgxkg1N4mdSyv16ZEQHjbVM8kjWWlnE2nFVMaEKlfTve4hUg==
+"@chakra-ui/slider@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/slider/-/slider-1.0.0-rc.8.tgz#6d47d23a03b429bb1468a3a9de6a3bdb66aea01a"
+  integrity sha512-56N7dTHyh4PeUbeZFUuqS+pva7p7uAvuK2/EnVkpDzpHgCf6wFltuzM5m67XG2jAd2WFxAt7j6m76PIGxy1OWQ==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/spinner@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/spinner/-/spinner-1.0.0-rc.7.tgz#cfc76de3be2e5c0ee37aea64ff10515d4f1b996f"
-  integrity sha512-GsMfPOw4KMPSo77XHIuKW64oxqJYWhCX4E4TMW0HGtdZ+AsgNSL4BYUI34/bTm6BgooHldEYag34mzYpVEO4dA==
+"@chakra-ui/spinner@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/spinner/-/spinner-1.0.0-rc.8.tgz#04c3149af4f13bc87c1099c06bcfa98635a9e752"
+  integrity sha512-6XXdFwZM4BQo1JJbvcarRaDIp1LCuYBhh6QdtLaIjLcKMFOM8fttmLgxSRpQOSKBw21YIGLpqWknEaOjBDaI2A==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
-    "@chakra-ui/visually-hidden" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
+    "@chakra-ui/visually-hidden" "1.0.0-rc.8"
 
-"@chakra-ui/stat@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/stat/-/stat-1.0.0-rc.7.tgz#5c40dd56ea3c36dd71210f1b6b8ec319e1c91f11"
-  integrity sha512-0f/Ur0YWqEfp+wLrJmEn1jYgi6q63LVjnqYoi/WoXIYlYJ1ERcmp88qZpq/cy5Mj9th9tETuN+zJOXgghxAhhw==
+"@chakra-ui/stat@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/stat/-/stat-1.0.0-rc.8.tgz#d7385326ae1dc4d6a0c2b5d927bdcb9ae1f08530"
+  integrity sha512-4a4SBB3rvhh+0NKr+4LcFHS1bMOXrIRKLvjo9xvhZrlow1XMnajryIUt/m5WhuaqxiVYsNzIQwyWNNWuxgXjHw==
   dependencies:
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
-    "@chakra-ui/visually-hidden" "1.0.0-rc.7"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
+    "@chakra-ui/visually-hidden" "1.0.0-rc.8"
 
-"@chakra-ui/styled-system@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-1.0.0-rc.7.tgz#d31840a4918edf794fc22f59b7169fa347bf7f45"
-  integrity sha512-ICOP+vTLmMEi7TLB8g9pyqioXxwX1StQG8utkveEBB4Im7cDzgSUgL06j7EgP4OjiezEI5+75u0P2nDEWiFvlQ==
+"@chakra-ui/styled-system@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-1.0.0-rc.8.tgz#0b55145493c9833bd2fb31d65acb8e992093e238"
+  integrity sha512-SaxZrljWayOUQPxje6IkfDyIujoptRSjp4rBZpzju7KgPz4Ledv5ygg9GaxwowlGKFlVpdvo79QAhff0WKNcrg==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
     "@styled-system/core" "5.1.2"
     css-get-unit "1.0.1"
     csstype "3.0.3"
 
-"@chakra-ui/switch@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/switch/-/switch-1.0.0-rc.7.tgz#19c762e7816281263508ec3c6a7590b1e39d9549"
-  integrity sha512-xyK1CwGlxDgKOOeqIqxuiYxcWB+L4T6iDMCbOitjfAkq2hChOAmKlpBCWhNHJNiuo2KojyaiV6WfhBWRQo0veQ==
+"@chakra-ui/switch@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/switch/-/switch-1.0.0-rc.8.tgz#1797f998bba1e74c9241a95f8fbe1f1625a596f4"
+  integrity sha512-LnWYSs+eOeWui3GnC2qtKMfHwLi4WVrOmTrwlEgQ+kXjUPNlenIryTUFyTguQhd4yqZ3ph93khW2kl+9DNJcnw==
   dependencies:
-    "@chakra-ui/checkbox" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/checkbox" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/system@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/system/-/system-1.0.0-rc.7.tgz#35e99632e8cb9a590b7510f3fd222f71230b9809"
-  integrity sha512-4juq5IlSZhBrf0izCzlKakZn2vBG8j8AuFy37OWMHuO9/4bDtnK9mOKLvPcb9gLounbHSsCw2wB+wMRanrvpPg==
+"@chakra-ui/system@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/system/-/system-1.0.0-rc.8.tgz#0bca9a5d649ec3c44004a872f3e171567ccd6c7c"
+  integrity sha512-+jBXq15wwzvUht8weW/Svbuw704ArWdnto/mrfMJdB+ZVpyekhiD2lRoMJu5bxX7iD8sKhkKr5UjSRh97Gcdiw==
   dependencies:
-    "@chakra-ui/color-mode" "1.0.0-rc.7"
-    "@chakra-ui/styled-system" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/color-mode" "1.0.0-rc.8"
+    "@chakra-ui/styled-system" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
     "@emotion/core" "10.0.35"
     "@emotion/styled" "10.0.27"
     react-fast-compare "3.2.0"
 
-"@chakra-ui/tabs@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tabs/-/tabs-1.0.0-rc.7.tgz#35305fbf3334c8784666a8b9f9a28971a0f0da86"
-  integrity sha512-gEDRzqD70V5nEotXq3pjMAQjuqAHoRFvkXFIK6rpvz8DwbCjFZCWxRWaETjoc23/UFnvrR+i/Jo83l0aZ7aBFQ==
+"@chakra-ui/tabs@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tabs/-/tabs-1.0.0-rc.8.tgz#407ac59a73ee838ccd9ccd290d820a4a3e6e7d86"
+  integrity sha512-7bGm/5RsjbFavlt4Qog6+hayTdsXi3J/UTpbHX3QgXuFvPuCvv2pqThRaljvzA16DqOAdo+vuWDREcVmpS0tCw==
   dependencies:
-    "@chakra-ui/clickable" "1.0.0-rc.7"
-    "@chakra-ui/descendant" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/clickable" "1.0.0-rc.8"
+    "@chakra-ui/descendant" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/tag@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tag/-/tag-1.0.0-rc.7.tgz#e8abe94de8b0ae62a46f409c76a99413fb8f3b45"
-  integrity sha512-ZYUWJRY4hzb3kEY59X1A5ARhIn/gzTVft3Wbo8BXTe3koBUwgwTSeJYHaoc8FCH9ZnNqLlDHd0fmE7zUHClW2w==
+"@chakra-ui/tag@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tag/-/tag-1.0.0-rc.8.tgz#5d7cd51eb77288f8ceb48fa6de34935e48b55653"
+  integrity sha512-fIxnhJ5sNGBYxe35+Mq0ZUtQiu3sshtIgGRm5l3hlzpTPBNVwkG5zJbra11NAj0WzOWPg7Khl9H1jvrDD5C9Tw==
   dependencies:
-    "@chakra-ui/icon" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/icon" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/textarea@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/textarea/-/textarea-1.0.0-rc.7.tgz#08f25cbfce8aaf5fc9e4cc54a4e77eb77643ce37"
-  integrity sha512-mBHtdeFyu1+TLR9acNU24tu/LKim8iiQ7WDmXvbIfriASGn6cfklb8qgrG6Cm2BIaHqp7sb1j316vkYPONKhtw==
+"@chakra-ui/textarea@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/textarea/-/textarea-1.0.0-rc.8.tgz#4b831d9ba24b79744cb031c4b732b384d06e51c3"
+  integrity sha512-ZI4PWEOPXzpqdG7A48AXRFsBIOFVGCm13X1e1aGot18QlPJe7jCKTLRDrpVairMbFdLysjgzFr9DfO3G3V8BnA==
   dependencies:
-    "@chakra-ui/form-control" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/form-control" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/theme-tools@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/theme-tools/-/theme-tools-1.0.0-rc.7.tgz#254e000042454b51962683db44748a68acb3318d"
-  integrity sha512-L00aW95Z36c0Wv/yYNeKPRMOq2JbCzKCibiaORVlzojdnuv1THlhE/t3NDZzCJQDl6sFRsm5BCFrHPAylY9c7g==
+"@chakra-ui/theme-tools@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/theme-tools/-/theme-tools-1.0.0-rc.8.tgz#6be5c3ccdc34904893dbe73ad7db371c6c674988"
+  integrity sha512-z9suTMHa+La8mpYKS3c601PMa9YMtZqJCucflPXqTvHog8YMJFgsw2nAV5hdtmE81L6z/qzhNxrS8W+uzXrmCQ==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
     "@types/tinycolor2" "1.4.2"
     tinycolor2 "1.4.1"
 
-"@chakra-ui/theme@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/theme/-/theme-1.0.0-rc.7.tgz#8456d0ea51e7ee92601a712c11f612345bb32717"
-  integrity sha512-CSkIr+4/sxDAOpVJxiJDQmeoyFiOOh2JMFahW5pDx1wyi6tmLG5h/PE7kRyHb+C7iKz8/htBC/f236Ret8jVig==
+"@chakra-ui/theme@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/theme/-/theme-1.0.0-rc.8.tgz#7033c61f2bbc5984960b38f34d621dea62a7f11d"
+  integrity sha512-P7X6j2WqTR2YpqXjX5dAWQ6N9QwB11QOwuPL1V+wQoQVIIcElUm9koibhWPN8oUqDteTPa9lQ+cK79RIJ2bw4w==
   dependencies:
-    "@chakra-ui/theme-tools" "1.0.0-rc.7"
+    "@chakra-ui/theme-tools" "1.0.0-rc.8"
 
-"@chakra-ui/toast@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/toast/-/toast-1.0.0-rc.7.tgz#367fd07e615c7db5619cb4032ec8578c6d67605e"
-  integrity sha512-UYXwbbUkvFiWrrikdtXOW4KpPbNhmw/Lg+NJfeKhs8rvvv+b5cZULEIxWKjXW69kL6rIKGtK3n8W7GUIlQsObA==
+"@chakra-ui/toast@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/toast/-/toast-1.0.0-rc.8.tgz#277f95f4447d6a5a198f769a36d40011039209a7"
+  integrity sha512-Ivc8iTxKOq5bN2cC1v91nj60GesZnEqQ0W0CXXjWSGHzYBge3JkZpZH6mu5R5PHB+Tke3+orGQ5q8aGSTMUlrQ==
   dependencies:
-    "@chakra-ui/alert" "1.0.0-rc.7"
-    "@chakra-ui/close-button" "1.0.0-rc.7"
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/theme" "1.0.0-rc.7"
-    "@chakra-ui/transition" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/alert" "1.0.0-rc.8"
+    "@chakra-ui/close-button" "1.0.0-rc.8"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/theme" "1.0.0-rc.8"
+    "@chakra-ui/transition" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
     "@reach/alert" "0.11.0"
 
-"@chakra-ui/tooltip@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tooltip/-/tooltip-1.0.0-rc.7.tgz#846f41ee95b6fec136d88cadb828475713ad68a1"
-  integrity sha512-pvP5U+eeR6brXjR/ti1s+1ctFIGj5byWhaE8jyZnPxh+X1y/xMfRVfGa69vSbY36tBBnDoPikrpP/eHeYhyjrw==
+"@chakra-ui/tooltip@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tooltip/-/tooltip-1.0.0-rc.8.tgz#2a401f7e486272cc04f4239a7b687416496ad9de"
+  integrity sha512-kXXBM9MMIDZ6Sf5PgPeAvhgbIq/TTorCYk0mp4kZ68V5LUijNpwmi5g0Szqw5DNo1dGW+MSj221qoiFCr9abuQ==
   dependencies:
-    "@chakra-ui/hooks" "1.0.0-rc.7"
-    "@chakra-ui/popper" "1.0.0-rc.7"
-    "@chakra-ui/portal" "1.0.0-rc.7"
-    "@chakra-ui/utils" "1.0.0-rc.7"
-    "@chakra-ui/visually-hidden" "1.0.0-rc.7"
+    "@chakra-ui/hooks" "1.0.0-rc.8"
+    "@chakra-ui/popper" "1.0.0-rc.8"
+    "@chakra-ui/portal" "1.0.0-rc.8"
+    "@chakra-ui/utils" "1.0.0-rc.8"
+    "@chakra-ui/visually-hidden" "1.0.0-rc.8"
 
-"@chakra-ui/transition@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/transition/-/transition-1.0.0-rc.7.tgz#8913b1018ce2ab6144020a16d9dfeef81df4444c"
-  integrity sha512-Ri15Ccz7No+n7uydMzKF9YpIxrcz8am1Vv+fgId9OWyAUWlvelLxlypy0/Oq1o1aMBOCjhHnrYL9gYj6vhYn2g==
+"@chakra-ui/transition@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/transition/-/transition-1.0.0-rc.8.tgz#e797e54e070641e4c4c75f9e49c2b3b511f7bf99"
+  integrity sha512-JT40Uh+FVtl3iks8eL1zA4JIXFKoJNsJzCuejxX6HOStYdWM/+ygf0NsLIAIJyvA3v4INXR1h/yNnNWEN3Nolg==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
-"@chakra-ui/utils@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.0.0-rc.7.tgz#5321fa7e7dfce323b9ec3590040b9254c02f7230"
-  integrity sha512-5syANaa9SeNIAhj5kGlc7YznXMCO5TVQPsuiAnwMgIrk7Pgq8Rtr46nDTyXGV+FTdsj5P7lZjwE19U+CNJAifQ==
+"@chakra-ui/utils@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.0.0-rc.8.tgz#b485f27b0c8a569ce127fea1414e1223ea4e363d"
+  integrity sha512-FgmKvJ18cM1f2/49EyzJu18KAcgu0En0DjcmsflMFqjW9AQqi0Z2llhcXA/naX4VpqQ2fLf+tU8vbGYK2sY3fw==
   dependencies:
     "@types/lodash.mergewith" "4.6.6"
     "@types/object-assign" "4.0.30"
@@ -1691,12 +1706,12 @@
     lodash.mergewith "4.6.2"
     object-assign "4.1.1"
 
-"@chakra-ui/visually-hidden@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/visually-hidden/-/visually-hidden-1.0.0-rc.7.tgz#dd23a4aaa0be3f71308b1fedff29eeeeef2eb71d"
-  integrity sha512-V7nZt2Kj3JaEFDUjeeJyIw8y0qJm5i6oOm6qAgCY1crQPyCfuheMv+IpUPOroBqqMa72JoIiLn/NVaAaOYjPpQ==
+"@chakra-ui/visually-hidden@1.0.0-rc.8":
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/visually-hidden/-/visually-hidden-1.0.0-rc.8.tgz#141a071d9d38e4a8ec8b8b7defcc9e3b37977c8f"
+  integrity sha512-qxGhD8ODDA7LAMBNVIxbBRJOlMpkPIfoTP69TeC+QHqBKz87y6EeKZoT0zXbye9kFj1EZhUGdzq4vxMBiMzOTw==
   dependencies:
-    "@chakra-ui/utils" "1.0.0-rc.7"
+    "@chakra-ui/utils" "1.0.0-rc.8"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -3795,9 +3810,9 @@ csstype@3.0.3:
   integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
 
 csstype@^2.5.7:
-  version "2.6.13"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
-  integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
+  version "2.6.14"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.14.tgz#004822a4050345b55ad4dcc00be1d9cf2f4296de"
+  integrity sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==
 
 csstype@^3.0.2:
   version "3.0.4"
@@ -3912,6 +3927,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -4915,9 +4935,9 @@ immediate@~3.0.5:
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
 import-fresh@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
-  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz#fc129c160c5d68235507f4331a6baad186bdbc3e"
+  integrity sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -5039,6 +5059,13 @@ is-core-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.0.0.tgz#58531b70aed1db7c0e8d4eb1a0a2d1ddd64bd12d"
   integrity sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.1.0.tgz#a4cc031d9b1aca63eecbd18a650e13cb4eeab946"
+  integrity sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==
   dependencies:
     has "^1.0.3"
 
@@ -7032,7 +7059,7 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-fast-compare@3.2.0, react-fast-compare@^3.0.1:
+react-fast-compare@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
@@ -7058,14 +7085,6 @@ react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
-
-react-popper@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
-  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
-  dependencies:
-    react-fast-compare "^3.0.1"
-    warning "^4.0.2"
 
 react-refresh@0.8.3:
   version "0.8.3"
@@ -7386,12 +7405,20 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
   integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
   dependencies:
     is-core-module "^2.0.0"
+    path-parse "^1.0.6"
+
+resolve@^1.12.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
 ret@~0.1.10:
@@ -8521,7 +8548,7 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@^4.0.2, warning@^4.0.3:
+warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
This fixes #124 .  The bug was the result of a regression in Chakra-UI. Updating to the latest release fixes it.  I also added a close button so the toast can be closed manually (note - even the close button wouldn't work on the previous version of Chakra) (see https://github.com/chakra-ui/chakra-ui/issues/2345)