### PR TITLE
Add Discernible Name to Inaccessible Links

### DIFF
--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -65,46 +65,55 @@ const Header = ({ data }: HeaderProps) => {
       name: 'lucide',
       Logo: JSLogo,
       href: '/docs/lucide',
+      label: 'Lucide documentation for JavaScript',
     },
     {
       name: 'lucide-react',
       Logo: ReactLogo,
       href: '/docs/lucide-react',
+      label: 'Lucide documentation for React',
     },
     {
       name: 'lucide-vue',
       Logo: VueLogo,
       href: '/docs/lucide-vue',
+      label: 'Lucide documentation for Vue',
     },
     {
       name: 'lucide-vue-next',
       Logo: Vue3Logo,
       href: '/docs/lucide-vue-next',
+      label: 'Lucide documentation for Vue 3',
     },
     {
       name: 'lucide-svelte',
       Logo: SvelteLogo,
       href: '/docs/lucide-svelte',
+      label: 'Lucide documentation for Svelte',
     },
     {
       name: 'lucide-preact',
       Logo: PreactLogo,
       href: '/docs/lucide-preact',
+      label: 'Lucide documentation for Preact',
     },
     {
       name: 'lucide-angular',
       Logo: AngularLogo,
       href: '/docs/lucide-angular',
+      label: 'Lucide documentation for Angluar',
     },
     {
       name: 'lucide-flutter',
       Logo: FlutterLogo,
       href: '/docs/lucide-flutter',
+      label: 'Lucide documentation for Flutter',
     },
     {
       name: 'lucide-laravel',
       Logo: LaravelLogo,
       href: 'https://github.com/mallardduck/blade-lucide-icons',
+      label: 'Lucide documentation for Laravel',
     },
   ];
 
@@ -141,10 +150,10 @@ const Header = ({ data }: HeaderProps) => {
             </Link>
           </NextLink>
         </WrapItem>
-        {packages.map(({ name, href, Logo }) => (
+        {packages.map(({ name, href, Logo, label }) => (
           <WrapItem key={name}>
             <NextLink href={href} key={name} passHref>
-              <Link _hover={{ opacity: 0.8 }}>
+              <Link _hover={{ opacity: 0.8 }} aria-label={label}>
                 <Logo />
               </Link>
             </NextLink>


### PR DESCRIPTION
Issue:
Fixes an accessibility issue where the anchor tags in the `Header` component, that link to the documentation of all the different frameworks, don't have a discernible name that accessibility tools can recognise.

![Screenshot 2022-06-13 at 16 36 59](https://user-images.githubusercontent.com/15114122/173378582-055c6cff-fd55-4398-bd1d-400ad6dede3f.png)