### PR TITLE
Add sprout icon

### DIFF
--- a/icons/sprout.svg
+++ b/icons/sprout.svg
@@ -1,0 +1,16 @@
+<svg
+  viewBox="0 0 24 24"
+  width="24"
+  height="24"
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7 20h10" />
+  <path d="M10 20c5.5-2.5.8-6.4 3-10"/>
+  <path d="M9.5 9.4c1.1.8 1.8 2.2 2.3 3.7-2 .4-3.5.4-4.8-.3-1.2-.6-2.3-1.9-3-4.2 2.8-.5 4.4 0 5.5.8z"/>
+  <path d="M14.1 6a7 7 0 00-1.1 4c1.9-.1 3.3-.6 4.3-1.4 1-1 1.6-2.3 1.7-4.6-2.7.1-4 1-4.9 2z"/>
+</svg>


### PR DESCRIPTION
Design From: https://github.com/feathericons/feather/issues/968
Thanks to @neelchanda for providing the image, I adjusted the icon a bit to match our guidelines.

![image](https://user-images.githubusercontent.com/11825403/102716582-0ee49880-42dd-11eb-9f79-58c79214b517.png)
100% ![image](https://user-images.githubusercontent.com/11825403/102716601-30458480-42dd-11eb-8334-e031af902ca3.png)
