### PR TITLE
Fix `arrow-up-left-from-circle` metadata ❗

### DIFF
--- a/icons/arrow-up-left-from-circle.json
+++ b/icons/arrow-up-left-from-circle.json
@@ -9,6 +9,6 @@
   ],
   "categories": [
     "arrows",
-    "coding"
+    "development"
   ]
 }


### PR DESCRIPTION
This is causing the `pre-commit` hook to fail, because it was merged after the `coding` category was removed.