### PR TITLE
Adds `circle-ellipsis` & `circle-dot`

### DIFF
--- a/icons/circle-dot.svg
+++ b/icons/circle-dot.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <circle cx="12" cy="12" r="1" />
+</svg>

--- a/icons/circle-ellipsis.svg
+++ b/icons/circle-ellipsis.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M17 12h.01" />
+  <path d="M12 12h.01" />
+  <path d="M7 12h.01" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -819,11 +819,6 @@
     "ellipsis",
     "progress"
   ],
-  "circle": [
-    "off",
-    "zero",
-    "record"
-  ],
   "circle-slashed": [
     "diameter",
     "zero",

--- a/tags.json
+++ b/tags.json
@@ -808,6 +808,22 @@
     "zero",
     "record"
   ],
+  "circle-dot": [
+    "pending",
+    "dot",
+    "progress",
+    "issue"
+  ],
+  "circle-ellipsis": [
+    "pending",
+    "ellipsis",
+    "progress"
+  ],
+  "circle": [
+    "off",
+    "zero",
+    "record"
+  ],
   "circle-slashed": [
     "diameter",
     "zero",


### PR DESCRIPTION
## Icon Request

* Icon name: circle ellipsis, circle dot
* Use case: https://github.com/feathericons/feather/issues/337, representing an uncompleted issue
* Originates from: https://github.com/lucide-icons/lucide/issues/119
* Screenshots of similar icons: 
![image](https://user-images.githubusercontent.com/17746067/174744000-6a6e520d-64b2-4bff-b8f0-a8509b6089ef.png)
![image](https://user-images.githubusercontent.com/17746067/174744100-b3cf605f-6f01-407a-b996-b2e3a4be3d01.png)

![image](https://user-images.githubusercontent.com/17746067/174744145-0e576830-121e-4fa0-968c-29387e4d5b65.png)
![image](https://user-images.githubusercontent.com/17746067/174744164-26faad07-c050-436e-ba0b-7c7a7dcccf1f.png)
