### PR TITLE
fixing the link title for Vue 2

### DIFF
--- a/packages/lucide-vue-next/README.md
+++ b/packages/lucide-vue-next/README.md
@@ -4,7 +4,7 @@ Implementation of the lucide icon library for Vue 3 applications.
 
 > What is lucide? Read it [here](https://github.com/lucide-icons/lucide#what-is-lucide).
 
-> :warning: This version of lucide is for Vue 3, For Vue 2 got to [lucide-vue-next](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-vue#lucide-vue)
+> :warning: This version of lucide is for Vue 3, For Vue 2 got to [lucide-vue](https://github.com/lucide-icons/lucide/tree/main/packages/lucide-vue#lucide-vue)
 
 ## Installation
 


### PR DESCRIPTION
The title was a left-over for `lucide-vue-next`.