### PR TITLE
Publish angular dist folder instead of project folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,7 +348,7 @@ jobs:
         run: pnpm --filter lucide-angular test
 
       - name: Publish
-        run: pnpm --filter lucide-angular publish dist --no-git-checks --ignore-scripts
+        run: pnpm --filter lucide-angular publish --no-git-checks --ignore-scripts
 
       - name: Upload package.json
         uses: actions/upload-artifact@v2

--- a/packages/lucide-angular/package.json
+++ b/packages/lucide-angular/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/lucide-icons/lucide.git",
     "directory": "packages/lucide-angular"
   },
+  "publishConfig": {
+    "directory": "dist"
+  },
   "keywords": [
     "Lucide",
     "Angular",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,7 @@ importers:
       tslint: 6.1.3_typescript@4.8.4
       typescript: 4.8.4
       zone.js: 0.11.8
+    publishDirectory: dist
 
   packages/lucide-figma:
     specifiers:


### PR DESCRIPTION
We currently publish the whole angular project instead of the dist folder. Here is a screenshot from the last release build
<img width="1325" alt="Screenshot 2022-11-03 at 02 43 14" src="https://user-images.githubusercontent.com/39923127/199633834-a4d63dd0-6b53-427c-a316-8c75c481b871.png">
