### PR TITLE
feat: Add plane icon

### DIFF
--- a/icons/plane.svg
+++ b/icons/plane.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M17.8 19.2L16 11L19.5 7.5C21 6 21.5 4 21 3C20 2.5 18 3 16.5 4.5L13 8L4.8 6.2C4.3 6.1 3.9 6.3 3.7 6.7L3.4 7.2C3.2 7.7 3.3 8.2 3.7 8.5L9 12L7 15H4L3 16L6 18L8 21L9 20V17L12 15L15.5 20.3C15.8 20.7 16.3 20.8 16.8 20.6L17.3 20.4C17.7 20.1 17.9 19.7 17.8 19.2Z" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -161,6 +161,7 @@
   "play": ["music", "start"],
   "pie-chart": ["statistics", "diagram"],
   "pipette": ["eye dropper", "color picker"],
+  "plane": ["plane", "trip"],
   "play-circle": ["music", "start"],
   "plus": ["add", "new"],
   "plus-circle": ["add", "new"],


### PR DESCRIPTION
Icon `plane` was added

<img width="673" alt="Icon plane" src="https://user-images.githubusercontent.com/3686790/100939291-19deb100-3507-11eb-9830-563360d0ecc2.png">
