### PR TITLE
fix: shrink arrow size in sidebar icons

### DIFF
--- a/icons/sidebar-close.svg
+++ b/icons/sidebar-close.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-  <line x1="9" y1="3" x2="9" y2="21" />
-  <path d="M17 16l-4-4 4-4" />
+  <path d="M19 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V5a2 2 0 00-2-2z" />
+  <path d="M9 3v18" />
+  <path d="M16 15l-3-3 3-3" />
 </svg>

--- a/icons/sidebar-open.svg
+++ b/icons/sidebar-open.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-  <line x1="9" y1="3" x2="9" y2="21" />
-  <path d="M13 8l4 4-4 4" />
+  <path d="M19 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V5a2 2 0 00-2-2z" />
+  <path d="M9 3v18" />
+  <path d="M14 9l3 3-3 3" />
 </svg>


### PR DESCRIPTION
This PR shrinks the size of the arrow in both the sidebar icons as they were looking too big and aligned the arrows 1px to the other side.
