### PR TITLE
Fixed error in link to the Angular specific docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ yarn add lucide-angular
 npm install lucide-angular
 ```
 
-For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/packages/lucide-angular#lucide-angular).
+For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-angular#lucide-angular).
 
 ### Preact
 


### PR DESCRIPTION
Just a small typo in the readme that didn't link to the corrects docs in this repo.