### PR TITLE
Refactor Alarm icons, shrink the plus and minus size

### DIFF
--- a/icons/alarm-minus.svg
+++ b/icons/alarm-minus.svg
@@ -14,5 +14,5 @@
   <path d="M22 6l-3-3" />
   <path d="M6 19l-2 2" />
   <path d="M18 19l2 2" />
-  <path d="M8 13h8" />
+  <path d="M9 13h6" />
 </svg>

--- a/icons/alarm-plus.svg
+++ b/icons/alarm-plus.svg
@@ -14,6 +14,6 @@
   <path d="M22 6l-3-3" />
   <path d="M6 19l-2 2" />
   <path d="M18 19l2 2" />
-  <path d="M12 9v8" />
-  <path d="M8 13h8" />
+  <path d="M12 10v6" />
+  <path d="M9 13h6" />
 </svg>


### PR DESCRIPTION
The plus and the minus look a bit to big on 100%.

I shrink them a bit.
![image](https://user-images.githubusercontent.com/11825403/111085356-5a42c780-8517-11eb-9772-e557fdab5072.png)
