### PR TITLE
Add `wrap-text` icon

### DIFF
--- a/icons/wrap-text.svg
+++ b/icons/wrap-text.svg
@@ -10,7 +10,7 @@
   stroke-linejoin="round"
 >
   <line x1="3" y1="6" x2="21" y2="6" />
-  <path d="M3 12 h15 a3 3 0 1 1 0 6h-4" />
+  <path d="M3 12h15a3 3 0 110 6h-4" />
   <polyline points="16 16 14 18 16 20" />
   <line x1="3" y1="18" x2="10" y2="18" />
 </svg>

--- a/icons/wrap-text.svg
+++ b/icons/wrap-text.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <line x1="3" y1="6" x2="21" y2="6" />
+  <path d="M3 12 h15 a3 3 0 1 1 0 6h-4" />
+  <polyline points="16 16 14 18 16 20" />
+  <line x1="3" y1="18" x2="10" y2="18" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -2074,6 +2074,12 @@
     "air",
     "blow"
   ],
+  "wrap-text": [
+    "words",
+    "lines",
+    "break",
+    "paragraph"
+  ],
   "wrench": [
     "tool",
     "settings",


### PR DESCRIPTION
* Started with the "align-justify" icon
* Updated the second line to form a circular arc towards the third line, moved left slightly to finish the arcing path. Geometry: https://svg-path-visualizer.netlify.app/#M3%2012%20h15%20a3%203%200%201%201%200%206h-4
* Shortened the third line to form a gap between the third line and tip of the arc
* Layered a smaller version of "chevron left" on top of the tip of the arc (polyline)

Codepen: https://codepen.io/bduffs/pen/VwzGKxv