### PR TITLE
Export an Icon type for React

### DIFF
--- a/packages/lucide-react/scripts/buildTypes.js
+++ b/packages/lucide-react/scripts/buildTypes.js
@@ -24,6 +24,7 @@ export interface LucideProps extends Partial<React.SVGProps<SVGSVGElement>> {
     strokeWidth?: string | number
 }
 
+export type Icon = React.FC<LucideProps>;
 // Generated icons
 `;
 


### PR DESCRIPTION
This will allow libs to build on Lucide by asking for an Icon from the lib