### PR TITLE
Build multiple font weights in action

### DIFF
--- a/.github/workflows/font.yml
+++ b/.github/workflows/font.yml
@@ -50,10 +50,11 @@ jobs:
 
     - name: Build 'Lucide'
       run: |
+          mkdir build
           list=(_200 _300 "" _500 _600)
           for name in "${list[@]}"
           do
-            fontcustom compile "./converted_icons${name}" -h -n "Lucide${name}" -o build -F
+            fontcustom compile "./converted_icons${name}" -h -n "Lucide${name}" -o ./tmp -F && mv ./tmp/* build
           done
 
     - name: Zip 'Lucide'

--- a/.github/workflows/font.yml
+++ b/.github/workflows/font.yml
@@ -46,10 +46,15 @@ jobs:
       run: sudo yarn add svg-outline-stroke -W
 
     - name: "Outline SVG"
-      run: mkdir converted_icons && node scripts/outline_svg.js
+      run: node scripts/outline_svg.js
 
     - name: Build 'Lucide'
-      run: echo "Building Lucide font" && fontcustom compile ./converted_icons -h -n Lucide -o build -F
+      run: |
+          list=(_200 _300 "" _500 _600)
+          for name in "${list[@]}"
+          do
+            fontcustom compile "./converted_icons${name}" -h -n "Lucide${name}" -o build -F
+          done
 
     - name: Zip 'Lucide'
       run: zip -r Lucide.zip build

--- a/scripts/outline_svg.js
+++ b/scripts/outline_svg.js
@@ -3,21 +3,34 @@ const outlineStroke = require('svg-outline-stroke');
 const { parse, stringify } = require('svgson');
 
 const inputDir = `./icons/`;
-const outputDir = `./converted_icons/`;
+const outputDirs = {
+  'converted_icons_200': '1',
+  'converted_icons_300': '1.5',
+  'converted_icons': '2',
+  'converted_icons_500': '2.5',
+  'converted_icons_600': '3'
+}
 
 async function init() {
   try {
+    for (const directory of Object.keys(outputDirs)) {
+      await fs.mkdir(`./${directory}`);
+    }
+
     const files = await fs.readdir(inputDir);
     for (const file of files) {
       const icon = await fs.readFile(`${inputDir}${file}`);
       const scaled = await parse(icon.toString(), {
         transformNode: transformForward,
       });
-      const outlined = await outlineStroke(stringify(scaled));
-      const outlinedWithoutAttrs = await parse(outlined, {
-        transformNode: transformBackwards,
-      });
-      await fs.writeFile(`${outputDir}${file}`, stringify(outlinedWithoutAttrs));
+      for (const [directory, width] of Object.entries(outputDirs)) {
+        scaled.attributes['stroke-width'] = width;
+        const outlined = await outlineStroke(stringify(scaled));
+        const outlinedWithoutAttrs = await parse(outlined, {
+          transformNode: transformBackwards,
+        });
+        await fs.writeFile(`./${directory}/${file}`, stringify(outlinedWithoutAttrs));
+      }
     }
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
Fixes #354 

This PR creates a build artifact with fonts in several different weights. `fontcustom` doesn't support any kind of font weight combining that I see, so if you wanted to use multiple weights in the same project, you'd need to create a merged CSS file with the additional font faces you need.

The default weight (2) has no name suffix, while the others (1, 1.5, 2.5, and 3) use filenames that might match their expected css font-weights.

Shown: 200, 400 (the default), and 600 weight:
![New Project](https://user-images.githubusercontent.com/242008/124212264-4c0fbb80-dab4-11eb-9b27-32364729b045.png)

Artifact output: https://github.com/Billiam/lucide/suites/3139790111/artifacts/72098979