### PR TITLE
Fix `chevron-up` metadata❗️

### DIFF
--- a/icons/chevron-up.json
+++ b/icons/chevron-up.json
@@ -11,7 +11,6 @@
     "button"
   ],
   "categories": [
-    "arrows",
-    "coding"
+    "arrows"
   ]
 }


### PR DESCRIPTION
Looks like another one snook through before the `coding` category was removed, and so is causing the `pre-commit` hook to fail…