### PR TITLE
Adds `bed`, `armchair` & `sofa`

### DIFF
--- a/icons/armchair.svg
+++ b/icons/armchair.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M19 9V6a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v3" />
+  <path d="M3 11v5a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5a2 2 0 0 0-4 0v2H7v-2a2 2 0 0 0-4 0Z" />
+  <path d="M5 18v2" />
+  <path d="M19 18v2" />
+</svg>

--- a/icons/bed-double.svg
+++ b/icons/bed-double.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 20v-8a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v8" />
+  <path d="M4 10V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4" />
+  <path d="M12 4v6" />
+  <path d="M2 18h20" />
+</svg>

--- a/icons/bed-single.svg
+++ b/icons/bed-single.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 20v-8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v8" />
+  <path d="M5 10V6a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v4" />
+  <path d="M3 18h18" />
+</svg>

--- a/icons/bed.svg
+++ b/icons/bed.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 4v16" />
+  <path d="M2 8h18a2 2 0 0 1 2 2v10" />
+  <path d="M2 17h20" />
+  <path d="M6 8v9" />
+</svg>

--- a/icons/sofa.svg
+++ b/icons/sofa.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 9V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v3" />
+  <path d="M2 11v5a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-5a2 2 0 0 0-4 0v2H6v-2a2 2 0 0 0-4 0Z" />
+  <path d="M4 18v2" />
+  <path d="M20 18v2" />
+  <path d="M12 4v9" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -229,6 +229,14 @@
     "index",
     "box"
   ],
+  "armchair": [
+    "sofa",
+    "furniture",
+    "leisure",
+    "lounge",
+    "loveseat",
+    "couch"
+  ],
   "arrow-big-down": [
     "key"
   ],
@@ -365,6 +373,21 @@
   ],
   "beaker": [
     "cup"
+  ],
+  "bed": [
+    "sleep",
+    "hotel",
+    "furniture"
+  ],
+  "bed-single": [
+    "sleep",
+    "hotel",
+    "furniture"
+  ],
+  "bed-double": [
+    "sleep",
+    "hotel",
+    "furniture"
   ],
   "bell": [
     "alarm",
@@ -2419,6 +2442,14 @@
     "weather",
     "freeze",
     "snow"
+  ],
+  "sofa": [
+    "armchair",
+    "furniture",
+    "leisure",
+    "lounge",
+    "loveseat",
+    "couch"
   ],
   "sort-asc": [
     "filter"


### PR DESCRIPTION
## Icon Request

* Icon name: bed, single bed, double bed, sofa, armchair
* Use case: used in hotel, booking and smart home applications, to signify sleeping area, lounge, single & double bed etc.
* Originates from: #683 

![image](https://user-images.githubusercontent.com/17746067/170959571-5941c620-a112-4898-9027-8d9434667688.png)
![image](https://user-images.githubusercontent.com/17746067/170959601-bac02e3c-abf3-48d5-a587-dc11e644bdca.png)
