### PR TITLE
Add `search` icons

### DIFF
--- a/icons/search-2.json
+++ b/icons/search-2.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "find",
+    "magnifier",
+    "magnifying glass"
+  ],
+  "categories": [
+    "text",
+    "account",
+    "social"
+  ]
+}

--- a/icons/search-2.svg
+++ b/icons/search-2.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <line x1="7.3" x2="3" y1="16.7" y2="21" />
+  <circle cx="13" cy="11" r="8" />
+</svg>

--- a/icons/search-slash.json
+++ b/icons/search-slash.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "find",
+    "magnifier",
+    "magnifying glass",
+    "clear",
+    "cancel",
+    "stop",
+    "Ø"
+  ],
+  "categories": [
+    "text",
+    "account",
+    "social"
+  ]
+}

--- a/icons/search-slash.svg
+++ b/icons/search-slash.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <line x1="7.3" x2="3" y1="16.7" y2="21" />
+  <circle cx="13" cy="11" r="8" />
+  <line x1="18.6" x2="7.4" y1="16.6" y2="5.4" />
+</svg>


### PR DESCRIPTION
Many search icons are the flip of the existing icon… But I think it depends on, for example, which side of a search bar the user wants to display the icon:

![image](https://user-images.githubusercontent.com/7797479/231714011-74280c3f-7a64-4c20-b189-6c3176e24b25.png)

I think the user should have a choice in this situation.

Also, `search-slash` (clear search) is meant to cover `search-stop` from [codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html)
