### PR TITLE
Fixes `globe-2` icon

### DIFF
--- a/icons/globe-2.svg
+++ b/icons/globe-2.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M15 21v-4a2 2 0 0 1 2-2h4" />
-  <path d="M7 4v2a3 3 0 0 0 3 2h0a2 2 0 0 1 2 2 2 2 0 0 0 4 0 2 2 0 0 1 2-2h3" />
-  <path d="M3 11h2a2 2 0 0 1 2 2v1a2 2 0 0 0 2 2 2 2 0 0 1 2 2v4" />
+  <path d="M21.54 15H17a2 2 0 0 0-2 2v4.54" />
+  <path d="M7 3.34V5a3 3 0 0 0 3 3v0a2 2 0 0 1 2 2v0c0 1.1.9 2 2 2v0a2 2 0 0 0 2-2v0c0-1.1.9-2 2-2h3.17" />
+  <path d="M11 21.95V18a2 2 0 0 0-2-2v0a2 2 0 0 1-2-2v-1a2 2 0 0 0-2-2H2.05" />
   <circle cx="12" cy="12" r="10" />
 </svg>


### PR DESCRIPTION
The current icon has a lot of misaligned paths (circled in blue) as well as a weird sharp corner (red):
![image](https://user-images.githubusercontent.com/17746067/215989635-3edb8de2-cd5f-4746-8d49-5217dce77a23.png)