### PR TITLE
[lucide-angular] Adds support for ng@16.x

### DIFF
--- a/packages/lucide-angular/package.json
+++ b/packages/lucide-angular/package.json
@@ -77,7 +77,7 @@
     "zone.js": "~0.11.4"
   },
   "peerDependencies": {
-    "@angular/common": "13.x - 15.x",
-    "@angular/core": "13.x - 15.x"
+    "@angular/common": "13.x - 16.x",
+    "@angular/core": "13.x - 16.x"
   }
 }


### PR DESCRIPTION
Angular v16.0.0 has just been released two days ago. 🥳 