### PR TITLE
Fixes `tag` & adds `tags`

### DIFF
--- a/icons/tag.svg
+++ b/icons/tag.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 2H2v10l9.3 9.3a2.4 2.4 0 0 0 3.4 0l6.6-6.6a2.4 2.4 0 0 0 0-3.4L12 2Z" />
+  <path d="M12 2H2v10l9.29 9.29c.94.94 2.48.94 3.42 0l6.58-6.58c.94-.94.94-2.48 0-3.42L12 2Z" />
   <path d="M7 7h.01" />
 </svg>

--- a/icons/tags.svg
+++ b/icons/tags.svg
@@ -9,6 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 2H2v10l9.3 9.3a2.4 2.4 0 0 0 3.4 0l6.6-6.6a2.4 2.4 0 0 0 0-3.4L12 2Z" />
-  <path d="M7 7h.01" />
+  <path d="M9 5H2v7l6.3 6.3a2.4 2.4 0 0 0 3.4 0l3.6-3.6a2.4 2.4 0 0 0 0-3.4L9 5Z" />
+  <path d="M6 9.01V9" />
+  <path d="m15 5 6.3 6.3a2.4 2.4 0 0 1 0 3.4L17 19" />
 </svg>

--- a/icons/tags.svg
+++ b/icons/tags.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M9 5H2v7l6.3 6.3a2.4 2.4 0 0 0 3.4 0l3.6-3.6a2.4 2.4 0 0 0 0-3.4L9 5Z" />
+  <path d="M9 5H2v7l6.29 6.29c.94.94 2.48.94 3.42 0l3.58-3.58c.94-.94.94-2.48 0-3.42L9 5Z" />
   <path d="M6 9.01V9" />
   <path d="m15 5 6.3 6.3a2.4 2.4 0 0 1 0 3.4L17 19" />
 </svg>

--- a/tags.json
+++ b/tags.json
@@ -3540,7 +3540,18 @@
     "device"
   ],
   "tag": [
-    "label"
+    "label",
+    "badge",
+    "ticket",
+    "mark"
+  ],
+  "tags": [
+    "labels",
+    "badges",
+    "tickets",
+    "marks",
+    "copy",
+    "multiple"
   ],
   "target": [
     "logo",


### PR DESCRIPTION
## Icon Request

* Icon name: tags
* Use case: represents multiple tags or copying tags
* Also fixes the existing `tag` icon, making it pixel perfect
![image](https://user-images.githubusercontent.com/17746067/179688078-b25d41b3-8d4d-4961-b695-949d0b5eb44e.png)
![image](https://user-images.githubusercontent.com/17746067/179688148-dd8e4d64-fd51-441e-9cc4-49c173aaeddc.png)
