### PR TITLE
Adds `backpage`, `luggage`, `baggage-claim`

### DIFF
--- a/icons/backpack.svg
+++ b/icons/backpack.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 20V10a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Z" />
+  <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+  <path d="M8 21v-5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v5" />
+  <path d="M8 10h8" />
+  <path d="M8 18h8" />
+</svg>

--- a/icons/baggage-claim.svg
+++ b/icons/baggage-claim.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 18H6a2 2 0 0 1-2-2V7a2 2 0 0 0-2-2" />
+  <path d="M17 14V4a2 2 0 0 0-2-2h-1a2 2 0 0 0-2 2v10" />
+  <rect x="8" y="6" width="13" height="8" rx="1" />
+  <circle cx="18" cy="20" r="2" />
+  <circle cx="9" cy="20" r="2" />
+</svg>

--- a/icons/luggage.svg
+++ b/icons/luggage.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 20h0a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h0" />
+  <path d="M8 18V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v14" />
+  <path d="M10 20h4" />
+  <circle cx="16" cy="20" r="2" />
+  <circle cx="8" cy="20" r="2" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -302,6 +302,21 @@
   "axe": [
     "hatchet"
   ],
+  "backpack": [
+    "bag",
+    "hiking",
+    "travel",
+    "camping",
+    "school",
+    "childhood"
+  ],
+  "baggage-claim": [
+    "baggage",
+    "luggage",
+    "travel",
+    "cart",
+    "trolley"
+  ],
   "banknote": [
     "currency",
     "money",
@@ -1658,6 +1673,11 @@
     "arrow",
     "exit",
     "auth"
+  ],
+  "luggage": [
+    "baggage",
+    "luggage",
+    "travel"
   ],
   "magnet": [
     "horseshoe",


### PR DESCRIPTION
## Icon Request

* Icon name: backpack, baggage/luggage, baggage claim
* Use case: hotel/airport applications
* Originates from: https://github.com/lucide-icons/lucide/issues/683

![image](https://user-images.githubusercontent.com/17746067/170967519-b26b5231-5be6-4f18-8331-657e2fa18d12.png)
![image](https://user-images.githubusercontent.com/17746067/170967536-dbde0cdc-9105-4e63-91d6-b9b5f387d525.png)
(briefcase for comparison)