### PR TITLE
Refine `list` icons

### DIFF
--- a/icons/list-minus.svg
+++ b/icons/list-minus.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M11 12H3" />
-  <path d="M16 6H3" />
-  <path d="M16 18H3" />
-  <path d="M21 12h-6" />
+  <path d="M21 6H3" />
+  <path d="M13 12H3" />
+  <path d="M21 18H3" />
+  <path d="M21 12h-4" />
 </svg>

--- a/icons/list-plus.svg
+++ b/icons/list-plus.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M11 12H3" />
-  <path d="M16 6H3" />
-  <path d="M16 18H3" />
-  <path d="M18 9v6" />
-  <path d="M21 12h-6" />
+  <path d="M21 6H3" />
+  <path d="M13 12H3" />
+  <path d="M21 18H3" />
+  <path d="M21 12h-4" />
+  <path d="M19 10v4" />
 </svg>

--- a/icons/list-x.svg
+++ b/icons/list-x.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M11 12H3" />
-  <path d="M16 6H3" />
-  <path d="M16 18H3" />
-  <path d="m19 10-4 4" />
-  <path d="m15 10 4 4" />
+  <path d="M21 6H3" />
+  <path d="M13 12H3" />
+  <path d="M21 18H3" />
+  <path d="m17 10 4 4" />
+  <path d="m21 10-4 4" />
 </svg>


### PR DESCRIPTION
Some of the existing `list` icons feel a bit off…

Some alternatives explored:

<img width="227" alt="Untitled" src="https://user-images.githubusercontent.com/7797479/233313249-e1f923fd-c98c-47be-bd75-42fd5ea26e72.png">
