### PR TITLE
Fix duplicate keys being generated if SVG attributes are identical

### DIFF
--- a/scripts/render/renderIconNodes.js
+++ b/scripts/render/renderIconNodes.js
@@ -18,10 +18,11 @@ export default (iconsObject, options) => {
     const svgString = iconsObject[icon];
     const dom = parseDOM(svgString);
 
-    const children = dom.map(element => {
+    const children = dom.map((element, index) => {
       if (options.renderUniqueKey) {
         const hashSource = {
           name: element.name,
+          index,
           ...element.attribs,
         };
 


### PR DESCRIPTION
Fixes issue #244 by adding an extra attribute to the generated hash