### PR TITLE
Adds extra `calendar-*` icons

### DIFF
--- a/icons/calendar-check-2.svg
+++ b/icons/calendar-check-2.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 14V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8" />
+  <line x1="16" y1="2" x2="16" y2="6" />
+  <line x1="8" y1="2" x2="8" y2="6" />
+  <line x1="3" y1="10" x2="21" y2="10" />
+  <path d="m16 20 2 2 4-4" />
+</svg>

--- a/icons/calendar-check.svg
+++ b/icons/calendar-check.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+  <line x1="16" y1="2" x2="16" y2="6" />
+  <line x1="8" y1="2" x2="8" y2="6" />
+  <line x1="3" y1="10" x2="21" y2="10" />
+  <path d="m9 16 2 2 4-4" />
+</svg>

--- a/icons/calendar-days.svg
+++ b/icons/calendar-days.svg
@@ -1,0 +1,22 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+  <line x1="16" y1="2" x2="16" y2="6" />
+  <line x1="8" y1="2" x2="8" y2="6" />
+  <line x1="3" y1="10" x2="21" y2="10" />
+  <path d="M8 14h.01" />
+  <path d="M12 14h.01" />
+  <path d="M16 14h.01" />
+  <path d="M8 18h.01" />
+  <path d="M12 18h.01" />
+  <path d="M16 18h.01" />
+</svg>

--- a/icons/calendar-minus.svg
+++ b/icons/calendar-minus.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 13V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8" />
+  <line x1="16" y1="2" x2="16" y2="6" />
+  <line x1="8" y1="2" x2="8" y2="6" />
+  <line x1="3" y1="10" x2="21" y2="10" />
+  <line x1="16" y1="19" x2="22" y2="19" />
+</svg>

--- a/icons/calendar-off.svg
+++ b/icons/calendar-off.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4.18 4.18A2 2 0 0 0 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 1.82-1.18" />
+  <path d="M21 15.5V6a2 2 0 0 0-2-2H9.5" />
+  <path d="M16 2v4" />
+  <path d="M3 10h7" />
+  <path d="M21 10h-5.5" />
+  <line x1="2" y1="2" x2="22" y2="22" />
+</svg>

--- a/icons/calendar-plus.svg
+++ b/icons/calendar-plus.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 13V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8" />
+  <line x1="16" y1="2" x2="16" y2="6" />
+  <line x1="8" y1="2" x2="8" y2="6" />
+  <line x1="3" y1="10" x2="21" y2="10" />
+  <line x1="19" y1="16" x2="19" y2="22" />
+  <line x1="16" y1="19" x2="22" y2="19" />
+</svg>

--- a/icons/calendar-range.svg
+++ b/icons/calendar-range.svg
@@ -1,0 +1,20 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+  <line x1="16" y1="2" x2="16" y2="6" />
+  <line x1="8" y1="2" x2="8" y2="6" />
+  <line x1="3" y1="10" x2="21" y2="10" />
+  <path d="M17 14h-6" />
+  <path d="M13 18H7" />
+  <path d="M7 14h.01" />
+  <path d="M17 18h.01" />
+</svg>

--- a/icons/calendar-x-2.svg
+++ b/icons/calendar-x-2.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+  <path d="M21 13V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8" />
   <line x1="16" y1="2" x2="16" y2="6" />
   <line x1="8" y1="2" x2="8" y2="6" />
   <line x1="3" y1="10" x2="21" y2="10" />
-  <line x1="10" y1="14" x2="14" y2="18" />
-  <line x1="14" y1="14" x2="10" y2="18" />
+  <line x1="17" y1="17" x2="22" y2="22" />
+  <line x1="17" y1="22" x2="22" y2="17" />
 </svg>

--- a/icons/calendar-x.svg
+++ b/icons/calendar-x.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 13V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8" />
+  <line x1="16" y1="2" x2="16" y2="6" />
+  <line x1="8" y1="2" x2="8" y2="6" />
+  <line x1="3" y1="10" x2="21" y2="10" />
+  <line x1="17" y1="17" x2="22" y2="22" />
+  <line x1="17" y1="22" x2="22" y2="17" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -570,6 +570,13 @@
     "date",
     "time",
     "event",
+    "remove",
+    "busy"
+  ],
+  "calendar-x-2": [
+    "date",
+    "time",
+    "event",
     "remove"
   ],
   "camera": [

--- a/tags.json
+++ b/tags.json
@@ -513,7 +513,64 @@
   ],
   "calendar": [
     "date",
+    "time",
+    "event",
     "birthdate"
+  ],
+  "calendar-check": [
+    "date",
+    "time",
+    "event",
+    "confirm",
+    "subscribe"
+  ],
+  "calendar-check-2": [
+    "date",
+    "time",
+    "event",
+    "confirm",
+    "subscribe"
+  ],
+  "calendar-days": [
+    "date",
+    "time",
+    "event"
+  ],
+  "calendar-minus": [
+    "date",
+    "time",
+    "event",
+    "delete",
+    "remove"
+  ],
+  "calendar-off": [
+    "date",
+    "time",
+    "event",
+    "delete",
+    "remove"
+  ],
+  "calendar-plus": [
+    "date",
+    "time",
+    "event",
+    "add",
+    "subscribe",
+    "create",
+    "new"
+  ],
+  "calendar-range": [
+    "date",
+    "time",
+    "event",
+    "range",
+    "period"
+  ],
+  "calendar-x": [
+    "date",
+    "time",
+    "event",
+    "remove"
   ],
   "camera": [
     "photo",


### PR DESCRIPTION
## Icon Request

* Icon name: extra calendar functions & operations
* Use cases:
  * `calendar-plus`: creating new event, adding event to calendar
  * `calendar-minus`: deleting or unsubscribing from event
  * `calendar-x`:  removing or deleting event or marking a date as taken/busy
  * `calendar-x-2`, `calendar-off`:  removing or deleting event
  * `calendar-check`: subscribing to event, adding event to calendar, marking an event as complete or a date as taken etc
  * `calendar-days`: using as an alternate style for calendar, representing a month or a list of dates.
  * `calendar-range`: representing a date range, e.g. for daterange widgets.

![image](https://user-images.githubusercontent.com/17746067/170657362-246a6513-8fbd-4112-9a76-3a75441188ee.png)
![calendar](https://user-images.githubusercontent.com/17746067/170657384-06e944fa-b995-423b-b7e8-4ef11392aafb.png)
