### PR TITLE
Adds `ferris-wheel` and `roller-coaster`

### DIFF
--- a/icons/ferris-wheel.json
+++ b/icons/ferris-wheel.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "big wheel",
+    "daisy wheel",
+    "observation",
+    "attraction",
+    "entertainment",
+    "amusement park",
+    "theme park",
+    "funfair"
+  ],
+  "categories": [
+    "maps"
+  ]
+}

--- a/icons/ferris-wheel.svg
+++ b/icons/ferris-wheel.svg
@@ -1,0 +1,21 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="2" />
+  <path d="M12 2v4" />
+  <path d="m6.8 15-3.5 2" />
+  <path d="m20.7 7-3.5 2" />
+  <path d="M6.8 9 3.3 7" />
+  <path d="m20.7 17-3.5-2" />
+  <path d="m9 22 3-8 3 8" />
+  <path d="M8 22h8" />
+  <path d="M18 18.7a9 9 0 1 0-12 0" />
+</svg>

--- a/icons/roller-coaster.json
+++ b/icons/roller-coaster.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "attraction",
+    "entertainment",
+    "amusement park",
+    "theme park",
+    "funfair"
+  ],
+  "categories": [
+    "maps"
+  ]
+}

--- a/icons/roller-coaster.svg
+++ b/icons/roller-coaster.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 20V4" />
+  <path d="M10 20V5.79" />
+  <path d="M14 20v-9.77" />
+  <path d="M18 4v4" />
+  <path d="M18 20v-8" />
+  <path d="M22 20V8" />
+  <path d="M2 20V8a4 4 0 0 1 4-4c2 0 4 1.33 6 4s4 4 6 4a4 4 0 1 0-2-7.47" />
+</svg>

--- a/icons/roller-coaster.svg
+++ b/icons/roller-coaster.svg
@@ -9,11 +9,11 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M6 20V4" />
-  <path d="M10 20V5.79" />
-  <path d="M14 20v-9.77" />
-  <path d="M18 4v4" />
-  <path d="M18 20v-8" />
-  <path d="M22 20V8" />
-  <path d="M2 20V8a4 4 0 0 1 4-4c2 0 4 1.33 6 4s4 4 6 4a4 4 0 1 0-2-7.47" />
+  <path d="M6 19V5" />
+  <path d="M10 19V6.8" />
+  <path d="M14 19v-7.8" />
+  <path d="M18 5v4" />
+  <path d="M18 19v-6" />
+  <path d="M22 19V9" />
+  <path d="M2 19V9a4 4 0 0 1 4-4c2 0 4 1.33 6 4s4 4 6 4a4 4 0 1 0-2-7.47" />
 </svg>


### PR DESCRIPTION
## Icon Request

* Icon name: `roller-coaster` & `ferris-wheel`
* Use case: to represent amusement parks, funfairs, tourist attractions in map / POI applications.
* _Screenshots_ of similar icons:
![image](https://user-images.githubusercontent.com/17746067/236134960-292e3c77-1751-4ca4-bbac-f1967f93e081.png)