### PR TITLE
fix: Spacing in License page

### DIFF
--- a/site/src/pages/license.tsx
+++ b/site/src/pages/license.tsx
@@ -44,13 +44,11 @@ const LicensePage = ({ licenseText }) => {
 export default LicensePage;
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const doc = await fs.readFile(resolve('../LICENSE'), 'utf-8');
+  const doc: string = await fs.readFile(resolve('../LICENSE'), 'utf-8');
 
   const licenseText = doc
-    .split('\n')
-    .map(line => (line === '' ? '|' : line))
-    .join('')
-    .split('|')
+    .split(/\n{2,}/)
+    .map(paragraph => paragraph.split('\n').join(' ').trim())
     .filter(Boolean);
 
   return { props: { licenseText } };


### PR DESCRIPTION
The license page has spaces missing where lines from the `LICENSE` file are joined.
I also changed the code a bit so the pipe symbol can be safely used in the license text :slightly_smiling_face: 

![missing spaces](https://user-images.githubusercontent.com/1277208/161255690-41a56c60-e71b-459a-9094-2b650167fa76.png)
