### PR TITLE
feat: add frame icon

### DIFF
--- a/icons/frame.svg
+++ b/icons/frame.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+    <path d="M7 4v16M17 4v16M4 7h16M4 17h16" />
+</svg>

--- a/icons/frame.svg
+++ b/icons/frame.svg
@@ -9,5 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-    <path d="M7 4v16M17 4v16M4 7h16M4 17h16" />
+  <line x1="22" y1="6" x2="2" y2="6"/>
+  <line x1="22" y1="18" x2="2" y2="18"/>
+  <line x1="6" y1="2" x2="6" y2="22"/>
+  <line x1="18" y1="2" x2="18" y2="22"/>
 </svg>

--- a/tags.json
+++ b/tags.json
@@ -1112,6 +1112,11 @@
     "share",
     "email"
   ],
+  "frame": [
+    "logo",
+    "design",
+    "tool"
+  ],
   "framer": [
     "logo",
     "design",


### PR DESCRIPTION
This PR adds a frame icon, as discussed in #531.

The chosen implementation is frame 1.

![image](https://user-images.githubusercontent.com/14151691/162577454-fe79a49f-8abd-4b81-a1c0-f6f8a49f57f3.png)
