### PR TITLE
Fix removal of `sidebar.json`❗️

### DIFF
--- a/icons/sidebar.json
+++ b/icons/sidebar.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "../icon.schema.json",
-  "tags": [
-    "menu"
-  ],
-  "categories": [
-    "layout"
-  ]
-}


### PR DESCRIPTION
Not sure what happened, but `sidebar.json` should have been deleted when replaced with `panel-left.json` in #1003… This is currently breaking the `pre-commit` hook!