### PR TITLE
Add missing key to map loops for site

### DIFF
--- a/site/src/components/Package.tsx
+++ b/site/src/components/Package.tsx
@@ -87,7 +87,7 @@ const Package = ({ name, description, icon, shields, source, documentation }: Pa
           <Text mb={3}>{description}</Text>
           <ButtonGroup spacing={2}>
             {shields.map(({ alt, src, href }, index) => (
-              <Link href={href} passHref>
+              <Link key={index} href={href} passHref>
                 <a target="_blank">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img {...{ alt, src }} key={index} />

--- a/site/src/pages/packages/index.tsx
+++ b/site/src/pages/packages/index.tsx
@@ -23,14 +23,18 @@ const PackagesPage = ({ packages, thirdPartyPackages }: PackagesPageProps): JSX.
           Packages
         </Heading>
         <Stack spacing={8} align="center">
-          {packages.length ? packages.map(packageItem => <Package {...packageItem} />) : null}
+          {packages.length
+            ? packages.map((packageItem) => <Package key={packageItem.name} {...packageItem} />)
+            : null}
         </Stack>
 
         <Heading as="h1" marginBottom={6} marginTop={12} textAlign="center">
           Third party packages
         </Heading>
         <Stack spacing={8} marginBottom={6} align="center">
-          {thirdPartyPackages.length ? thirdPartyPackages.map(packageItem => <Package {...packageItem} />) : null}
+          {thirdPartyPackages.length
+            ? thirdPartyPackages.map((packageItem) => (<Package key={packageItem.name} {...packageItem} />))
+            : null}
         </Stack>
       </Layout>
     </HeadingNavigationProvider>


### PR DESCRIPTION
Currently when running the site it will throw warnings that the `map()` needs a key.

This pr will fix this by adding the missing keys to the loop.