### PR TITLE
Optimise/refine `case-*`/`word`/`space` icons

### DIFF
--- a/icons/case-lower.svg
+++ b/icons/case-lower.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="17" cy="12" r="3" />
-  <line x1="14" x2="14" y1="7" y2="15" />
   <circle cx="7" cy="12" r="3" />
-  <line x1="10" x2="10" y1="9" y2="15" />
+  <path d="M10 9v6" />
+  <circle cx="17" cy="12" r="3" />
+  <path d="M14 7v8" />
 </svg>

--- a/icons/case-sensitive.svg
+++ b/icons/case-sensitive.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="3,15 7,7 11,15" />
-  <line x1="4" x2="10" y1="13" y2="13" />
+  <path d="m3 15 4-8 4 8" />
+  <path d="M4 13h6" />
   <circle cx="18" cy="12" r="3" />
-  <line x1="21" x2="21" y1="9" y2="15" />
+  <path d="M21 9v6" />
 </svg>

--- a/icons/case-upper.svg
+++ b/icons/case-upper.svg
@@ -9,8 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="3,15 7,7 11,15" />
-  <line x1="4" x2="10" y1="13" y2="13" />
-  <path d="M15 7h4c1.1 0 2 .9 2 2s-.9 2-2 2h-4V7z" />
-  <path d="M15 11h4.5c1.1 0 2 .9 2 2s-.9 2-2 2H15v-4z" />
+  <path d="m3 15 4-8 4 8" />
+  <path d="M4 13h6" />
+  <path d="M15 11h4.5a2 2 0 0 1 0 4H15V7h4a2 2 0 0 1 0 4" />
 </svg>

--- a/icons/space.svg
+++ b/icons/space.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="22,17 22,19 2,19 2,17" />
+  <path d="M22 17v2H2v-2" />
 </svg>

--- a/icons/space.svg
+++ b/icons/space.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M22 17v2H2v-2" />
+  <path d="M22 17v1c0 .5-.5 1-1 1H3c-.5 0-1-.5-1-1v-1" />
 </svg>

--- a/icons/whole-word.svg
+++ b/icons/whole-word.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="17" cy="12" r="3" />
-  <line x1="14" x2="14" y1="7" y2="15" />
   <circle cx="7" cy="12" r="3" />
-  <line x1="10" x2="10" y1="9" y2="15" />
-  <polyline points="22,17 22,19 2,19 2,17" />
+  <path d="M10 9v6" />
+  <circle cx="17" cy="12" r="3" />
+  <path d="M14 7v8" />
+  <path d="M22 17v2H2v-2" />
 </svg>

--- a/icons/whole-word.svg
+++ b/icons/whole-word.svg
@@ -13,5 +13,5 @@
   <path d="M10 9v6" />
   <circle cx="17" cy="12" r="3" />
   <path d="M14 7v8" />
-  <path d="M22 17v2H2v-2" />
+  <path d="M22 17v1c0 .5-.5 1-1 1H3c-.5 0-1-.5-1-1v-1" />
 </svg>


### PR DESCRIPTION
Optimisations from #1023. Also related to #1041.

Plus following #1191, as mentioned in https://github.com/lucide-icons/lucide/pull/1191#issuecomment-1531675386 …

>  I think it hurts overall legibility.

Agreed that 2px radius might, but not so sure 1px harms legibility… What do you think @karsa-mistmere?