### PR TITLE
Adds bomb

### DIFF
--- a/icons/bomb.svg
+++ b/icons/bomb.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="11" cy="13" r="8" />
+  <path d="m19 10 1.6-1.6c.8-.8.8-2 0-2.8l-2.2-2.2a2 2 0 0 0-2.8 0L14 5" />
+  <path d="m21 3-1.5 1.5" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -473,6 +473,16 @@
     "strong",
     "format"
   ],
+  "bomb": [
+    "fatal",
+    "error",
+    "crash",
+    "blockbuster",
+    "mine",
+    "explosion",
+    "explode",
+    "explosive"
+  ],
   "book": [
     "read",
     "dictionary",


### PR DESCRIPTION
## Icon Request
* Icon name: bomb
* Use case: fatal error, crash, blockbuster, https://en.wikipedia.org/wiki/Bomb_(icon)
* Originates from: https://github.com/feathericons/feather/issues/1153
* Screenshots of similar icons:
![image](https://user-images.githubusercontent.com/17746067/173509529-13f3d6e5-cdc6-4991-90e9-16965a7f22c9.png)
![image](https://user-images.githubusercontent.com/17746067/173509544-0e8c181b-9d64-49c8-9070-9ea48bef2b8e.png)