### PR TITLE
Replaces all occurences of `master` with `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm install lucide
 yarn add lucide
 ```
 
-For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/master/packages/lucide#lucide).
+For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/main/packages/lucide#lucide).
 
 ### React
 
@@ -74,7 +74,7 @@ yarn add lucide-react
 npm install lucide-react
 ```
 
-For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-react#lucide-react).
+For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-react#lucide-react).
 
 ### Vue 2
 
@@ -88,7 +88,7 @@ yarn add lucide-vue
 npm install lucide-vue
 ```
 
-For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-vue#lucide-vue).
+For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-vue#lucide-vue).
 
 ### Vue 3
 
@@ -102,7 +102,7 @@ yarn add lucide-vue-next
 npm install lucide-vue-next
 ```
 
-For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-vue-next#lucide-vue-next).
+For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-vue-next#lucide-vue-next).
 
 ### Angular
 
@@ -114,7 +114,7 @@ yarn add lucide-angular
 npm install lucide-angular
 ```
 
-For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-angular#lucide-angular).
+For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-angular#lucide-angular).
 
 ### Preact
 
@@ -128,7 +128,7 @@ yarn add lucide-preact
 npm install lucide-preact
 ```
 
-For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-preact#lucide-preact).
+For more details, see the [documentation](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-preact#lucide-preact).
 
 ### Static (svg sprite, font, icons ..)
 
@@ -177,9 +177,9 @@ For more details, see the [pub.dev](https://pub.dev/packages/lucide_icons).
 
 ## Contributing
 
-For more info on how to contribute please see the [contribution guidelines](https://github.com/lucide-icons/lucide/blob/master/CONTRIBUTING.md).
+For more info on how to contribute please see the [contribution guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
 
-Caught a mistake or want to contribute to the documentation? [Edit this page on Github](https://github.com/lucide-icons/lucide/blob/master/README.md)
+Caught a mistake or want to contribute to the documentation? [Edit this page on Github](https://github.com/lucide-icons/lucide/blob/main/README.md)
 
 ## Community
 
@@ -187,7 +187,7 @@ Join the community on our [Discord](https://discord.gg/EH6nSts) server!
 
 ## License
 
-Lucide is totally free for commercial use and personally use, this software is licensed under the [ISC License](https://github.com/lucide-icons/lucide/blob/master/LICENSE).
+Lucide is totally free for commercial use and personally use, this software is licensed under the [ISC License](https://github.com/lucide-icons/lucide/blob/main/LICENSE).
 
 ## Credits
 

--- a/docs/ILLUSTRATOR_GUIDE.md
+++ b/docs/ILLUSTRATOR_GUIDE.md
@@ -26,6 +26,6 @@ The Illustrator template is created following guidelines from the [Icon Design G
 
 ![SVG export options in Illustrator](images/illustrator-svg-options.png?raw=true "Setting Page Size")
 
-After that, double check that the [code conventions and SVG global attributes](https://github.com/lucide-icons/lucide/blob/master/docs/ICON_DESIGN_GUIDE.md#code-conventions) are correct.
+After that, double check that the [code conventions and SVG global attributes](https://github.com/lucide-icons/lucide/blob/main/docs/ICON_DESIGN_GUIDE.md#code-conventions) are correct.
 
 7. Minify paths with [SVGOMG](https://jakearchibald.github.io/svgomg/).

--- a/packages/lucide-figma/src/views/Info.tsx
+++ b/packages/lucide-figma/src/views/Info.tsx
@@ -12,7 +12,7 @@ const Info = ({ version }: PageProps) => {
     },
     {
       name: 'Contribute an icon',
-      url: 'https://github.com/lucide-icons/lucide/blob/master/CONTRIBUTING.md'
+      url: 'https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md'
     },
     {
       name: 'Website',

--- a/packages/lucide-static/README.md
+++ b/packages/lucide-static/README.md
@@ -13,7 +13,7 @@ This package include the following lucide implementations:
 
 This package is suitable for very specific use cases for example if you want to use icon fonts, svg sprites, normal svgs or Common.js Svg strings in your javascript project.
 
-> ⚠️ It is not recommended to use this package for svg sprites or icon fonts for web pages/applications, for prototyping it is ok. We recommend to bundlers for web applications to make sure you only bundle the used icons from this icon library (Threeshaking). Otherwise it will load all the icons, making you webpage loading slower. Threeshaking is only available in the packages: [lucide](https://github.com/lucide-icons/lucide/tree/master/packages/lucide), [lucide-react](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-react), [lucide-vue](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-vue), [lucide-vue-next](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-vue-next), [lucide-angular](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-angular), [lucide-preact](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-preact)
+> ⚠️ It is not recommended to use this package for svg sprites or icon fonts for web pages/applications, for prototyping it is ok. We recommend to bundlers for web applications to make sure you only bundle the used icons from this icon library (Threeshaking). Otherwise it will load all the icons, making you webpage loading slower. Threeshaking is only available in the packages: [lucide](https://github.com/lucide-icons/lucide/tree/main/packages/lucide), [lucide-react](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-react), [lucide-vue](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-vue), [lucide-vue-next](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-vue-next), [lucide-angular](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-angular), [lucide-preact](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-preact)
 
 ## Installation
 
@@ -183,9 +183,9 @@ app.listen(port, () => {
 
 ## Contributing
 
-For more info on how to contribute please see the [contribution guidelines](https://github.com/lucide-icons/lucide/blob/master/CONTRIBUTING.md).
+For more info on how to contribute please see the [contribution guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
 
-Caught a mistake or want to contribute to the documentation? [Edit this page on Github](https://github.com/lucide-icons/lucide/blob/master/README.md)
+Caught a mistake or want to contribute to the documentation? [Edit this page on Github](https://github.com/lucide-icons/lucide/blob/main/README.md)
 
 ## Community
 
@@ -193,4 +193,4 @@ Join the community on our [Discord](https://discord.gg/EH6nSts) server!
 
 ## License
 
-Lucide is totally free for commercial use and personally use, this software is licensed under the [ISC License](https://github.com/lucide-icons/lucide/blob/master/LICENSE).
+Lucide is totally free for commercial use and personally use, this software is licensed under the [ISC License](https://github.com/lucide-icons/lucide/blob/main/LICENSE).

--- a/packages/lucide-vue-next/README.md
+++ b/packages/lucide-vue-next/README.md
@@ -4,7 +4,7 @@ Implementation of the lucide icon library for Vue 3 applications.
 
 > What is lucide? Read it [here](https://github.com/lucide-icons/lucide#what-is-lucide).
 
-> :warning: This version of lucide is for Vue 3, For Vue 2 got to [lucide-vue-next](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-vue#lucide-vue)
+> :warning: This version of lucide is for Vue 3, For Vue 2 got to [lucide-vue-next](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-vue#lucide-vue)
 
 ## Installation
 

--- a/packages/lucide-vue/README.md
+++ b/packages/lucide-vue/README.md
@@ -4,7 +4,7 @@ Implementation of the lucide icon library for Vue applications.
 
 > What is lucide? Read it [here](https://github.com/lucide-icons/lucide#what-is-lucide).
 
-> :warning: This version of lucide is for Vue 2, For Vue 3 got to [lucide-vue-next](https://github.com/lucide-icons/lucide/tree/master/packages/lucide-vue-next#lucide-vue-next)
+> :warning: This version of lucide is for Vue 2, For Vue 3 got to [lucide-vue-next](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-vue-next#lucide-vue-next)
 
 ## Installation
 

--- a/scripts/generateChangelog.js
+++ b/scripts/generateChangelog.js
@@ -2,7 +2,7 @@ import getArgumentOptions from 'minimist'; // eslint-disable-line import/no-extr
 import githubApi from './githubApi';
 
 const fetchCompareTags = oldTag =>
-  githubApi(`https://api.github.com/repos/lucide-icons/lucide/compare/${oldTag}...master`);
+  githubApi(`https://api.github.com/repos/lucide-icons/lucide/compare/${oldTag}...main`);
 
 const iconRegex = /icons\/(.*)\.svg/g;
 const iconTemplate = ({ name, pullNumber, author }) =>

--- a/site/src/pages/packages/index.tsx
+++ b/site/src/pages/packages/index.tsx
@@ -36,7 +36,7 @@ export async function getStaticProps({ params }) {
         name,
         description,
         image: `/package-logos/${packageDirectory}-small.svg`,
-        source: `https://github.com/lucide-icons/lucide/tree/master/packages/${packageDirectory}`,
+        source: `https://github.com/lucide-icons/lucide/tree/main/packages/${packageDirectory}`,
         documentation: `/docs/${packageDirectory}`,
         ...packagesData[packageDirectory],
       };


### PR DESCRIPTION
...in site code, scripts, documentation and readmes.