### PR TITLE
Fixes `qr-code`

### DIFF
--- a/icons/qr-code.svg
+++ b/icons/qr-code.svg
@@ -9,15 +9,16 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="2" y="2" width="8" height="8" />
-  <path d="M6 6h.01" />
-  <rect x="14" y="2" width="8" height="8" />
-  <path d="M18 6h.01" />
-  <rect x="2" y="14" width="8" height="8" />
-  <path d="M6 18h.01" />
-  <path d="M14 14h.01" />
-  <path d="M18 18h.01" />
-  <path d="M18 22h4v-4" />
-  <path d="M14 18v4" />
-  <path d="M22 14h-4" />
+  <rect x="3" y="3" width="5" height="5" rx="1" />
+  <rect x="16" y="3" width="5" height="5" rx="1" />
+  <rect x="3" y="16" width="5" height="5" rx="1" />
+  <path d="M21 16h-3a2 2 0 0 0-2 2v3" />
+  <path d="M21 21v.01" />
+  <path d="M12 7v3a2 2 0 0 1-2 2H7" />
+  <path d="M3 12h.01" />
+  <path d="M12 3h.01" />
+  <path d="M12 16v.01" />
+  <path d="M16 12h1" />
+  <path d="M21 12v.01" />
+  <path d="M12 21v-1" />
 </svg>


### PR DESCRIPTION
Updates `qr-code` to have the same dimensions as other square icons.
![image](https://user-images.githubusercontent.com/17746067/179711486-d3e58a75-3ed8-467b-b14e-ef07c4ef9521.png)
