### PR TITLE
fix: Remove console.log calls from site

### DIFF
--- a/site/src/components/DocsMenu.tsx
+++ b/site/src/components/DocsMenu.tsx
@@ -2,13 +2,9 @@ import { Box, Text, Link, BoxProps } from '@chakra-ui/react';
 import docsMenuTree from '../lib/docsMenuTree';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 
 const DocsMenu = (props: BoxProps) => {
   const router = useRouter();
-  useEffect(() => {
-    console.log(router.asPath);
-  }, [router]);
   const linkIsActive = (currentPath, href) => currentPath === `/docs/${href}`;
   return (
     <Box {...props}>

--- a/site/src/components/HeadingTreeMenu.tsx
+++ b/site/src/components/HeadingTreeMenu.tsx
@@ -7,7 +7,6 @@ const HeadingTreeMenu = () => {
     () =>
       headings.map(heading => {
         const headingElement = document.getElementById(heading.anchor);
-        console.log(headingElement);
 
         return {
           element: headingElement,

--- a/site/src/components/IconDetailOverlay.tsx
+++ b/site/src/components/IconDetailOverlay.tsx
@@ -28,11 +28,6 @@ const IconDetailOverlay = ({ open = true, close, icon }) => {
   };
 
   useEffect(() => {
-    console.log(icon);
-
-  }, [icon])
-
-  useEffect(() => {
     if(open) {
       onOpen()
     }

--- a/site/src/pages/icon/[iconName].tsx
+++ b/site/src/pages/icon/[iconName].tsx
@@ -18,7 +18,6 @@ const IconPage = ({ icon, data }) => {
         search: router.query.search,
       };
     }
-    console.log('CLOSE');
 
     router.push(
       {


### PR DESCRIPTION
I noticed a bunch of `console.log` calls on the website, which I assume were used at one point to test the website code but should probably not still be there.