### PR TITLE
add `expand` and `collapse` icons

### DIFF
--- a/icons/collapse-down.json
+++ b/icons/collapse-down.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "collapse",
+    "fold",
+    "vertical"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/collapse-down.svg
+++ b/icons/collapse-down.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 3v14m0 0c-2.734-2.538-7-7-7-7m7 7c2.734-2.538 7-7 7-7M3 21h18"/>
+</svg>

--- a/icons/collapse-left.json
+++ b/icons/collapse-left.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "collapse",
+    "fold",
+    "horizontal"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/collapse-left.svg
+++ b/icons/collapse-left.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 12h14m0 0c-2.538-2.734-7-7-7-7m7 7c-2.538 2.734-7 7-7 7M21 3v18"/>
+</svg>

--- a/icons/collapse-right.json
+++ b/icons/collapse-right.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "collapse",
+    "fold",
+    "horizontal"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/collapse-right.svg
+++ b/icons/collapse-right.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7 12h14m0 0c-2.538-2.734-7-7-7-7m7 7c-2.538 2.734-7 7-7 7M3 3v18"/>
+</svg>

--- a/icons/collapse-up.json
+++ b/icons/collapse-up.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "collapse",
+    "fold",
+    "vertical"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/collapse-up.svg
+++ b/icons/collapse-up.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 21V7m0 0c-2.734 2.538-7 7-7 7m7-7c2.734 2.538 7 7 7 7M3 3h18"/>
+</svg>

--- a/icons/expand-down.json
+++ b/icons/expand-down.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "expand",
+    "unfold",
+    "vertical"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/expand-down.svg
+++ b/icons/expand-down.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 17V3m0 0c-2.734 2.538-7 7-7 7m7-7c2.734 2.538 7 7 7 7M3 21h18" />
+</svg>

--- a/icons/expand-left.json
+++ b/icons/expand-left.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "expand",
+    "unfold",
+    "horizontal"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/expand-left.svg
+++ b/icons/expand-left.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M17 12H3m0 0c2.538-2.734 7-7 7-7m-7 7c2.538 2.734 7 7 7 7M21 3v18" />
+</svg>

--- a/icons/expand-right.json
+++ b/icons/expand-right.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "expand",
+    "unfold",
+    "horizontal"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/expand-right.svg
+++ b/icons/expand-right.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 12H7m0 0c2.538-2.734 7-7 7-7m-7 7c2.538 2.734 7 7 7 7M3 3v18" />
+</svg>

--- a/icons/expand-up.json
+++ b/icons/expand-up.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "expand",
+    "unfold",
+    "vertical"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/expand-up.svg
+++ b/icons/expand-up.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 7v14m0 0c-2.734-2.538-7-7-7-7m7 7c2.734-2.538 7-7 7-7M3 3h18" />
+</svg>


### PR DESCRIPTION
---
name: New icon
about: Add a new icon to the library
labels: "🎨 <icon"
---

<!-- Thanks for submitting an icon! Please make sure you read the icon design guide
at https://github.com/lucide-icons/lucide/blob/main/docs/icon-design-guide.md beforehand,
and please fill everything below. -->

- **Name of the icon** : expand-[right | left | up | down] and collapse[right | left | up | down]
- **Tags (alternative names for this icon)** (add them in as a separate json file using the same icon name) :
- **What is the purpose of this icon?** : Shows that one can click it to expand or collapse an area (example: sidenav)
- **100% scale preview** : 
![COLLAPSE_DOWN](https://user-images.githubusercontent.com/9553777/224741597-c4ec600b-f3ca-4a6e-a960-7f06b6452002.png)
![EXPAND_DOWN](https://user-images.githubusercontent.com/9553777/224741604-17d541b5-5829-417a-a5a5-e5a6641cbb12.png)
![COLLAPSE_UP](https://user-images.githubusercontent.com/9553777/224741609-1d86b4c3-a80c-4eb7-b591-3f088b4db331.png)
![EXPAND_UP](https://user-images.githubusercontent.com/9553777/224741612-846b3c5e-bc50-4262-a38a-d72b4e6a02c5.png)
![COLLAPSE_RIGHT](https://user-images.githubusercontent.com/9553777/224741614-7e13130a-5ff1-4598-a548-bdffa66b961a.png)
![EXPAND_RIGHT](https://user-images.githubusercontent.com/9553777/224741618-8c0aa148-3cdd-4077-adce-a060a3226ff9.png)
![COLLAPSE_LEFT](https://user-images.githubusercontent.com/9553777/224741622-a21fad3c-4c5d-4c42-b70b-04bd8d0995eb.png)
![EXPAND_LEFT](https://user-images.githubusercontent.com/9553777/224741626-57c3df96-ea51-4e70-b9c5-d2f52d8819f1.png)

- **Have you considered alternative possibilities** for its naming or design? :
