### PR TITLE
Adds `trophy` & `medal` icons

### DIFF
--- a/icons/medal.svg
+++ b/icons/medal.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7.21 15 2.66 7.14a2 2 0 0 1 .13-2.2L4.4 2.8A2 2 0 0 1 6 2h12a2 2 0 0 1 1.6.8l1.6 2.14a2 2 0 0 1 .14 2.2L16.79 15" />
+  <path d="M11 12 5.12 2.2" />
+  <path d="m13 12 5.88-9.8" />
+  <path d="M8 7h8" />
+  <circle cx="12" cy="17" r="5" />
+  <path d="M12 18v-2h-.5" />
+</svg>

--- a/icons/trophy.svg
+++ b/icons/trophy.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
+  <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
+  <path d="M4 22h16" />
+  <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
+  <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
+  <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -2477,6 +2477,14 @@
     "arrows",
     "expand"
   ],
+  "medal": [
+    "prize",
+    "sports",
+    "winner",
+    "trophy",
+    "award",
+    "achievement"
+  ],
   "megaphone": [
     "advertisement",
     "attention",
@@ -3690,6 +3698,13 @@
   ],
   "triangle": [
     "delta"
+  ],
+  "trophy": [
+    "prize",
+    "sports",
+    "winner",
+    "achievement",
+    "award"
   ],
   "truck": [
     "delivery",


### PR DESCRIPTION
## Icon Request

* Icon name: trophy & medal
* Use case: represents a winner, prize, award of achievement, as well as sports in general
* Originates from: #119 
* Screenshots of similar icons: 
![image](https://user-images.githubusercontent.com/17746067/179525195-e469272c-5594-45ad-add5-cc75dbad39ae.png)

![image](https://user-images.githubusercontent.com/17746067/179525278-6207bc98-4fb4-4802-96ad-eadc3ac8c285.png)
![image](https://user-images.githubusercontent.com/17746067/179525309-ff1b850d-102b-4f26-b8ce-fc881be8ee7d.png)

  
