### PR TITLE
Fix `signal-zero`

### DIFF
--- a/icons/signal-zero.svg
+++ b/icons/signal-zero.svg
@@ -10,5 +10,4 @@
   stroke-linejoin="round"
 >
   <path d="M2 20h.01" />
-  <path d="M7 20v-4" />
 </svg>


### PR DESCRIPTION
Currently the icons `signal-zero` and `signal-low` are exactly the same.

![signal-low](https://github.com/lucide-icons/lucide/blob/main/icons/signal-low.svg) ![signal-zero](https://github.com/lucide-icons/lucide/blob/main/icons/signal-zero.svg)

Previously called out here https://github.com/lucide-icons/lucide/pull/428#issuecomment-1099289022 and confirmed by @ericfennis, the author of the original PR.

I've just manually edited `signal-zero` to remove the second bar.