### PR TITLE
fix: fix lucide-react-native failing to publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,6 +496,7 @@ jobs:
         pre-build,
         lucide,
         lucide-react,
+        lucide-react-native,
         lucide-vue,
         lucide-vue-next,
         lucide-angular,

--- a/packages/lucide-react-native/package.json
+++ b/packages/lucide-react-native/package.json
@@ -33,12 +33,13 @@
     "jest": "^26.6.3",
     "prop-types": "^15.7.2",
     "react": "^16.5.1",
-    "react-dom": "^17.0.2",
+    "react-native": "^0.69.0",
     "react-native-svg": "^12.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
     "react": "^16.5.1 || ^17.0.0 || ^18.0.0",
+    "react-native": ">=0.50.0",
     "react-native-svg": "^12.0.0"
   }
 }


### PR DESCRIPTION
I believe that should fix the issues we're dealing with.

https://github.com/lucide-icons/lucide/runs/7116958776?check_suite_focus=true

Note: I was not able to get Yarn classic installed on my machine, so the changes related to lockfile are not included here. Sorry about that!