### PR TITLE
Don't use md4 in crypto.createHash

### DIFF
--- a/site/src/lib/fetchAllContributors.ts
+++ b/site/src/lib/fetchAllContributors.ts
@@ -11,7 +11,7 @@ const IGNORE_COMMIT_MESSAGES = ['fork', 'optimize'];
 
 function getContentHashOfFile(path) {
   return new Promise((resolve, reject) => {
-    const hash = crypto.createHash('md4');
+    const hash = crypto.createHash('sha256');
     const stream = fs.createReadStream(path);
     stream.on('error', err => reject(err));
     stream.on('data', chunk => hash.update(chunk));


### PR DESCRIPTION
Fixes #842

Please review carefully - I don't fully understand how this hash is used and whether there are any implications of changing it.