### PR TITLE
Add color prop to "Additional Props" example

### DIFF
--- a/docs/packages/lucide-svelte.md
+++ b/docs/packages/lucide-svelte.md
@@ -35,7 +35,7 @@ You can pass additional props to adjust the icon.
 import { Camera } from 'lucide-svelte'
 </script>
 
-<Camera />
+<Camera color="#ff3e98" />
 ```
 
 ### Available props


### PR DESCRIPTION
The additional props example previously had no props at all, this adds the color prop to solve that problem.

Resolves #782 