### PR TITLE
Fix `unplug` metadata❗️

### DIFF
--- a/icons/unplug.json
+++ b/icons/unplug.json
@@ -9,7 +9,6 @@
   ],
   "categories": [
     "devices",
-    "coding",
     "development"
   ]
 }


### PR DESCRIPTION
This broke the `pre-commit` hook again, because it was `merge`d after the `coding` category was removed.