### PR TITLE
Add show more link for packages on Homepage

### DIFF
--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -11,7 +11,6 @@ import PreactLogo from '../../public/framework-logos/preact.svg';
 import AngularLogo from '../../public/framework-logos/angular.svg';
 import FlutterLogo from '../../public/framework-logos/flutter.svg';
 import SvelteLogo from '../../public/framework-logos/svelte.svg';
-import LaravelLogo from '../../public/framework-logos/laravel.svg';
 import { useState } from 'react';
 import { useCustomizeIconContext } from './CustomizeIconContext';
 import { IconEntity } from '../types';
@@ -115,12 +114,6 @@ const Header = ({ data }: HeaderProps) => {
       Logo: FlutterLogo,
       href: '/docs/lucide-flutter',
       label: 'Lucide documentation for Flutter',
-    },
-    {
-      name: 'lucide-laravel',
-      Logo: LaravelLogo,
-      href: 'https://github.com/mallardduck/blade-lucide-icons',
-      label: 'Lucide documentation for Laravel',
     },
   ];
 

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -159,6 +159,13 @@ const Header = ({ data }: HeaderProps) => {
             </NextLink>
           </WrapItem>
         ))}
+        <WrapItem>
+          <NextLink href="/packages" passHref>
+            <Link _hover={{ opacity: 0.8 }} marginX="auto">
+              <Text fontSize="md" opacity={0.5}>More options</Text>
+            </Link>
+          </NextLink>
+        </WrapItem>
       </Wrap>
       <Wrap marginTop={3} marginBottom={12} spacing="15px" justify="center">
         <WrapItem>


### PR DESCRIPTION
This makes it more clear there are more options than just the ones shown on the homepage.

Also removes the Laravel icon from the homepage,
since it is already part of the 3de party section.