### PR TITLE
Allow children in React and Preact icons

### DIFF
--- a/packages/lucide-preact/src/createPreactComponent.js
+++ b/packages/lucide-preact/src/createPreactComponent.js
@@ -1,4 +1,4 @@
-import { h } from 'preact';
+import { h, toChildArray } from 'preact';
 import defaultAttributes from './defaultAttributes';
 
 /**
@@ -12,7 +12,7 @@ import defaultAttributes from './defaultAttributes';
 export const toKebabCase = string => string.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 
 export default (iconName, iconNode) => {
-  const Component = ({ color = 'currentColor', size = 24, strokeWidth = 2, ...rest }) =>
+  const Component = ({ color = 'currentColor', size = 24, strokeWidth = 2, children, ...rest }) =>
     h(
       'svg',
       {
@@ -24,7 +24,7 @@ export default (iconName, iconNode) => {
         class: `lucide lucide-${toKebabCase(iconName)}`,
         ...rest,
       },
-      iconNode.map(([tag, attrs]) => h(tag, attrs)),
+      [...iconNode.map(([tag, attrs]) => h(tag, attrs)), ...toChildArray(children)],
     );
 
   Component.displayName = `${iconName}`;

--- a/packages/lucide-preact/src/createPreactComponent.js
+++ b/packages/lucide-preact/src/createPreactComponent.js
@@ -24,7 +24,7 @@ export default (iconName, iconNode) => {
         class: `lucide lucide-${toKebabCase(iconName)}`,
         ...rest,
       },
-      [...iconNode.map(([tag, attrs]) => h(tag, attrs)), ...toChildArray(children)],
+      [...toChildArray(children), ...iconNode.map(([tag, attrs]) => h(tag, attrs))],
     );
 
   Component.displayName = `${iconName}`;

--- a/packages/lucide-preact/src/createPreactComponent.js
+++ b/packages/lucide-preact/src/createPreactComponent.js
@@ -24,7 +24,7 @@ export default (iconName, iconNode) => {
         class: `lucide lucide-${toKebabCase(iconName)}`,
         ...rest,
       },
-      [...toChildArray(children), ...iconNode.map(([tag, attrs]) => h(tag, attrs))],
+      [...iconNode.map(([tag, attrs]) => h(tag, attrs)), ...toChildArray(children)],
     );
 
   Component.displayName = `${iconName}`;

--- a/packages/lucide-react/src/createReactComponent.js
+++ b/packages/lucide-react/src/createReactComponent.js
@@ -27,7 +27,7 @@ export default (iconName, iconNode) => {
           className: `lucide lucide-${toKebabCase(iconName)}`,
           ...rest,
         },
-        [...(children || []), ...iconNode.map(([tag, attrs]) => createElement(tag, attrs))],
+        [...iconNode.map(([tag, attrs]) => createElement(tag, attrs)), ...(children || [])],
       ),
   );
 

--- a/packages/lucide-react/src/createReactComponent.js
+++ b/packages/lucide-react/src/createReactComponent.js
@@ -14,7 +14,7 @@ export const toKebabCase = string => string.replace(/([a-z0-9])([A-Z])/g, '$1-$2
 
 export default (iconName, iconNode) => {
   const Component = forwardRef(
-    ({ color = 'currentColor', size = 24, strokeWidth = 2, ...rest }, ref) =>
+    ({ color = 'currentColor', size = 24, strokeWidth = 2, children, ...rest }, ref) =>
       createElement(
         'svg',
         {
@@ -27,7 +27,7 @@ export default (iconName, iconNode) => {
           className: `lucide lucide-${toKebabCase(iconName)}`,
           ...rest,
         },
-        iconNode.map(([tag, attrs]) => createElement(tag, attrs)),
+        [...iconNode.map(([tag, attrs]) => createElement(tag, attrs)), ...(children || [])],
       ),
   );
 

--- a/packages/lucide-react/src/createReactComponent.js
+++ b/packages/lucide-react/src/createReactComponent.js
@@ -27,7 +27,7 @@ export default (iconName, iconNode) => {
           className: `lucide lucide-${toKebabCase(iconName)}`,
           ...rest,
         },
-        [...iconNode.map(([tag, attrs]) => createElement(tag, attrs)), ...(children || [])],
+        [...(children || []), ...iconNode.map(([tag, attrs]) => createElement(tag, attrs))],
       ),
   );
 


### PR DESCRIPTION
This will allow adding children to the SVG icons in React and Preact, thus allowing important a11y features like `<title>` tags, and of lesser importance also allowing custom additions to icons.

Both the Preact and React version place new children _before_ existing elements within the SVG. This is to comply with [this caveat found here on MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title) to be backward compatible with SVG 1.1 (if this is a non-issue and other arguments can be made for adding new elements _after_ existing children, this can be reversed).

To avoid errors with destructuring non-existent Arrays, the Preact version uses `Preact.toChildArray()` (available in the Preact version required by the package) and the React version `children || []`.

Edit: I see this has (recently) been mentioned in an issue before as well: fixes #477 