### PR TITLE
Add packageManager to package.json to allow usage with Corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
   },
   "lint-staged": {
     "icons/*.svg": "node ./scripts/optimizeStagedSvgs.mjs"
-  }
+  },
+  "packageManager": "pnpm@7.14.0"
 }


### PR DESCRIPTION
For devs with Node + Corepack, but no pnpm, contribution will be seamless, as pnpm will be installed transparently in the background while running the first command.

https://pnpm.io/installation#using-corepack