### PR TITLE
Remove post-install lucide-angular

### DIFF
--- a/packages/lucide-angular/package.json
+++ b/packages/lucide-angular/package.json
@@ -31,7 +31,6 @@
     "test:watch": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "postinstall": "ngcc",
     "version": "pnpm version --git-tag-version=false"
   },
   "dependencies": {

--- a/packages/lucide-angular/tsconfig.lib.prod.json
+++ b/packages/lucide-angular/tsconfig.lib.prod.json
@@ -5,6 +5,7 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "enableIvy": false
+    "enableIvy": true,
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
Fixes #800

Changes:
This removes the legacy ngcc compiler, so this removes compatibility for angular versions lower then 9.