### PR TITLE
Support Nuxt auto-importing Vue components

### DIFF
--- a/packages/lucide-vue/README.md
+++ b/packages/lucide-vue/README.md
@@ -105,3 +105,21 @@ export default {
   </div>
 </template>
 ```
+
+## Use with [@nuxt/components](https://github.com/nuxt/components#readme)
+
+### Setup
+In your `nuxt.config.js`, add `lucide-vue/nuxt` to your `buildModules`
+```js
+export default {
+  buildModules: ['lucide-vue/nuxt']
+}
+```
+
+### How to use
+Icon components are prefixed with `Icon`. Use icon components without importing them.
+
+### Example
+```html
+<IconCamera color="red" :size="32" />
+```

--- a/packages/lucide-vue/nuxt.js
+++ b/packages/lucide-vue/nuxt.js
@@ -1,0 +1,12 @@
+import { join } from 'path'
+
+export default function () {
+
+  this.nuxt.hook('components:dirs', dirs => {
+    dirs.push({
+      path: join(__dirname, 'dist', 'esm', 'icons'),
+      prefix: 'Icon',
+      ignore: ['**/index.js']
+    })
+  })
+}


### PR DESCRIPTION
This PR adds support for the [@nuxt/components](https://github.com/nuxt/components) module's ability to automatically import Vue modules. As documented [here](https://github.com/nuxt/components#library-authors), a `nuxt.js` file tells Nuxt where the components are. 

In addition, this PR adds documentation on how to use this feature with Nuxt.