### PR TITLE
Fixes `dollar-sign`

### DIFF
--- a/icons/dollar-sign.svg
+++ b/icons/dollar-sign.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="12" y1="1" x2="12" y2="23" />
+  <line x1="12" y1="2" x2="12" y2="22" />
   <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
 </svg>


### PR DESCRIPTION
Fixes design guideline violations of `dollar-sign`.
![image](https://user-images.githubusercontent.com/17746067/162990548-2ac5e475-0aaf-43f0-a900-8dc364671cc0.png)

