### PR TITLE
Adds `citrus` icon

### DIFF
--- a/icons/citrus.svg
+++ b/icons/citrus.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5.51 18.49a12 12 0 0 0 16.12.78c.49-.41.49-1.15.03-1.6L6.34 2.33a1.08 1.08 0 0 0-1.6.03A12 12 0 0 0 5.5 18.5Z" />
+  <path d="M8.34 15.66a8 8 0 0 0 10.4.78c.54-.4.54-1.16.06-1.64L9.2 5.2c-.48-.48-1.25-.48-1.64.06a8 8 0 0 0 .78 10.4Z" />
+  <path d="m14 10-5.5 5.5" />
+  <path d="M14 10v8" />
+  <path d="M14 10H6" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -851,6 +851,12 @@
     "null",
     "nothing"
   ],
+  "citrus": [
+    "lemon",
+    "orange",
+    "grapefruit",
+    "fruit"
+  ],
   "clapperboard": [
     "movie",
     "film",


### PR DESCRIPTION
## Icon Request

![image](https://user-images.githubusercontent.com/17746067/179523250-022c7ac4-05e3-4791-9ca4-706c142d7de4.png)
![image](https://user-images.githubusercontent.com/17746067/179523293-1003f6e9-53ff-44e7-a87b-594dbf82eaaa.png)

* Icon name: citrus
* Use case: cocktails or fruit in general, citrusy notes in smell/taste
* _Screenshots_ of similar icons:
![image](https://user-images.githubusercontent.com/17746067/179523128-fdf94084-998d-4499-b972-19a5108392e2.png)
![image](https://user-images.githubusercontent.com/17746067/179523147-424b88fc-e538-4e5d-8a21-5f2f9a38e76b.png)
![image](https://user-images.githubusercontent.com/17746067/179523167-73156034-ed8f-47a5-888e-9e785450ece1.png)
![image](https://user-images.githubusercontent.com/17746067/179523193-6cb60fa5-682e-48f8-9997-ff06c593bfb0.png)
