### PR TITLE
add nuxt.js to `package.json` files

### DIFF
--- a/packages/lucide-vue/package.json
+++ b/packages/lucide-vue/package.json
@@ -19,7 +19,8 @@
   "unpkg": "dist/umd/lucide-vue.min.js",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "nuxt.js"
   ],
   "scripts": {
     "build": "pnpm clean && pnpm copy:license && pnpm build:icons && pnpm build:es && pnpm build:bundles",


### PR DESCRIPTION
I've opened this PR in relation to this [issue](https://github.com/lucide-icons/lucide/issues/888).

I've noticed that the Nuxt components integration works as expected until 0.84.0 (inclusive). It seems that the only thing that changed since then was the addition of the `files` property in `/packages/lucide-vue/package.json`, which only contained `dist`.
I've updated it to also contian `nuxt.js`, assuming this is what prevents `pnpm build` from removing it.

I would like to apologise if my approach is incorrect - my experience with front-end ecosystems is very limited, but I'm more than happy to learn.