### PR TITLE
add battery-warning icon

### DIFF
--- a/icons/battery-warning.json
+++ b/icons/battery-warning.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "power",
+    "electricity"
+  ],
+  "categories": [
+    "connectivity",
+    "devices"
+  ]
+}

--- a/icons/battery-warning.svg
+++ b/icons/battery-warning.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14 7h2a2 2 0 0 1 2 2v6c0 1 -1 2 -2 2h-2" />
+  <path d="M6 7h-2a2 2 0 0 0-2 2v6c0 1 1 2 2 2h2" />
+  <line x1="22" x2="22" y1="11" y2="13" />
+  <line x1="10" x2="10" y1="7" y2="13" />
+  <line x1="10" x2="10" y1="17" y2="17.01" />
+</svg>

--- a/tags.json
+++ b/tags.json
@@ -431,6 +431,10 @@
     "power",
     "electricity"
   ],
+  "battery-warning": [
+    "power",
+    "electricity"
+  ],
   "battery-full": [
     "power",
     "electricity"


### PR DESCRIPTION
Can be useful when there's something wrong with the battery
![image](https://user-images.githubusercontent.com/94393888/215256180-6c8871b6-abd6-4bab-a65e-f9b8eca6e6ba.png)
![image](https://user-images.githubusercontent.com/94393888/215256153-3f16c0a7-60b2-4266-bb64-09cb7bfc652d.png)
![battery-warning](https://user-images.githubusercontent.com/94393888/215255660-244fad6d-9283-412a-8cd7-7d4a4c1eb572.svg)
