### PR TITLE
Adds icons for various design tools

### DIFF
--- a/icons/paint-bucket.svg
+++ b/icons/paint-bucket.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m19 11-8-8-8.6 8.6a2 2 0 0 0 0 2.8l5.2 5.2c.8.8 2 .8 2.8 0L19 11Z" />
+  <path d="m5 2 5 5" />
+  <path d="M2 13h15" />
+  <path d="M22 20a2 2 0 1 1-4 0c0-1.6 1.7-2.4 2-4 .3 1.6 2 2.4 2 4Z" />
+</svg>

--- a/icons/paintbrush-2.svg
+++ b/icons/paintbrush-2.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14 19.9V16h3a2 2 0 0 0 2-2v-2H5v2c0 1.1.9 2 2 2h3v3.9a2 2 0 1 0 4 0Z" />
+  <path d="M6 12V2h12v10" />
+  <path d="M14 2v4" />
+  <path d="M10 2v2" />
+</svg>

--- a/icons/paintbrush.svg
+++ b/icons/paintbrush.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18.37 2.63 14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a2.12 2.12 0 1 0-3-3Z" />
+  <path d="M9 8c-2 3-4 3.5-7 4l8 10c2-1 6-5 6-7" />
+  <path d="M14.5 17.5 4.5 15" />
+</svg>

--- a/icons/scaling.svg
+++ b/icons/scaling.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 3 9 15" />
+  <path d="M12 3H3v18h18v-9" />
+  <path d="M16 3h5v5" />
+  <path d="M14 15H9v-5" />
+</svg>

--- a/icons/slice.svg
+++ b/icons/slice.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m8 14-6 6h9v-3" />
+  <path d="M18.37 3.63 8 14l3 3L21.37 6.63a2.12 2.12 0 1 0-3-3Z" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -2092,6 +2092,22 @@
     "delete",
     "remove"
   ],
+  "paint-bucket": [
+    "fill",
+    "paint",
+    "bucket",
+    "design"
+  ],
+  "paintbrush": [
+    "brush",
+    "paintbrush",
+    "design"
+  ],
+  "paintbrush-2": [
+    "brush",
+    "paintbrush",
+    "design"
+  ],
   "palette": [
     "color",
     "theme"
@@ -2341,6 +2357,11 @@
   ],
   "save": [
     "floppy disk"
+  ],
+  "scaling": [
+    "scale",
+    "resize",
+    "design"
   ],
   "scale": [
     "balance",
@@ -2594,6 +2615,11 @@
     "forbidden",
     "prohibited",
     "error"
+  ],
+  "slice": [
+    "cutter",
+    "scalpel",
+    "knife"
   ],
   "sliders": [
     "settings",


### PR DESCRIPTION
## Icon Request

* Icon name: design tools
* Use case: on UI design interfaces

![image](https://user-images.githubusercontent.com/17746067/173385841-681c0fd0-84a8-465c-a749-cff18aa9de09.png)
![design](https://user-images.githubusercontent.com/17746067/173386086-e70da884-8e1e-4fd6-807d-e0f02d051be9.png)
(The complete set designed is shown on the 100% view, I've chosen not to include all of them, since some are bit too random).

There's a naming conflict with the current `scale` icon, not sure how this should be resolved, that one probably should have been called `scales`.