### PR TITLE
Fixes `credit-card`

### DIFF
--- a/icons/credit-card.svg
+++ b/icons/credit-card.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="1" y="4" width="22" height="16" rx="2" ry="2" />
-  <line x1="1" y1="10" x2="23" y2="10" />
+  <rect x="2" y="5" width="20" height="14" rx="2"/>
+  <path d="M2 10 22 10"/>
 </svg>

--- a/icons/credit-card.svg
+++ b/icons/credit-card.svg
@@ -10,5 +10,5 @@
   stroke-linejoin="round"
 >
   <rect x="2" y="5" width="20" height="14" rx="2"/>
-  <path d="M2 10 22 10"/>
+  <line x1="2" y1="10" x2="22" y2="10" />
 </svg>

--- a/icons/credit-card.svg
+++ b/icons/credit-card.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="5" width="20" height="14" rx="2"/>
+  <rect x="2" y="5" width="20" height="14" rx="2" />
   <line x1="2" y1="10" x2="22" y2="10" />
 </svg>


### PR DESCRIPTION
This PR fixes guideline violations of the `credit-card` icon.
![image](https://user-images.githubusercontent.com/17746067/162905291-602a45be-0731-4216-b191-35adb919a74b.png)
