### PR TITLE
Optimizes `clipboard` icons

### DIFF
--- a/icons/clipboard-check.svg
+++ b/icons/clipboard-check.svg
@@ -10,6 +10,6 @@
   stroke-linejoin="round"
 >
   <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
-  <path d="M15 2H9a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z" />
+  <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
   <path d="m9 13 2 2 4-4" />
 </svg>

--- a/icons/clipboard-list.svg
+++ b/icons/clipboard-list.svg
@@ -10,7 +10,7 @@
   stroke-linejoin="round"
 >
   <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
-  <path d="M15 2H9a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z" />
+  <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
   <path d="M12 11h4" />
   <path d="M12 16h4" />
   <path d="M8 11h.01" />

--- a/icons/clipboard-x.svg
+++ b/icons/clipboard-x.svg
@@ -10,7 +10,7 @@
   stroke-linejoin="round"
 >
   <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
-  <path d="M15 2H9a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z" />
+  <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
   <path d="m15 11-6 6" />
   <path d="m9 11 6 6" />
 </svg>


### PR DESCRIPTION
Simplifies the source code of clipboard icons:
```diff
-  <path d="M15 2H9a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1z" />
+  <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
```