### PR TITLE
lucide-react - Generate types for all exported icons

### DIFF
--- a/packages/lucide-react/build-types.js
+++ b/packages/lucide-react/build-types.js
@@ -38,7 +38,7 @@ fs.readdir(iconsFolder, (err, files) => {
                                   .join("")
 
     // Declare component type
-    const exportTypeString = `export const ${componentName}: LucideIcon;\n`
+    const exportTypeString = `export declare const ${componentName}: (props: LucideProps) => JSX.Element;\n`
 
     // Add component to the types file
     fs.appendFileSync(

--- a/packages/lucide-react/build-types.js
+++ b/packages/lucide-react/build-types.js
@@ -3,19 +3,17 @@ const path = require("path")
 const srcDirectory = path.join(__dirname, "dist")
 
 // Declare type definitions
-const typeDefinitions = `/// <reference types="react" />
-import {FC, SVGAttributes} from 'react'
+const typeDefinitions = `
+/// <reference types="react" />
+import { SVGAttributes } from 'react'
 
 // Create interface extending SVGAttributes
-interface LucideProps extends SVGAttributes<SVGElement> {
+export interface LucideProps extends Partial<React.SVGProps<SVGSVGElement>> {
     color?: string
     size?: string | number
     stroke?: string | number
     strokeWidth?: string | number
 }
-
-// Create type
-type LucideIcon = FC<LucideProps>
 
 // Generated icons
 `
@@ -54,4 +52,3 @@ fs.readdir(iconsFolder, (err, files) => {
   console.log("Generated index.d.ts file with", files.length, "icons")
 
 })
-

--- a/packages/lucide-react/build-types.js
+++ b/packages/lucide-react/build-types.js
@@ -1,0 +1,57 @@
+const fs = require("fs")
+const path = require("path")
+const srcDirectory = path.join(__dirname, "dist")
+
+// Declare type definitions
+const typeDefinitions = `/// <reference types="react" />
+import {FC, SVGAttributes} from 'react'
+
+// Create interface extending SVGAttributes
+interface LucideProps extends SVGAttributes<SVGElement> {
+    color?: string
+    size?: string | number
+    stroke?: string | number
+    strokeWidth?: string | number
+}
+
+// Create type
+type LucideIcon = FC<LucideProps>
+
+// Generated icons
+`
+
+// Write type definitions to file
+fs.writeFileSync(
+  path.join(srcDirectory, "index.d.ts"),
+  typeDefinitions,
+  "utf-8",
+)
+
+const iconsFolder = "./build/icons"
+fs.readdir(iconsFolder, (err, files) => {
+
+  files.forEach(file => {
+
+    const fileName = file.replace(".js", "")
+
+    // Convert fileName to component name
+    const componentName = fileName.split("-")
+                                  .map(word => word[0].toUpperCase() + word.substr(1, word.length))
+                                  .join("")
+
+    // Declare component type
+    const exportTypeString = `export const ${componentName}: LucideIcon;\n`
+
+    // Add component to the types file
+    fs.appendFileSync(
+      path.join(srcDirectory, "index.d.ts"),
+      exportTypeString,
+      "utf-8",
+    )
+
+  })
+
+  console.log("Generated index.d.ts file with", files.length, "icons")
+
+})
+

--- a/packages/lucide-react/package.json
+++ b/packages/lucide-react/package.json
@@ -16,11 +16,13 @@
   "main:umd": "dist/umd/lucide-react.js",
   "module": "dist/esm/lucide-react.js",
   "unpkg": "dist/umd/lucide-react.min.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "yarn clean && yarn build:move && yarn build:icons && yarn build:es && yarn build:bundles",
+    "build": "yarn clean && yarn build:move && yarn build:icons && yarn build:es && yarn build:types && yarn build:bundles",
     "clean": "rm -rf dist && rm -rf build",
     "build:move": "cp -av src build",
     "build:icons": "yarn --cwd ../../ build:icons --output=../packages/lucide-react/build --templateSrc=../packages/lucide-react/scripts/exportTemplate --camelizeAttrs --noDefaultAttrs --renderUniqueKey",
+    "build:types": "node build-types.js",
     "build:es": "yarn --cwd ../../ babel packages/lucide-react/build -d packages/lucide-react/dist/esm",
     "build:bundles": "yarn --cwd ../../ rollup -c packages/lucide-react/rollup.config.js",
     "test": "jest"

--- a/scripts/render/renderIconNodes.js
+++ b/scripts/render/renderIconNodes.js
@@ -18,11 +18,10 @@ export default (iconsObject, options) => {
     const svgString = iconsObject[icon];
     const dom = parseDOM(svgString);
 
-    const children = dom.map((element, index) => {
+    const children = dom.map(element => {
       if (options.renderUniqueKey) {
         const hashSource = {
           name: element.name,
-          index,
           ...element.attribs,
         };
 

--- a/scripts/render/renderIconNodes.js
+++ b/scripts/render/renderIconNodes.js
@@ -18,10 +18,11 @@ export default (iconsObject, options) => {
     const svgString = iconsObject[icon];
     const dom = parseDOM(svgString);
 
-    const children = dom.map(element => {
+    const children = dom.map((element, index) => {
       if (options.renderUniqueKey) {
         const hashSource = {
           name: element.name,
+          index,
           ...element.attribs,
         };
 


### PR DESCRIPTION
Solves the React.js part of issue #226 

The types in LucideProps are declared so they match the props mentioned in https://github.com/lucide-icons/lucide/blob/master/packages/lucide-react/README.md#props. They could be removed, since they're already present in SVGAttributes.