### PR TITLE
add title attr for "Available for" icons on home

### DIFF
--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -153,7 +153,7 @@ const Header = ({ data }: HeaderProps) => {
         {packages.map(({ name, href, Logo, label }) => (
           <WrapItem key={name}>
             <NextLink href={href} key={name} passHref>
-              <Link _hover={{ opacity: 0.8 }} aria-label={label}>
+              <Link _hover={{ opacity: 0.8 }} aria-label={label} title={label}>
                 <Logo />
               </Link>
             </NextLink>


### PR DESCRIPTION
Should make it easier to distinguish react and react-native - shows a tiny hint when you hover over it.