### PR TITLE
Added `cigarette` & `cigarette-off`

### DIFF
--- a/icons/cigarette-off.svg
+++ b/icons/cigarette-off.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <line x1="2" y1="2" x2="22" y2="22" />
+  <path d="M13 13H2v4h15" />
+  <path d="M22 13v4" />
+  <path d="M7 13v4" />
+  <path d="M18 9c0-2.5-2-2.5-2-5" />
+  <path d="M22 9c0-2.5-2-2.5-2-5" />
+  <path d="M18 13h.01" />
+</svg>

--- a/icons/cigarette-off.svg
+++ b/icons/cigarette-off.svg
@@ -10,10 +10,10 @@
   stroke-linejoin="round"
 >
   <line x1="2" y1="2" x2="22" y2="22" />
-  <path d="M13 13H2v4h15" />
-  <path d="M22 13v4" />
-  <path d="M7 13v4" />
-  <path d="M18 9c0-2.5-2-2.5-2-5" />
-  <path d="M22 9c0-2.5-2-2.5-2-5" />
-  <path d="M18 13h.01" />
+  <path d="M12 12H2v4h14" />
+  <path d="M22 12v4" />
+  <path d="M18 12h-.5" />
+  <path d="M7 12v4" />
+  <path d="M18 8c0-2.5-2-2.5-2-5" />
+  <path d="M22 8c0-2.5-2-2.5-2-5" />
 </svg>

--- a/icons/cigarette.svg
+++ b/icons/cigarette.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M18 13H2v4h16" />
-  <path d="M22 13v4" />
-  <path d="M7 13v4" />
-  <path d="M18 9c0-2.5-2-2.5-2-5" />
-  <path d="M22 9c0-2.5-2-2.5-2-5" />
+  <path d="M18 12H2v4h16" />
+  <path d="M22 12v4" />
+  <path d="M7 12v4" />
+  <path d="M18 8c0-2.5-2-2.5-2-5" />
+  <path d="M22 8c0-2.5-2-2.5-2-5" />
 </svg>

--- a/icons/cigarette.svg
+++ b/icons/cigarette.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 13H2v4h16" />
+  <path d="M22 13v4" />
+  <path d="M7 13v4" />
+  <path d="M18 9c0-2.5-2-2.5-2-5" />
+  <path d="M22 9c0-2.5-2-2.5-2-5" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -619,6 +619,13 @@
   "chrome": [
     "browser"
   ],
+  "cigarette": [
+    "smoking"
+  ],
+  "cigarette-off": [
+    "smoking",
+    "no-smoking"
+  ],
   "circle": [
     "off",
     "zero",


### PR DESCRIPTION
## Icon Request

* Icon name: `cigarette`, `cigarette-off`
* Use case: Marking smoking and especially no smoking environments.
* Screenshots of similar icons:
![image](https://user-images.githubusercontent.com/17746067/170955217-04029101-1bb3-4b4e-8108-28224af9f9ec.png)


![image](https://user-images.githubusercontent.com/17746067/170954222-90fc9096-5401-4612-8b21-3ee082777e5c.png)
![image](https://user-images.githubusercontent.com/17746067/170953606-09171c4b-802d-4a0a-9b37-8605702ae7ae.png)
