### PR TITLE
Add `save-as` icon and `save` alternative

### DIFF
--- a/icons/save-2.svg
+++ b/icons/save-2.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 17v1a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v1" />
+  <path d="m10 15 3-3-3-3" />
+  <path d="M2 12h11" />
+</svg>

--- a/icons/save-as.svg
+++ b/icons/save-as.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 17v1a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v1" />
+  <path d="m10 15 3-3-3-3" />
+  <path d="M2 12h11" />
+  <path d="M17 12.01V12" />
+  <path d="M17 8.01V8" />
+  <path d="M17 16.01V16" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -2034,6 +2034,13 @@
   "save": [
     "floppy disk"
   ],
+  "save-2": [
+    "write"
+  ],
+  "save-as": [
+    "write",
+    "rename"
+  ],
   "scale": [
     "balance",
     "legal",


### PR DESCRIPTION
I had these a bit more modern looking alternatives for save icons lying around for a while now.

This would also address https://github.com/feathericons/feather/issues/609

<img width="600" alt="image" src="https://user-images.githubusercontent.com/44374653/166153275-95291c52-27c9-4c2f-a201-e5a63b3c34fe.png">
