### PR TITLE
Added `milestone` icon

### DIFF
--- a/icons/milestone.svg
+++ b/icons/milestone.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 6H5a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h13l4-3.5L18 6Z"/>
+  <path d="M12 13v9"/>
+  <path d="M12 2v4"/>
+</svg>

--- a/icons/milestone.svg
+++ b/icons/milestone.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M18 6H5a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h13l4-3.5L18 6Z"/>
-  <path d="M12 13v9"/>
-  <path d="M12 2v4"/>
+  <path d="M18 6H5a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h13l4-3.5L18 6Z" />
+  <path d="M12 13v9" />
+  <path d="M12 2v4" />
 </svg>

--- a/tags.json
+++ b/tags.json
@@ -1588,6 +1588,11 @@
     "sound",
     "mute"
   ],
+  "milestone": [
+    "sign",
+    "signpost",
+    "version control"
+  ],
   "minimize": [
     "exit fullscreen",
     "close",


### PR DESCRIPTION
## Icon Request

* Icon name: milestone
* Use case: When representing GIT milestones or signs, signposts.
* _Screenshots_ of similar icons:
![image](https://user-images.githubusercontent.com/17746067/162815864-ba6b8be7-c97f-4de5-a3a9-df14dfdc1aa8.png)

![image](https://user-images.githubusercontent.com/17746067/162815992-06bef344-0b73-4f8f-9881-72880e683a06.png)
