### PR TITLE
Docs: fix and extend the generic vue3 icon component example

### DIFF
--- a/docs/packages/lucide-vue-next.md
+++ b/docs/packages/lucide-vue-next.md
@@ -35,15 +35,8 @@ You can pass additional props to adjust the icon.
   />
 </template>
 
-<script>
-// Returns Vue component
+<script setup>
 import { Camera } from 'lucide-vue-next';
-
-export default {
-  name: "My Component",
-  components: { Camera }
-}
-
 </script>
 ```
 
@@ -107,5 +100,4 @@ const icon = computed(() => icons[props.name]);
   </div>
 </template>
 ```
-
-> ℹ️ All other props listed above also work on the `Icon` Component.
+All other props listed above also work on the `Icon` Component.

--- a/docs/packages/lucide-vue-next.md
+++ b/docs/packages/lucide-vue-next.md
@@ -76,25 +76,25 @@ It is possible to create one generic icon component to load icons.
 
 ``` html
 <template>
-  <component :is="icon" />
+    <component :is="icon" :size="size" :color="color" :strokeWidth="strokeWidth" :defaultClass="defaultClass" />
 </template>
 
-<script>
+<script setup>
+import { computed } from 'vue';
 import * as icons from "lucide-vue-next";
 
-export default {
-  props: {
-    name: {
-      type: String,
-      required: true,
-    },
+const props = defineProps({
+  name: {
+    type: String,
+    required: true
   },
-  setup(props) {
-    const icon = computed(() => icons[props.name])
+  size: Number,
+  color: String,
+  strokeWidth: Number,
+  defaultClass: String
+})
 
-    return { icon }
-  }
-};
+const icon = computed(() => icons[props.name]);
 </script>
 ```
 
@@ -107,3 +107,5 @@ export default {
   </div>
 </template>
 ```
+
+> ℹ️ All other props listed above also work on the `Icon` Component.

--- a/docs/packages/lucide-vue-next.md
+++ b/docs/packages/lucide-vue-next.md
@@ -46,8 +46,8 @@ import { Camera } from 'lucide-vue-next';
 | ------------ | -------- | --------
 | `size`       | *Number* | 24
 | `color`      | *String* | currentColor
-| `strokeWidth`| *Number* | 2
-| `defaultClass`| *String* | lucide-icon
+| `stroke-width`| *Number* | 2
+| `default-class`| *String* | lucide-icon
 
 ### Custom props
 
@@ -69,7 +69,7 @@ It is possible to create one generic icon component to load icons.
 
 ``` html
 <template>
-    <component :is="icon" :size="size" :color="color" :strokeWidth="strokeWidth" :defaultClass="defaultClass" />
+    <component :is="icon" :size="size" :color="color" :stroke-width="strokeWidth" :default-class="defaultClass" />
 </template>
 
 <script setup>


### PR DESCRIPTION
The generic icon component example for vue3 was missing an import for `computed` which has become an optional import with the composition api in vue3. I've fixed that and also refactored both examples to utilize the recently introduced `<script setup>` which increases the readability of components while reducing their lines of code.

The minimal usage example now looks like this:
``` html
<template>
  <Camera
    color="red"
    :size="32"
  />
</template>

<script setup>
import { Camera } from 'lucide-vue-next';
</script>
```


Furthermore I've extended the example to proxy all properties (`size`, `color`, `strokeWidth` and `defaultClass`) to the specific icon components. Things like this are now possible with the example:
``` html
<template>
  <div id="app">
    <Icon name="Airplay" size="20" stroke-width="1"  />
  </div>
</template>
```
