### PR TITLE
Add [`un`]`group` icons

### DIFF
--- a/icons/group.json
+++ b/icons/group.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "cubes",
+    "packages",
+    "parts",
+    "units",
+    "collection",
+    "cluster",
+    "gather"
+  ],
+  "categories": [
+    "shapes",
+    "files"
+  ]
+}

--- a/icons/group.svg
+++ b/icons/group.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 7V5c0-1.1.9-2 2-2h2" />
+  <path d="M17 3h2c1.1 0 2 .9 2 2v2" />
+  <path d="M21 17v2c0 1.1-.9 2-2 2h-2" />
+  <path d="M7 21H5c-1.1 0-2-.9-2-2v-2" />
+  <rect width="7" height="5" x="7" y="7" rx="1" />
+  <rect width="7" height="5" x="10" y="12" rx="1" />
+</svg>

--- a/icons/ungroup.json
+++ b/icons/ungroup.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "cubes",
+    "packages",
+    "parts",
+    "units",
+    "collection",
+    "cluster",
+    "separate"
+  ],
+  "categories": [
+    "shapes",
+    "files"
+  ]
+}

--- a/icons/ungroup.svg
+++ b/icons/ungroup.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="8" height="6" x="5" y="4" rx="1" />
+  <rect width="8" height="6" x="11" y="14" rx="1" />
+</svg>


### PR DESCRIPTION
Alternatives:

![](https://user-images.githubusercontent.com/7797479/232518615-ea437dc8-ec6a-48af-8bd8-6df5705d7b8c.png)

Maybe the `selection` (dashed) version would be more appropriate…?