### PR TITLE
Adds generate icons script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "generate:changelog": "node ./scripts/generateChangelog.mjs",
     "postinstall": "husky install",
     "lint": "eslint --ext .ts,.js,.mjs ./{packages/lucide,scripts}",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "gi": "node ./scripts/generate/generateIcons.mjs"
   },
   "devDependencies": {
     "eslint": "^8.26.0",

--- a/scripts/generate/generateIcons.mjs
+++ b/scripts/generate/generateIcons.mjs
@@ -1,0 +1,35 @@
+import path from 'path';
+import {getCurrentDirPath, writeFileIfNotExists} from "../helpers.mjs";
+
+const currentDir = getCurrentDirPath(import.meta.url);
+const ICONS_DIR = path.resolve(currentDir, '../../icons');
+
+const iconNames = process.argv.slice(2);
+
+const iconSvgTemplate = `<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+</svg>
+`;
+
+const iconJsonTemplate = `{
+  "$schema": "../icon.schema.json",
+  "tags": [
+  ],
+  "categories": [
+  ]
+}
+`;
+
+iconNames.forEach(iconName => {
+  writeFileIfNotExists(iconSvgTemplate, `${iconName}.svg`, ICONS_DIR);
+  writeFileIfNotExists(iconJsonTemplate, `${iconName}.json`, ICONS_DIR);
+});

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -71,6 +71,19 @@ export const writeFile = (content, fileName, outputDirectory) =>
   fs.writeFileSync(path.join(outputDirectory, fileName), content, 'utf-8');
 
 /**
+ * writes content to a file if it does not exist
+ *
+ * @param {string} content
+ * @param {string} fileName
+ * @param {string} outputDirectory
+ */
+export const writeFileIfNotExists = (content, fileName, outputDirectory) => {
+  if (!fs.existsSync(path.join(outputDirectory, fileName))) {
+    writeFile(content, fileName, outputDirectory);
+  }
+};
+
+/**
  * Reads metadata from the icons/categories directories
  *
  * @param {string} directory


### PR DESCRIPTION
This PR adds a very simple helper script to add SVG and JSON skeletons for multiple icons at once. Usage:

```sh
pnpm gi icon-name-1 icon-name-2
```