### PR TITLE
Add `text` icon

### DIFF
--- a/icons/text.json
+++ b/icons/text.json
@@ -2,7 +2,11 @@
   "$schema": "../icon.schema.json",
   "tags": [
     "find",
-    "search"
+    "search",
+    "data",
+    "txt",
+    "pdf",
+    "document"
   ],
   "categories": [
     "text",

--- a/icons/text.json
+++ b/icons/text.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "find",
+    "search"
+  ],
+  "categories": [
+    "text",
+    "files",
+    "cursors"
+  ]
+}

--- a/icons/text.svg
+++ b/icons/text.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M17 6.1H3" />
+  <path d="M21 12.1H3" />
+  <path d="M15.1 18H3" />
+</svg>


### PR DESCRIPTION
Keep existing icon, but match [`align-*`](https://lucide.dev/icons?search=align) icons, along with `list-selection` from [codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html).