### PR TITLE
Add `ethereum` icon

### DIFF
--- a/icons/ethereum.json
+++ b/icons/ethereum.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "currency",
+    "money",
+    "payment"
+  ],
+  "categories": [
+    "brands",
+    "currency",
+    "development",
+    "money"
+  ]
+}

--- a/icons/ethereum.svg
+++ b/icons/ethereum.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polygon points="19 10 12 2 5 10 12 13" />
+  <line x1="12" x2="12" y1="13" y2="2" />
+  <polygon points="19 14 12 17 5 14 12 22" />
+</svg>


### PR DESCRIPTION
Can’t have BTC https://lucide.dev/icons?search=bitcoin without ETH… That’s just not on :)

Alts:

<img width="264" alt="Untitled" src="https://user-images.githubusercontent.com/7797479/234645202-81307640-528b-4ab4-aea8-f189df6be2a6.png">

<img width="89" alt="Untitled" src="https://user-images.githubusercontent.com/7797479/234645312-85cddfbf-f187-461e-9116-50c854c3fb58.png">
