### PR TITLE
Optimise `copy`[`-*`] icons/add `copy-down` (download all/generic clone) icon

### DIFF
--- a/icons/copy-check.json
+++ b/icons/copy-check.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "clone",

--- a/icons/copy-check.json
+++ b/icons/copy-check.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
   "tags": [
     "clone",
     "duplicate",

--- a/icons/copy-check.svg
+++ b/icons/copy-check.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
   <path d="m12 15 2 2 4-4" />
-  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
 </svg>

--- a/icons/copy-code.json
+++ b/icons/copy-code.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "clone",
+    "duplicate",
+    "multiple",
+    "codebase",
+    "source",
+    "raw",
+    "snippets",
+    "gists"
+  ],
+  "categories": [
+    "text",
+    "development"
+  ]
+}

--- a/icons/copy-code.svg
+++ b/icons/copy-code.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <path d="m13 13-1 2 1 2" />
+  <path d="m17 13 1 2-1 2" />
+</svg>

--- a/icons/copy-down.json
+++ b/icons/copy-down.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
   "tags": [
     "read",
     "dictionary",

--- a/icons/copy-down.json
+++ b/icons/copy-down.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "read",
+    "dictionary",
+    "booklet",
+    "library",
+    "code",
+    "version control",
+    "git",
+    "repository",
+    "clone",
+    "download all"
+  ],
+  "categories": [
+    "development"
+  ]
+}

--- a/icons/copy-down.svg
+++ b/icons/copy-down.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <path d="M15 12v6" />
+  <path d="m12 15 3 3 3-3" />
+</svg>

--- a/icons/copy-file-path.json
+++ b/icons/copy-file-path.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "relative",
+    "location",
+    "multiple"
+  ],
+  "categories": [
+    "files",
+    "development",
+    "text"
+  ]
+}

--- a/icons/copy-file-path.json
+++ b/icons/copy-file-path.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
   "tags": [
     "relative",
     "location",

--- a/icons/copy-file-path.svg
+++ b/icons/copy-file-path.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  <path d="M12 18h.01" />
+  <line x1="18" x2="16" y1="12" y2="18" class="st0" />
+</svg>

--- a/icons/copy-file-path.svg
+++ b/icons/copy-file-path.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
   <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
   <path d="M12 18h.01" />
-  <line x1="18" x2="16" y1="12" y2="18" class="st0" />
+  <path d="m18 12-2 6" />
 </svg>

--- a/icons/copy-image.json
+++ b/icons/copy-image.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "clone",
+    "duplicate",
+    "multiple",
+    "images",
+    "pictures",
+    "photos",
+    "album",
+    "collection",
+    "event"
+  ],
+  "categories": [
+    "photography",
+    "text",
+    "multimedia",
+    "files",
+    "social"
+  ]
+}

--- a/icons/copy-image.json
+++ b/icons/copy-image.json
@@ -12,13 +12,16 @@
     "photos",
     "album",
     "collection",
-    "event"
+    "event",
+    "gallery"
   ],
   "categories": [
     "photography",
     "text",
     "multimedia",
     "files",
-    "social"
+    "social",
+    "design",
+    "development"
   ]
 }

--- a/icons/copy-image.svg
+++ b/icons/copy-image.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <circle cx="14" cy="14" r="2" />
+  <path d="m13.4 22 4.7-3.9c.8-.8 2-.8 2.8 0l1.1 1.1" />
+</svg>

--- a/icons/copy-minus.json
+++ b/icons/copy-minus.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "clone",

--- a/icons/copy-minus.json
+++ b/icons/copy-minus.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
   "tags": [
     "clone",
     "duplicate",

--- a/icons/copy-minus.svg
+++ b/icons/copy-minus.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="12" x2="18" y1="15" y2="15" />
-  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <path d="M12 15h6" />
 </svg>

--- a/icons/copy-plus.json
+++ b/icons/copy-plus.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "clone",

--- a/icons/copy-plus.json
+++ b/icons/copy-plus.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
   "tags": [
     "clone",
     "duplicate",

--- a/icons/copy-plus.svg
+++ b/icons/copy-plus.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="15" x2="15" y1="12" y2="18" />
-  <line x1="12" x2="18" y1="15" y2="15" />
-  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <path d="M12 15h6" />
+  <path d="M15 12v6" />
 </svg>

--- a/icons/copy-slash.json
+++ b/icons/copy-slash.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "clone",

--- a/icons/copy-slash.json
+++ b/icons/copy-slash.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
   "tags": [
     "clone",
     "duplicate",

--- a/icons/copy-slash.svg
+++ b/icons/copy-slash.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="12" x2="18" y1="18" y2="12" />
-  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <path d="m12 18 6-6" />
 </svg>

--- a/icons/copy-text.json
+++ b/icons/copy-text.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "clone",
+    "duplicate",
+    "multiple",
+    "texts",
+    "lines",
+    "drafts",
+    "script",
+    "plagiarism"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/copy-text.svg
+++ b/icons/copy-text.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <path d="M12 13h6" />
+  <path d="M12 17h6" />
+</svg>

--- a/icons/copy-type.json
+++ b/icons/copy-type.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "formatting",
+    "styling",
+    "rich text",
+    "rtf",
+    "fonts",
+    "font book",
+    "typography",
+    "collection",
+    "slab serif",
+    "clone",
+    "duplicate",
+    "multiple",
+    "toolbar",
+    "button"
+  ],
+  "categories": [
+    "text",
+    "tools",
+    "design"
+  ]
+}

--- a/icons/copy-type.svg
+++ b/icons/copy-type.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  <path d="M12 13v-1h6v1" />
+  <path d="M15 12v6" />
+  <path d="M14 18h2" />
+</svg>

--- a/icons/copy-x.json
+++ b/icons/copy-x.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
   "tags": [
     "cancel",
     "close",

--- a/icons/copy-x.json
+++ b/icons/copy-x.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "cancel",

--- a/icons/copy-x.svg
+++ b/icons/copy-x.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="12" x2="18" y1="12" y2="18" />
-  <line x1="12" x2="18" y1="18" y2="12" />
-  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
+  <path d="m12 18 6-6" />
+  <path d="m12 12 6 6" />
 </svg>

--- a/icons/copy.svg
+++ b/icons/copy.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  <path d="M4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2" />
+  <rect width="14" height="14" x="8" y="8" rx="2" />
 </svg>


### PR DESCRIPTION
* `copy-down` can be a generic clone icon, 'download all' or download*s*…
* `copy-file-path` is self-explanatory… Useful in editors.
* `copy-image` self-explanatory, but also can be photos/album/gallery…
* `copy-type` is copy with formatting (closely related to #1298)
