### PR TITLE
Reduce __NEXT_DATA__ size by removing content and author.commit properties from IconEntity

### DIFF
--- a/site/src/components/IconDetailOverlay.tsx
+++ b/site/src/components/IconDetailOverlay.tsx
@@ -6,7 +6,7 @@ import {useContext, useEffect, useRef} from "react";
 import {IconStyleContext} from "./CustomizeIconContext";
 import {IconWrapper} from "./IconWrapper";
 import ModifiedTooltip from "./ModifiedTooltip";
-import { IconData } from "../lib/icons";
+import { IconEntity } from "../types";
 
 type IconDownload = {
   src: string;
@@ -16,7 +16,7 @@ type IconDownload = {
 interface IconDetailOverlayProps {
   open: boolean
   close: () => void
-  icon?: IconData
+  icon?: IconEntity
 }
 
 const IconDetailOverlay = ({ open = true, close, icon }: IconDetailOverlayProps) => {
@@ -152,7 +152,7 @@ const IconDetailOverlay = ({ open = true, close, icon }: IconDetailOverlayProps)
                     className="icon-large"
                   >
                     <IconWrapper
-                      content={icon.content}
+                      src={icon.src}
                       stroke={color}
                       strokeWidth={strokeWidth}
                       height={size}
@@ -229,8 +229,8 @@ const IconDetailOverlay = ({ open = true, close, icon }: IconDetailOverlayProps)
                       </Heading>
                       <AvatarGroup size="md">
                         { icon.contributors.map((commit, index) => (
-                          <Link href={`https://github.com/${commit.author}`} isExternal key={`${index}_${commit.commit}`}>
-                            <Tooltip label={commit.author} key={commit.commit}>
+                          <Link href={`https://github.com/${commit.author}`} isExternal key={`${index}_${commit.author}`}>
+                            <Tooltip label={commit.author} key={commit.author}>
                               <Avatar name={commit.author} src={`https://github.com/${commit.author}.png?size=88`} />
                             </Tooltip>
                           </Link>

--- a/site/src/components/IconList.tsx
+++ b/site/src/components/IconList.tsx
@@ -2,8 +2,8 @@ import { Grid } from '@chakra-ui/react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { memo } from 'react';
-import { IconEntity } from '../types';
 import IconListItem from './IconListItem';
+import { IconEntity } from '../types';
 
 interface IconListProps {
   icons: IconEntity[];

--- a/site/src/components/IconListItem.tsx
+++ b/site/src/components/IconListItem.tsx
@@ -1,19 +1,16 @@
 import { Button, ButtonProps, Flex, Text, useToast } from '@chakra-ui/react';
 import download from 'downloadjs';
 import { memo } from 'react';
-import { Contributor } from '../lib/fetchAllContributors';
 import { useCustomizeIconContext } from './CustomizeIconContext';
 import { IconWrapper } from './IconWrapper';
 
 interface IconListItemProps {
   name: string;
-  content: string;
-  contributors: Contributor[]
-  src: string;
   onClick?: ButtonProps['onClick']
+  src: string;
 }
 
-const IconListItem = ({ name, content, onClick, src: svg }: IconListItemProps) => {
+const IconListItem = ({ name, onClick, src: svg }: IconListItemProps) => {
   const toast = useToast();
   const { color, size, strokeWidth, iconsRef } = useCustomizeIconContext();
 
@@ -53,7 +50,7 @@ const IconListItem = ({ name, content, onClick, src: svg }: IconListItemProps) =
       <Flex direction="column" align="center" justify="stretch" width="100%" gap={4}>
         <Flex flex={2} flexBasis="100%" minHeight={10} align="flex-end">
           <IconWrapper
-            content={content}
+            src={svg}
             stroke={color}
             strokeWidth={strokeWidth}
             height={size}

--- a/site/src/components/IconOverview.tsx
+++ b/site/src/components/IconOverview.tsx
@@ -1,9 +1,9 @@
 import { Box, Text } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import useSearch from '../lib/useSearch';
-import { IconEntity } from '../types';
 import IconList from './IconList';
 import { SearchInput } from './SearchInput';
+import { IconEntity } from '../types';
 
 interface IconOverviewProps {
   data: IconEntity[];

--- a/site/src/components/IconWrapper.tsx
+++ b/site/src/components/IconWrapper.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, SVGProps } from 'react';
 
 interface IconWrapperProps extends SVGProps<SVGSVGElement> {
-  content: string;
+  src: string;
 }
 
 export const IconWrapper = forwardRef<SVGSVGElement, IconWrapperProps>((props, ref) => {
@@ -17,11 +17,12 @@ export const IconWrapper = forwardRef<SVGSVGElement, IconWrapperProps>((props, r
     strokeLinejoin: 'round',
   };
 
-  const { content, ...rest } = props;
+  const { src, ...rest } = props;
   const attrs = {
     ...defaultAttrs,
     ...rest,
   };
+  const content = src.replace(/<svg[^>]*>|<\/svg>/g, '');
 
   return <svg ref={ref} {...attrs} dangerouslySetInnerHTML={{ __html: content }} />;
 });

--- a/site/src/lib/fetchAllContributors.ts
+++ b/site/src/lib/fetchAllContributors.ts
@@ -1,11 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-
-export interface Contributor {
-  author: string
-  commit: string
-}
+import { Contributor } from '../types';
 
 const IGNORE_COMMIT_MESSAGES = ['fork', 'optimize'];
 
@@ -54,9 +50,8 @@ export const filterCommits = (commits) =>
     !IGNORE_COMMIT_MESSAGES.some(ignoreItem =>
       commit.message.toLowerCase().includes(ignoreItem),
     ))
-  .map(({ sha, author }) => ({
+  .map(({ author }) => ({
     author: author && author.login ? author.login : null,
-    commit: sha,
   }))
   .filter(({ author }, index, self) => self.findIndex((commit) => commit.author === author) === index);
 

--- a/site/src/lib/icons.tsx
+++ b/site/src/lib/icons.tsx
@@ -2,7 +2,8 @@ import fs from "fs";
 import path from "path";
 import { parseSync, stringify } from 'svgson';
 import tags from '../../../tags.json';
-import { Contributor, getContributors } from "./fetchAllContributors";
+import { IconEntity } from "../types";
+import { getContributors } from "./fetchAllContributors";
 
 const directory = path.join(process.cwd(), "../icons");
 
@@ -28,20 +29,11 @@ export async function getData(name: string) {
     name,
     tags: tags[name] || [],
     contributors,
-    src: fileContent,
-    content: svgContent
+    src: fileContent
   };
 }
 
-export interface IconData {
-  name: string
-  tags: string[]
-  contributors: Contributor[]
-  src: string
-  content: string
-}
-
-export async function getAllData(): Promise<IconData[]> {
+export async function getAllData(): Promise<IconEntity[]> {
   const names = getAllNames();
 
   return Promise.all(names.map((name) => getData(name)));

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import Layout from '../components/Layout';
-import { getAllData, IconData } from '../lib/icons';
+import { getAllData } from '../lib/icons';
 
 import IconOverview from '../components/IconOverview';
 import IconDetailOverlay from '../components/IconDetailOverlay';
@@ -8,9 +8,10 @@ import Header from '../components/Header';
 import MobileMenu from '../components/MobileMenu';
 import { useMemo } from 'react';
 import { GetStaticPropsResult, NextPage } from 'next';
+import { IconEntity } from '../types';
 
 interface HomePageProps {
-  data: IconData[]
+  data: IconEntity[]
 }
 
 const HomePage: NextPage<HomePageProps> = ({ data }) => {

--- a/site/src/types.ts
+++ b/site/src/types.ts
@@ -1,5 +1,4 @@
 export interface IconEntity {
-  content: string;
   contributors: Contributor[];
   name: string;
   src: string;
@@ -8,5 +7,4 @@ export interface IconEntity {
 
 export interface Contributor {
   author: string;
-  commit: string;
 }


### PR DESCRIPTION
Reduces `__NEXT_DATA__` size on main page by 202694 bytes (~31%) by removing `content` property (it's now calculated based on `src` property) and removing `author.commit` data altogether.