### PR TITLE
Add missing tag "text" to bold icon

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -231,6 +231,7 @@
     "pairing"
   ],
   "bold": [
+    "text",
     "strong"
   ],
   "book": [


### PR DESCRIPTION
You can't find bold icon if you search for "text" / "text editor" etc...
This should fix it.