### PR TITLE
Adds `list-start`, `list-end`, `list-music` & `list-video`

### DIFF
--- a/icons/list-end.svg
+++ b/icons/list-end.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 12H3" />
+  <path d="M16 6H3" />
+  <path d="M10 18H3" />
+  <path d="M21 6v10a2 2 0 0 1-2 2h-4" />
+  <path d="m16 16-2 2 2 2" />
+</svg>

--- a/icons/list-music.svg
+++ b/icons/list-music.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 15V6" />
+  <path d="M18.5 18a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
+  <path d="M12 12H3" />
+  <path d="M16 6H3" />
+  <path d="M12 18H3" />
+</svg>

--- a/icons/list-start.svg
+++ b/icons/list-start.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 12H3" />
+  <path d="M16 18H3" />
+  <path d="M10 6H3" />
+  <path d="M21 18V8a2 2 0 0 0-2-2h-5" />
+  <path d="m16 8-2-2 2-2" />
+</svg>

--- a/icons/list-video.svg
+++ b/icons/list-video.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 12H3" />
+  <path d="M16 6H3" />
+  <path d="M12 18H3" />
+  <path d="m16 12 5 3-5 3v-6Z" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -1591,6 +1591,12 @@
     "todo",
     "done"
   ],
+  "list-end": [
+    "queue",
+    "bottom",
+    "end",
+    "playlist"
+  ],
   "list-minus": [
     "playlist",
     "remove",
@@ -1598,6 +1604,13 @@
     "subtract",
     "remove",
     "delete"
+  ],
+  "list-music": [
+    "playlist",
+    "queue",
+    "music",
+    "audio",
+    "playback"
   ],
   "list-ordered": [
     "number",
@@ -1609,6 +1622,18 @@
     "song",
     "track",
     "new"
+  ],
+  "list-start": [
+    "queue",
+    "top",
+    "start",
+    "next",
+    "playlist"
+  ],
+  "list-video": [
+    "playlist",
+    "video",
+    "playback"
   ],
   "list-x": [
     "playlist",


### PR DESCRIPTION
## Icon Request

* Icon name: playlist
* Use case:
  * used for audio or video playback / playlists / queues
  * `list-start` and `list-end` also useable when ordering lists (for the actions move to top/start & move to bottom/end)
* Screenshots of similar icons:
![image](https://user-images.githubusercontent.com/17746067/171412338-d50fd8ab-add1-4a26-81bd-2037166398a0.png)

![image](https://user-images.githubusercontent.com/17746067/171392216-dd37f7e8-ef95-4b5a-bee7-cf47dca85152.png)
![image](https://user-images.githubusercontent.com/17746067/171392050-33cda178-4d2a-43b4-a807-822e573faf50.png)
