### PR TITLE
Add `tab-*` icons

### DIFF
--- a/icons/tab-arrow-up-right.json
+++ b/icons/tab-arrow-up-right.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "application",
+    "window",
+    "user interface",
+    "ui",
+    "browser",
+    "webpage",
+    "open",
+    "new",
+    "external"
+  ],
+  "categories": [
+    "layout",
+    "design"
+  ]
+}

--- a/icons/tab-arrow-up-right.svg
+++ b/icons/tab-arrow-up-right.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 18h2V8a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v10h2" />
+  <path d="m15.1 10.1-6 5.9" />
+  <path d="M10.1 10.1h5v5" />
+</svg>

--- a/icons/tab-plus.json
+++ b/icons/tab-plus.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "application",
+    "window",
+    "user interface",
+    "ui",
+    "browser",
+    "webpage",
+    "open",
+    "new"
+  ],
+  "categories": [
+    "layout",
+    "design"
+  ]
+}

--- a/icons/tab-plus.svg
+++ b/icons/tab-plus.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 18h2V8a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v10h2" />
+  <path d="M15.1 13.1h-6" />
+  <path d="M12.1 10.1V16" />
+</svg>

--- a/icons/tab-x.json
+++ b/icons/tab-x.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "application",
+    "window",
+    "user interface",
+    "ui",
+    "browser",
+    "webpage",
+    "close"
+  ],
+  "categories": [
+    "layout",
+    "design"
+  ]
+}

--- a/icons/tab-x.svg
+++ b/icons/tab-x.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 18h2V8a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v10h2" />
+  <path d="m15.1 10.1-6 5.9" />
+  <path d="m15.1 16-6-5.9" />
+</svg>

--- a/icons/tab.json
+++ b/icons/tab.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "application",
+    "window",
+    "user interface",
+    "ui",
+    "browser",
+    "webpage"
+  ],
+  "categories": [
+    "layout",
+    "design"
+  ]
+}

--- a/icons/tab.svg
+++ b/icons/tab.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 18h2V8a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v10h2" />
+</svg>


### PR DESCRIPTION
`tab-arrow-up-right` is `tab-external` from [octicons](https://primer.style/design/foundations/icons).

Edit: _Possibly_ superseded by #1237.