### PR TITLE
Adds `wand-2` icon

### DIFF
--- a/icons/wand-2.svg
+++ b/icons/wand-2.svg
@@ -1,0 +1,20 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72Z" />
+  <path d="m14 7 3 3" />
+  <path d="M5 6v4" />
+  <path d="M19 14v4" />
+  <path d="M10 2v2" />
+  <path d="M7 8H3" />
+  <path d="M21 16h-4" />
+  <path d="M11 3H9" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -3888,6 +3888,10 @@
     "magic",
     "selection"
   ],
+  "wand-2": [
+    "magic",
+    "wizard"
+  ],
   "watch": [
     "clock",
     "time"


### PR DESCRIPTION
## Icon Request

* Icon name: magic wand
* Use case: application wizards
(the current wand icon is not quite suitable for this purpose as it more often represents selection)
* Screenshots of similar icons:
![image](https://user-images.githubusercontent.com/17746067/179537080-03267356-cbbf-4785-990e-3952c9f1f54b.png)

![image](https://user-images.githubusercontent.com/17746067/179537184-6aa4b82d-4191-45fc-9a54-390560847f25.png)
![image](https://user-images.githubusercontent.com/17746067/179537206-5c1403be-2c55-4e43-a485-953f7f5e72ad.png)
