### PR TITLE
Allow to use with React 17

### DIFF
--- a/packages/lucide-react/package.json
+++ b/packages/lucide-react/package.json
@@ -37,6 +37,6 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.5.1"
+    "react": "^16.5.1 || ^17.0.0"
   }
 }


### PR DESCRIPTION
The library works perfectly with React 17 so it will allow users to not use `npm --legacy-peer-deps`