### PR TITLE
chevrons-right-left + chevrons-left-right

### DIFF
--- a/icons/chevrons-left-right.svg
+++ b/icons/chevrons-left-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 7L4 12L9 17"/>
+  <path d="M15 7L20 12L15 17"/>
+</svg>

--- a/icons/chevrons-right-left.svg
+++ b/icons/chevrons-right-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 17L15 12L20 7"/>
+  <path d="M4 17L9 12L4 7"/>
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -544,20 +544,36 @@
   ],
   "chevrons-down-up": [
     "arrow",
-    "fold"
+    "collapse",
+    "fold",
+    "vertical"
   ],
   "chevrons-left": [
     "arrow"
   ],
+  "chevrons-left-right": [
+    "arrow",
+    "expand",
+    "horizonal",
+    "unfold"
+  ],
   "chevrons-right": [
     "arrow"
+  ],
+  "chevrons-right-left": [
+    "arrow",
+    "collapse",
+    "fold",
+    "horizonal"
   ],
   "chevrons-up": [
     "arrow"
   ],
   "chevrons-up-down": [
     "arrow",
-    "unfold"
+    "expand",
+    "unfold",
+    "vertical"
   ],
   "chrome": [
     "browser"


### PR DESCRIPTION
## Icon Request

* Icon name: chevrons-right-left + chevrons-left-right
* Use case: expanding and collapsing horizontally collapsible content (e.g. offcanvas or collapsible sidebar)

This pull request simply adds a horizontal variant of the already existing vertical double chevron icons:
![image](https://user-images.githubusercontent.com/17746067/162759136-f245b341-9427-4298-9e4f-603786ff6759.png)
