### PR TITLE
Add sideEffects false in package jsons

### DIFF
--- a/packages/lucide-preact/package.json
+++ b/packages/lucide-preact/package.json
@@ -17,6 +17,8 @@
   "module": "dist/esm/lucide-preact.js",
   "unpkg": "dist/umd/lucide-preact.min.js",
   "typings": "dist/lucide-preact.d.ts",
+  "sideEffects": false,
+
   "scripts": {
     "build": "yarn clean && yarn build:icons && yarn build:es && yarn build:types && yarn build:bundles",
     "clean": "rm -rf dist && rm -rf stats && rm -rf ./src/icons/*.js",

--- a/packages/lucide-react/package.json
+++ b/packages/lucide-react/package.json
@@ -17,6 +17,7 @@
   "module": "dist/esm/lucide-react.js",
   "unpkg": "dist/umd/lucide-react.min.js",
   "typings": "dist/lucide-react.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "yarn clean && yarn build:icons && yarn build:es && yarn build:types && yarn build:bundles",
     "clean": "rm -rf dist && rm -rf stats && rm -rf ./src/icons/*.js",

--- a/packages/lucide-vue-next/package.json
+++ b/packages/lucide-vue-next/package.json
@@ -18,6 +18,7 @@
   "module": "dist/esm/lucide-vue-next.js",
   "unpkg": "dist/umd/lucide-vue-next.min.js",
   "typings": "dist/lucide-vue-next.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "yarn clean && yarn build:icons && yarn build:es && yarn build:types && yarn build:bundles",
     "clean": "rm -rf dist && rm -rf ./src/icons/*.js",

--- a/packages/lucide-vue/package.json
+++ b/packages/lucide-vue/package.json
@@ -17,9 +17,7 @@
   "main:umd": "dist/umd/lucide-vue.js",
   "module": "dist/esm/lucide-vue.js",
   "unpkg": "dist/umd/lucide-vue.min.js",
-  "dependencies": {
-    "vue": "^2.6.12"
-  },
+  "sideEffects": false,
   "scripts": {
     "build": "yarn clean && yarn build:icons && yarn build:es && yarn build:bundles",
     "clean": "rm -rf dist && rm -rf stats && rm -rf ./src/icons/*.js",
@@ -33,7 +31,8 @@
     "@vue/test-utils": "^1.1.2",
     "jest-serializer-vue": "^2.0.2",
     "vue-jest": "^3.0.7",
-    "vue-template-compiler": "^2.6.12"
+    "vue-template-compiler": "^2.6.12",
+    "vue": "^2.6.12"
   },
   "peerDependencies": {
     "vue": "^2.6.12"


### PR DESCRIPTION
Closes #332

`sideEffects` was missing in the package.jsons in the following packages:
- `lucide-react`
- `lucide-preact`
- `lucide-vue`
- `lucide-vue-next`

I added it so packages will be three shakable.