### PR TITLE
Don't hardcode GitHub username in fetchCommitsOfIcon, allow usage of GITHUB_TOKEN instead

### DIFF
--- a/site/src/lib/fetchAllContributors.ts
+++ b/site/src/lib/fetchAllContributors.ts
@@ -22,11 +22,12 @@ function getContentHashOfFile(path) {
 const fetchCommitsOfIcon = async (name) =>{
     try {
       const headers = new Headers();
-      const username = 'ericfennis';
+      const token = process.env.GITHUB_TOKEN;
+      const username = process.env.GITHUB_USERNAME;
       const password = process.env.GITHUB_API_KEY;
       headers.set(
         'Authorization',
-        `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+        token ? `Bearer ${token}` : `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
       );
 
       const res = await fetch(


### PR DESCRIPTION
Allows running marketing site in development for literally anyone else but @ericfennis :joy: