### PR TITLE
Fix optimizeSvgs script

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "htmlparser2": "^4.1.0",
     "jest": "^26.4.2",
     "minimist": "^1.2.5",
-    "prettier": "^1.8.2",
+    "prettier": "1.17.1",
     "rollup": "^2.7.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-license": "^2.0.0",

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -82,7 +82,7 @@ export const readSvg = (fileName, directory) => fs.readFileSync(path.join(direct
  * @param {string} content
  */
 export const writeSvgFile = (fileName, outputDirectory, content) =>
-  fs.appendFileSync(path.join(outputDirectory, fileName), content, 'utf-8');
+  fs.writeFileSync(path.join(outputDirectory, fileName), content, 'utf-8');
 
 // This is a djb2 hashing function
 export const hash = (string, seed = 5381) => {

--- a/scripts/optimizeSvgs.js
+++ b/scripts/optimizeSvgs.js
@@ -11,5 +11,5 @@ const svgFiles = readSvgDirectory(ICONS_DIR);
 
 svgFiles.forEach(svgFile => {
   const content = fs.readFileSync(path.join(ICONS_DIR, svgFile));
-  processSvg(content).then(svg => writeSvgFile(svg, ICONS_DIR, content));
+  processSvg(content).then(svg => writeSvgFile(svgFile, ICONS_DIR, svg));
 });

--- a/scripts/render/processSvg.js
+++ b/scripts/render/processSvg.js
@@ -14,7 +14,7 @@ function processSvg(svg) {
   return (
     optimize(svg)
       .then(setAttrs)
-      .then(format)
+      .then(optimizedSvg => format(optimizedSvg, { parser: 'babel' }))
       // remove semicolon inserted by prettier
       // because prettier thinks it's formatting JSX not HTML
       .then(svg => svg.replace(/;/g, ''))
@@ -36,9 +36,7 @@ function optimize(svg) {
     ],
   });
 
-  return new Promise(resolve => {
-    svgo.optimize(svg, ({ data }) => resolve(data));
-  });
+  return svgo.optimize(svg).then(({ data }) => data);
 }
 
 /**


### PR DESCRIPTION
- Switch `SVGO.optimize` function to returning a promise instead of accepting a callback - https://github.com/svg/svgo/releases/tag/v1.0.0
- Pin prettier to the last version before `1.18.0` which removed the self closing JSX brackets.  On a clean install without a `package-lock.json` a higher version would automatically be installed - https://prettier.io/blog/2019/06/06/1.18.0.html#stop-converting-empty-jsx-elements-to-self-closing-elements-6127-by-duailibe
  - Add `{ parser: babel }` option to `format` to avoid warnings on each iteration
- Fix some incorrect arguments for writing the SVGs to disk