### PR TITLE
Refactor the archive icon

### DIFF
--- a/icons/archive.svg
+++ b/icons/archive.svg
@@ -1,1 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 9v9a2 2 0 01-2 2H6a2 2 0 01-2-2V9M20 4H4a2 2 0 00-2 2v1a2 2 0 002 2h16a2 2 0 002-2V6a2 2 0 00-2-2zM10 13h4"/></svg>
+<svg
+ xmlns="http://www.w3.org/2000/svg"
+ width="24"
+ height="24"
+ viewBox="0 0 24 24"
+ fill="none"
+ stroke="currentColor"
+ stroke-width="2"
+ stroke-linecap="round"
+ stroke-linejoin="round"
+>
+  <path d="M20 9v9a2 2 0 01-2 2H6a2 2 0 01-2-2V9M20 4H4a2 2 0 00-2 2v1a2 2 0 002 2h16a2 2 0 002-2V6a2 2 0 00-2-2zM10 13h4"/>
+</svg>

--- a/icons/archive.svg
+++ b/icons/archive.svg
@@ -1,15 +1,1 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="currentColor"
-  stroke-width="2"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <polyline points="21 8 21 21 3 21 3 8" />
-  <rect x="1" y="3" width="22" height="5" />
-  <line x1="10" y1="12" x2="14" y2="12" />
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 9v9a2 2 0 01-2 2H6a2 2 0 01-2-2V9M20 4H4a2 2 0 00-2 2v1a2 2 0 002 2h16a2 2 0 002-2V6a2 2 0 00-2-2zM10 13h4"/></svg>


### PR DESCRIPTION
Hello,  
I saw that the `archive` icon is breaking the "1 pixel padding within the canvas" rule and the "border radius of 2 pixels" rule.  
I made it a little smaller and added the border radius.  
This is how it looks now  
![image](https://user-images.githubusercontent.com/45879791/127867309-7dc7e51f-0870-4699-97b8-2f85569767c3.png)
and this is how it looks at 100% scale  
![archive-png](https://user-images.githubusercontent.com/45879791/127867429-ce5814c1-8f26-4e25-bde0-530023009726.png)
