### PR TITLE
Add `arrow-up-down` icon

### DIFF
--- a/icons/arrow-up-down.svg
+++ b/icons/arrow-up-down.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polyline points="11 17 7 21 3 17" />
+  <line x1="7" y1="21" x2="7" y2="9" />
+  <polyline points="21 7 17 3 13 7" />
+  <line x1="17" y1="15" x2="17" y2="3" />
+</svg>

--- a/icons/arrow-up-down.svg
+++ b/icons/arrow-up-down.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="11 17 7 21 3 17" />
-  <line x1="7" y1="21" x2="7" y2="9" />
-  <polyline points="21 7 17 3 13 7" />
-  <line x1="17" y1="15" x2="17" y2="3" />
+  <polyline points="11 17 7 21 3 17"/>
+  <line x1="7" y1="21" x2="7" y2="9"/>
+  <polyline points="21 7 17 3 13 7"/>
+  <line x1="17" y1="15" x2="17" y2="3"/>
 </svg>

--- a/tags.json
+++ b/tags.json
@@ -324,10 +324,10 @@
     "swap",
     "switch",
     "network",
-	"mobile data",
-	"internet",
-	"reorder",
-	"move"
+    "mobile data",
+    "internet",
+    "reorder",
+    "move"
   ],
   "arrow-up-left": [
     "direction"

--- a/tags.json
+++ b/tags.json
@@ -325,7 +325,9 @@
     "switch",
     "network",
 	"mobile data",
-	"internet"
+	"internet",
+	"reorder",
+	"move"
   ],
   "arrow-up-left": [
     "direction"

--- a/tags.json
+++ b/tags.json
@@ -318,6 +318,15 @@
   "arrow-up-circle": [
     "direction"
   ],
+  "arrow-up-down": [
+    "bidirectional",
+    "direction",
+    "swap",
+    "switch",
+    "network",
+	"mobile data",
+	"internet"
+  ],
   "arrow-up-left": [
     "direction"
   ],

--- a/tags.json
+++ b/tags.json
@@ -304,7 +304,9 @@
     "direction",
     "swap",
     "switch",
-    "transaction"
+    "transaction",
+    "reorder",
+    "move"
   ],
   "arrow-right": [
     "direction"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72697755/185184677-65dff883-5a9e-4d78-bfe2-1baee10aa628.png)

There is already an `arrow-left-right` icon but not an `arrow-up-down` icon (this icon has just been turned around). You could use it as a reorder icon or as a mobile data icon.