### PR TITLE
Update CONTRIBUTING.md minimum node version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ If you are a designer who wants to contribute to Lucide but you don't know what 
 
 ## Development
 
-You will need minimum version of [Nodejs 16+](https://nodejs.org)
+You will need minimum version of [Nodejs 16.4+](https://nodejs.org)
 For packagemanagement you will need [yarn v1](https://yarnpkg.com/getting-started/install).
 For flutter package development, you need [Flutter 1.17+](https://docs.flutter.dev/get-started/install).
 


### PR DESCRIPTION
The build process uses import assertions which were added in Node 16.4. Updating the docs to reflect that since this bit me while contributing.

Example of import assertion

https://github.com/lucide-icons/lucide/blob/aa524c65a059ae802752c84f860b17cc3fa30977/scripts/render/processSvg.mjs#L5

[documentation for when import assertions were added in node](https://nodejs.org/api/esm.html#import-assertions)