### PR TITLE
Fix typo in lucide-vue

### DIFF
--- a/docs/packages/lucide-vue-next.md
+++ b/docs/packages/lucide-vue-next.md
@@ -2,7 +2,7 @@
 
 Implementation of the lucide icon library for Vue 3 applications.
 
-> ⚠️ This version of lucide is for Vue 3, For Vue 2 got to [lucide-vue-next](lucide-vue)
+> ⚠️ This version of lucide is for Vue 3, For Vue 2 got to [lucide-vue](lucide-vue)
 
 ## Installation
 


### PR DESCRIPTION
Currently the Vue 3 page tells you to go to `lucide-vue-next` for the Vue 2-compatible version

![Screenshot 2022-09-12 at 16 21 08](https://user-images.githubusercontent.com/9140811/189665255-05eb3abf-705a-48cf-afe7-3fe2aa75c65b.png)
