### PR TITLE
Added `stars` and `moon-star`

### DIFF
--- a/icons/moon-star.json
+++ b/icons/moon-star.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "dark",
+    "night",
+    "star"
+  ],
+  "categories": [
+    "accessibility",
+    "weather"
+  ]
+}

--- a/icons/moon-star.svg
+++ b/icons/moon-star.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 3a6.364 6.364 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+  <path d="M19 3v4" />
+  <path d="M21 5h-4" />
+</svg>

--- a/icons/stars.json
+++ b/icons/stars.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "effect",
+    "filter",
+    "night",
+    "sparkles",
+    "magic"
+  ],
+  "categories": [
+    "shapes",
+    "cursors",
+    "multimedia",
+    "gaming",
+    "weather"
+  ]
+}

--- a/icons/stars.svg
+++ b/icons/stars.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" />
+  <path d="M5 3v4" />
+  <path d="M19 17v4" />
+  <path d="M3 5h4" />
+  <path d="M17 19h4" />
+</svg>


### PR DESCRIPTION
## Icon Request

* Icon name: `stars`, `moon-star`
* Use case:
  * `stars`: multimedia effects or filters, signifying nighttime or magic
  * `moon-star`: an alternate for the regular moon icon to stand in for dark mode or nighttime.
* Screenshots of similar icons:
  * ![image](https://user-images.githubusercontent.com/17746067/233136100-2e3473c8-ab4e-406b-a26f-816ffc7c5f1b.png)
  * ![image](https://user-images.githubusercontent.com/17746067/233136230-583461ea-68fe-49f3-9f82-a2daa3286284.png)

