### PR TITLE
Fix misaligned lines in `crop`

### DIFF
--- a/icons/crop.svg
+++ b/icons/crop.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M6.13 1 6 16a2 2 0 0 0 2 2h15" />
-  <path d="M1 6.13 16 6a2 2 0 0 1 2 2v15" />
+  <path d="M6 1v15a2 2 0 0 0 2 2h15"/>
+  <path d="M18 23V8a2 2 0 0 0-2-2H1"/>
 </svg>

--- a/icons/crop.svg
+++ b/icons/crop.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M6 1v15a2 2 0 0 0 2 2h15"/>
-  <path d="M18 23V8a2 2 0 0 0-2-2H1"/>
+  <path d="M6 2v14a2 2 0 0 0 2 2h14"/>
+  <path d="M18 22V8a2 2 0 0 0-2-2H2"/>
 </svg>


### PR DESCRIPTION
The `crop` icon has a few misaligned lines which I believe are probably not intentional. This pull request fixes these (assumed) errors, see (old vs. new):
![image](https://user-images.githubusercontent.com/17746067/162747876-77ee4561-791e-4dff-ba89-23b41a9c84ae.png)
