### PR TITLE
Add `spell-check` icons

### DIFF
--- a/icons/spell-check-2.json
+++ b/icons/spell-check-2.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "spelling",
+    "error",
+    "mistake",
+    "oversight",
+    "typo",
+    "correction",
+    "code",
+    "linter"
+  ],
+  "categories": [
+    "text",
+    "development"
+  ]
+}

--- a/icons/spell-check-2.json
+++ b/icons/spell-check-2.json
@@ -8,7 +8,8 @@
     "typo",
     "correction",
     "code",
-    "linter"
+    "linter",
+    "a"
   ],
   "categories": [
     "text",

--- a/icons/spell-check-2.svg
+++ b/icons/spell-check-2.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m6 16 6-12 6 12" />
+  <path d="M8 12h8" />
+  <path d="M4 21c1.1 0 1.1-1 2.3-1s1.1 1 2.3 1c1.1 0 1.1-1 2.3-1 1.1 0 1.1 1 2.3 1 1.1 0 1.1-1 2.3-1 1.1 0 1.1 1 2.3 1 1.1 0 1.1-1 2.3-1" />
+</svg>

--- a/icons/spell-check.json
+++ b/icons/spell-check.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "spelling",
+    "error",
+    "mistake",
+    "oversight",
+    "typo",
+    "correction",
+    "code",
+    "linter"
+  ],
+  "categories": [
+    "text",
+    "development"
+  ]
+}

--- a/icons/spell-check.json
+++ b/icons/spell-check.json
@@ -8,7 +8,8 @@
     "typo",
     "correction",
     "code",
-    "linter"
+    "linter",
+    "a"
   ],
   "categories": [
     "text",

--- a/icons/spell-check.svg
+++ b/icons/spell-check.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m6 16 6-12 6 12" />
+  <path d="M8 12h8" />
+  <path d="m16 20 2 2 4-4" />
+</svg>


### PR DESCRIPTION
See #928… with credit to @jguddas

Explored:

<img width="175" alt="Untitled" src="https://user-images.githubusercontent.com/7797479/236281794-d5aef482-316c-4260-bdae-2a0a0278e6cf.png">

<img width="338" alt="Untitled" src="https://user-images.githubusercontent.com/7797479/236285925-30309e33-3a0d-464a-8454-2935a9d9ff78.png">

Closes #928.