### PR TITLE
Adds further `mail` icons

### DIFF
--- a/icons/mail-check.svg
+++ b/icons/mail-check.svg
@@ -9,6 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
+  <path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h8" />
   <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <path d="m16 19 2 2 4-4" />
 </svg>

--- a/icons/mail-minus.svg
+++ b/icons/mail-minus.svg
@@ -9,6 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
+  <path d="M22 15V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h8" />
   <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <path d="M16 19h6" />
 </svg>

--- a/icons/mail-open.svg
+++ b/icons/mail-open.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
-  <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <path d="M21.2 8.4c.5.38.8.97.8 1.6v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V10a2 2 0 0 1 .8-1.6l8-6a2 2 0 0 1 2.4 0l8 6Z" />
+  <path d="m22 10-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 10" />
 </svg>

--- a/icons/mail-plus.svg
+++ b/icons/mail-plus.svg
@@ -9,6 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
+  <path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h8" />
   <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <path d="M19 16v6" />
+  <path d="M16 19h6" />
 </svg>

--- a/icons/mail-question.svg
+++ b/icons/mail-question.svg
@@ -9,6 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
+  <path d="M22 10.5V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h12.5" />
   <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <path d="M18 15.28c.2-.4.5-.8.9-1a2.1 2.1 0 0 1 2.6.4c.3.4.5.8.5 1.3 0 1.3-2 2-2 2" />
+  <path d="M20 22v.01" />
 </svg>

--- a/icons/mail-search.svg
+++ b/icons/mail-search.svg
@@ -9,6 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
+  <path d="M22 12.5V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h7.5" />
   <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <path d="M18 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6v0Z" />
+  <circle cx="18" cy="18" r="3" />
+  <path d="m22 22-1.5-1.5" />
 </svg>

--- a/icons/mail-warning.svg
+++ b/icons/mail-warning.svg
@@ -9,6 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
+  <path d="M22 10.5V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h12.5" />
   <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <path d="M20 14v4" />
+  <path d="M20 22v.01" />
 </svg>

--- a/icons/mail-x.svg
+++ b/icons/mail-x.svg
@@ -9,6 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
+  <path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h9" />
   <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <path d="m17 17 4 4" />
+  <path d="m21 17-4 4" />
 </svg>

--- a/icons/mails.svg
+++ b/icons/mails.svg
@@ -9,6 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="4" width="20" height="16" rx="2" />
-  <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  <rect x="6" y="4" width="16" height="13" rx="2" />
+  <path d="m22 7-7.1 3.78c-.57.3-1.23.3-1.8 0L6 7" />
+  <path d="M2 8v11c0 1.1.9 2 2 2h14" />
 </svg>

--- a/tags.json
+++ b/tags.json
@@ -2449,6 +2449,7 @@
     "message",
     "letter",
     "subscribe",
+    "delivered'",
     "success"
   ],
   "mail-minus": [

--- a/tags.json
+++ b/tags.json
@@ -2441,7 +2441,72 @@
   "mail": [
     "email",
     "message",
-    "letter"
+    "letter",
+    "unread"
+  ],
+  "mail-check": [
+    "email",
+    "message",
+    "letter",
+    "subscribe",
+    "success"
+  ],
+  "mail-minus": [
+    "email",
+    "message",
+    "letter",
+    "remove",
+    "delete"
+  ],
+  "mail-open": [
+    "email",
+    "message",
+    "letter",
+    "read"
+  ],
+  "mail-plus": [
+    "email",
+    "message",
+    "letter",
+    "add",
+    "create",
+    "new",
+    "compose"
+  ],
+  "mail-question": [
+    "email",
+    "message",
+    "letter",
+    "delivery",
+    "undelivered"
+  ],
+  "mail-search": [
+    "email",
+    "message",
+    "letter",
+    "search"
+  ],
+  "mail-warning": [
+    "email",
+    "message",
+    "letter",
+    "delivery error"
+  ],
+  "mail-x": [
+    "email",
+    "message",
+    "letter",
+    "remove",
+    "delete"
+  ],
+  "mails": [
+    "emails",
+    "messages",
+    "letters",
+    "multiple",
+    "mailing list",
+    "newsletter",
+    "copy"
   ],
   "map": [
     "location",

--- a/tags.json
+++ b/tags.json
@@ -2449,7 +2449,7 @@
     "message",
     "letter",
     "subscribe",
-    "delivered'",
+    "delivered",
     "success"
   ],
   "mail-minus": [


### PR DESCRIPTION
## Icon Request

* Icon name: mail-plus, mail-minus etc.
* Use cases:
  * `mail-plus`: add/compose new mail
  * `mail-minus`: remove mail
  * `mail-check`: subscribed to mailing list or delivery success
  * `mail-search`: search in mails
  * `mails`: a list of emails, copy mail etc.
  * `mail-open`: mail has been opened
  * `mail-question`: unknown delivery status
  * `mail-x`: delivery error or remove
  * `mail-warning`: delivery error
* Also adjusts mail to be more in line with our design guidelines (no sharp corners unless necessary for clarity)

![image](https://user-images.githubusercontent.com/17746067/179495267-87485ed6-8bb8-4dc2-829c-f01ae3b3a1eb.png)
![image](https://user-images.githubusercontent.com/17746067/179495283-13f8b91d-c0fa-4228-938a-0bd855662788.png)
