### PR TITLE
Add `find-replace` icons

### DIFF
--- a/icons/case-lower.json
+++ b/icons/case-lower.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "text",
+    "letters",
+    "characters",
+    "font",
+    "typography"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/case-lower.svg
+++ b/icons/case-lower.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="17" cy="12" r="3" />
+  <line x1="14" x2="14" y1="7" y2="15" />
+  <circle cx="7" cy="12" r="3" />
+  <line x1="10" x2="10" y1="9" y2="15" />
+</svg>

--- a/icons/case-sensitive.json
+++ b/icons/case-sensitive.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "text",
+    "letters",
+    "characters",
+    "font",
+    "typography"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/case-sensitive.svg
+++ b/icons/case-sensitive.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polyline points="3,15 7,7 11,15" />
+  <line x1="4" x2="10" y1="13" y2="13" />
+  <circle cx="18" cy="12" r="3" />
+  <line x1="21" x2="21" y1="9" y2="15" />
+</svg>

--- a/icons/case-upper.json
+++ b/icons/case-upper.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "text",
+    "letters",
+    "characters",
+    "font",
+    "typography"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/case-upper.svg
+++ b/icons/case-upper.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polyline points="3,15 7,7 11,15" />
+  <line x1="4" x2="10" y1="13" y2="13" />
+  <path d="M15 7h4c1.1 0 2 .9 2 2s-.9 2-2 2h-4V7z" />
+  <path d="M15 11h4.5c1.1 0 2 .9 2 2s-.9 2-2 2H15v-4z" />
+</svg>

--- a/icons/replace-all.json
+++ b/icons/replace-all.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "search",
+    "substitute",
+    "swap",
+    "change"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/replace-all.svg
+++ b/icons/replace-all.svg
@@ -1,0 +1,21 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6,10V5c0-1.7,1.3-3,3-3h1" />
+  <polyline points="3,7 6,10 9,7" />
+  <path d="M22,8c0,1.1-0.9,2-2,2" />
+  <path d="M20,2c1.1,0,2,0.9,2,2" />
+  <path d="M14,4c0-1.1,0.9-2,2-2" />
+  <path d="M16,10c-1.1,0-2-0.9-2-2" />
+  <path d="M8,22H4c-1.1,0-2-0.9-2-2v-4c0-1.1,0.9-2,2-2h4c1.1,0,2,0.9,2,2v4C10,21.1,9.1,22,8,22z" />
+  <path d="M14,14c1.1,0,2,0.9,2,2v4c0,1.1-0.9,2-2,2" />
+  <path d="M20,14c1.1,0,2,0.9,2,2v4c0,1.1-0.9,2-2,2" />
+</svg>

--- a/icons/replace.json
+++ b/icons/replace.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "search",
+    "substitute",
+    "swap",
+    "change"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/replace.svg
+++ b/icons/replace.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6,10V5c0-1.7,1.3-3,3-3h1" />
+  <polyline points="3,7 6,10 9,7" />
+  <path d="M22,8c0,1.1-0.9,2-2,2" />
+  <path d="M20,2c1.1,0,2,0.9,2,2" />
+  <path d="M14,4c0-1.1,0.9-2,2-2" />
+  <path d="M16,10c-1.1,0-2-0.9-2-2" />
+  <path d="M8,22H4c-1.1,0-2-0.9-2-2v-4c0-1.1,0.9-2,2-2h4c1.1,0,2,0.9,2,2v4C10,21.1,9.1,22,8,22z" />
+</svg>

--- a/icons/space.json
+++ b/icons/space.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "text",
+    "selection",
+    "letters",
+    "characters",
+    "font",
+    "typography"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/space.svg
+++ b/icons/space.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polyline points="22,17 22,19 2,19 2,17" />
+</svg>

--- a/icons/text-selection.json
+++ b/icons/text-selection.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "find",
+    "search"
+  ],
+  "categories": [
+    "text",
+    "cursors"
+  ]
+}

--- a/icons/text-selection.svg
+++ b/icons/text-selection.svg
@@ -1,0 +1,27 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 3a2 2 0 0 0-2 2" />
+  <path d="M19 3a2 2 0 0 1 2 2" />
+  <path d="M21 19a2 2 0 0 1-2 2" />
+  <path d="M5 21a2 2 0 0 1-2-2" />
+  <path d="M9 3h1" />
+  <path d="M9 21h1" />
+  <path d="M14 3h1" />
+  <path d="M14 21h1" />
+  <path d="M3 9v1" />
+  <path d="M21 9v1" />
+  <path d="M3 14v1" />
+  <path d="M21 14v1" />
+  <line x1="7" x2="15" y1="8" y2="8" />
+  <line x1="7" x2="17" y1="12" y2="12" />
+  <line x1="7" x2="13" y1="16" y2="16" />
+</svg>

--- a/icons/whole-word.json
+++ b/icons/whole-word.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "text",
+    "selection",
+    "letters",
+    "characters",
+    "font",
+    "typography"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/whole-word.svg
+++ b/icons/whole-word.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="17" cy="12" r="3" />
+  <line x1="14" x2="14" y1="7" y2="15" />
+  <circle cx="7" cy="12" r="3" />
+  <line x1="10" x2="10" y1="9" y2="15" />
+  <polyline points="22,17 22,19 2,19 2,17" />
+</svg>


### PR DESCRIPTION
As mentioned in another PR, I’m putting together a VS Code extension for Lucide product and file icons…

This PR is meant to cover the find/replace panel:

<img width="478" alt="Screenshot 2023-04-07 at 9 51 38 pm" src="https://user-images.githubusercontent.com/7797479/230677878-ef5c227b-deb2-4ebc-aac3-e7aa7658ee5e.png">

See also: _[codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html)_