### PR TITLE
Add tent icon

### DIFF
--- a/icons/campsite.svg
+++ b/icons/campsite.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 20h18M5 20l7-13 7 13M10 4l2 3 2-3" />
+  <path d="M9 20l3-5 3 5" />
+</svg>

--- a/icons/tent.svg
+++ b/icons/tent.svg
@@ -9,6 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M3 20h18M5 20l7-13 7 13M10 4l2 3 2-3" />
-  <path d="M9 20l3-5 3 5" />
+  <path d="M19 20L10 4" />
+  <path d="M5 20l9-16" />
+  <path d="M3 20h18" />
+  <path d="M12 15l-3 5" />
+  <path d="M12 15l3 5" />
 </svg>

--- a/tags.json
+++ b/tags.json
@@ -262,6 +262,9 @@
     "webcam",
     "video"
   ],
+  "campsite": [
+    "tent"
+  ],
   "car": [
     "vehicle",
     "transport",

--- a/tags.json
+++ b/tags.json
@@ -262,9 +262,6 @@
     "webcam",
     "video"
   ],
-  "campsite": [
-    "tent"
-  ],
   "car": [
     "vehicle",
     "transport",
@@ -1512,6 +1509,10 @@
   "target": [
     "logo",
     "bullseye"
+  ],
+  "tent": [
+    "campsite",
+    "wigwam"
   ],
   "terminal": [
     "code",


### PR DESCRIPTION
name | about | labels
-- | -- | --
New icon | Add a new icon to the library | 🎨 <icon


- **Name of the icon** : Campsite
- **Tags (alternative names for this icon)** (add them in tags.json) :  tent
- **What is the purpose of this icon?** : Depicting holidays or outdoor activities. Can be used in maps as well.
- **100% scale preview** : ![campsite](https://user-images.githubusercontent.com/13321277/118512116-d1bcef00-b732-11eb-93e8-8b5f2f4d8869.png)
- **Have you considered alternative possibilities** for its naming or design? : It's roughly based on [#61 at feather](https://github.com/feathericons/feather/issues/61), but I feel this one is slightly more recognizable as a tent.