### PR TITLE
chore: remove unnecessary bit from `pencil` icon

### DIFF
--- a/icons/pencil.svg
+++ b/icons/pencil.svg
@@ -10,5 +10,5 @@
   stroke-linejoin="round"
 >
   <line x1="18" y1="2" x2="22" y2="6" />
-  <path d="M7.5 20.5L19 9l-4-4L3.5 16.5 2 22l5.5-1.5z" />
+  <path d="M7.5 20.5L19 9l-4-4L3.5 16.5 2 22z" />
 </svg>


### PR DESCRIPTION
There was a line drawn all the way to the beginning of the path, which is what `z` already does anyway.

Refs: #129