### PR TITLE
Improve metadata for keys, and modify `arrow-big-*` icons to include `shift` key

### DIFF
--- a/icons/arrow-big-down-dash.json
+++ b/icons/arrow-big-down-dash.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "key",
+    "download"
+  ],
+  "categories": [
+    "arrows",
+    "files"
+  ]
+}

--- a/icons/arrow-big-down-dash.svg
+++ b/icons/arrow-big-down-dash.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 5H9" />
+  <path d="M15 9v3h4l-7 7-7-7h4V9h6z" />
+</svg>

--- a/icons/arrow-big-down.svg
+++ b/icons/arrow-big-down.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M9 3h6v11h4l-7 7-7-7h4z" />
+  <path d="M15,6v6h4l-7,7l-7-7h4V6H15z" />
 </svg>

--- a/icons/arrow-big-down.svg
+++ b/icons/arrow-big-down.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M15,6v6h4l-7,7l-7-7h4V6H15z" />
+  <path d="M15 6v6h4l-7 7-7-7h4V6h6z" />
 </svg>

--- a/icons/arrow-big-left-dash.json
+++ b/icons/arrow-big-left-dash.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "key",
+    "back"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/arrow-big-left-dash.svg
+++ b/icons/arrow-big-left-dash.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M19 15V9" />
+  <path d="M15 15h-3v4l-7-7 7-7v4h3v6z" />
+</svg>

--- a/icons/arrow-big-left.json
+++ b/icons/arrow-big-left.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "tags": [
-    "key"
+    "key",
+    "back"
   ],
   "categories": [
     "arrows"

--- a/icons/arrow-big-left.svg
+++ b/icons/arrow-big-left.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m3 12 7-7v4h11v6H10v4z" />
+  <path d="M18,15l-6,0l0,4l-7-7l7-7l0,4l6,0L18,15z" />
 </svg>

--- a/icons/arrow-big-left.svg
+++ b/icons/arrow-big-left.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M18,15l-6,0l0,4l-7-7l7-7l0,4l6,0L18,15z" />
+  <path d="M18 15h-6v4l-7-7 7-7v4h6v6z" />
 </svg>

--- a/icons/arrow-big-right-dash.json
+++ b/icons/arrow-big-right-dash.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "key",
+    "forward"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/arrow-big-right-dash.svg
+++ b/icons/arrow-big-right-dash.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 9v6" />
+  <path d="M9 9h3V5l7 7-7 7v-4H9V9z" />
+</svg>

--- a/icons/arrow-big-right.svg
+++ b/icons/arrow-big-right.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m21 12-7-7v4H3v6h11v4z" />
+  <path d="M6,9h6V5l7,7l-7,7v-4H6V9z" />
 </svg>

--- a/icons/arrow-big-right.svg
+++ b/icons/arrow-big-right.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M6,9h6V5l7,7l-7,7v-4H6V9z" />
+  <path d="M6 9h6V5l7 7-7 7v-4H6V9z" />
 </svg>

--- a/icons/arrow-big-up-dash.json
+++ b/icons/arrow-big-up-dash.json
@@ -11,6 +11,6 @@
   ],
   "categories": [
     "arrows",
-    "coding"
+    "development"
   ]
 }

--- a/icons/arrow-big-up-dash.json
+++ b/icons/arrow-big-up-dash.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "keyboard",
+    "key",
+    "forward",
+    "caps lock",
+    "capitals",
+    "mac",
+    "button"
+  ],
+  "categories": [
+    "arrows",
+    "coding"
+  ]
+}

--- a/icons/arrow-big-up-dash.svg
+++ b/icons/arrow-big-up-dash.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 17v4H9v-4h6z" />
+  <path d="M9 13v-3H5l7-7 7 7h-4v3H9z" />
+</svg>

--- a/icons/arrow-big-up-dash.svg
+++ b/icons/arrow-big-up-dash.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M15 17v4H9v-4h6z" />
-  <path d="M9 13v-3H5l7-7 7 7h-4v3H9z" />
+  <path d="M9 19h6" />
+  <path d="M9 15v-3H5l7-7 7 7h-4v3H9z" />
 </svg>

--- a/icons/arrow-big-up.json
+++ b/icons/arrow-big-up.json
@@ -1,10 +1,15 @@
 {
   "$schema": "../icon.schema.json",
   "tags": [
+    "keyboard",
     "key",
-    "forward"
+    "forward",
+    "shift",
+    "mac",
+    "button"
   ],
   "categories": [
-    "arrows"
+    "arrows",
+    "coding"
   ]
 }

--- a/icons/arrow-big-up.json
+++ b/icons/arrow-big-up.json
@@ -10,6 +10,6 @@
   ],
   "categories": [
     "arrows",
-    "coding"
+    "development"
   ]
 }

--- a/icons/arrow-big-up.svg
+++ b/icons/arrow-big-up.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M9 21V10H5l7-7 7 7h-4v11z" />
+  <path d="M9,18v-6H5l7-7l7,7h-4v6H9z" />
 </svg>

--- a/icons/arrow-big-up.svg
+++ b/icons/arrow-big-up.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M9,18v-6H5l7-7l7,7h-4v6H9z" />
+  <path d="M9 18v-6H5l7-7 7 7h-4v6H9z" />
 </svg>

--- a/icons/chevron-up.json
+++ b/icons/chevron-up.json
@@ -1,9 +1,17 @@
 {
   "$schema": "../icon.schema.json",
   "tags": [
-    "arrow"
+    "arrow",
+    "caret",
+    "keyboard",
+    "key",
+    "mac",
+    "control",
+    "ctrl",
+    "button"
   ],
   "categories": [
-    "arrows"
+    "arrows",
+    "coding"
   ]
 }

--- a/icons/command.json
+++ b/icons/command.json
@@ -2,9 +2,10 @@
   "$schema": "../icon.schema.json",
   "tags": [
     "keyboard",
+    "key",
+    "mac",
     "cmd",
-    "terminal",
-    "prompt"
+    "button"
   ],
   "categories": [
     "coding"

--- a/icons/option.json
+++ b/icons/option.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../icon.schema.json",
   "tags": [
+    "keyboard",
     "key",
     "mac",
+    "alt",
     "button"
   ],
   "categories": [


### PR DESCRIPTION
<kbd>⇧</kbd>

See also #1013.