### PR TITLE
Add `font-size` icons

### DIFF
--- a/icons/a-arrow-down.json
+++ b/icons/a-arrow-down.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "it-is-not",
+    "jguddas",
+    "danielbayley",
+    "ericfennis"
+  ],
+  "tags": [
+    "letter",
+    "font size",
+    "text",
+    "formatting",
+    "smaller"
+  ],
+  "categories": [
+    "text",
+    "design"
+  ]
+}

--- a/icons/a-arrow-down.svg
+++ b/icons/a-arrow-down.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3.5 13h6" />
+  <path d="m2 16 4.5-9 4.5 9" />
+  <path d="M18 7v9" />
+  <path d="m14 12 4 4 4-4" />
+</svg>

--- a/icons/a-arrow-up.json
+++ b/icons/a-arrow-up.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "it-is-not",
+    "jguddas",
+    "danielbayley",
+    "ericfennis"
+  ],
+  "tags": [
+    "letter",
+    "font size",
+    "text",
+    "formatting",
+    "larger",
+    "bigger"
+  ],
+  "categories": [
+    "text",
+    "design"
+  ]
+}

--- a/icons/a-arrow-up.svg
+++ b/icons/a-arrow-up.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3.5 13h6" />
+  <path d="m2 16 4.5-9 4.5 9" />
+  <path d="M18 16V7" />
+  <path d="m14 11 4-4 4 4" />
+</svg>

--- a/icons/a-large-small.json
+++ b/icons/a-large-small.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "it-is-not",
+    "jguddas",
+    "danielbayley",
+    "ericfennis"
+  ],
+  "tags": [
+    "letter",
+    "font size",
+    "text",
+    "formatting"
+  ],
+  "categories": [
+    "text",
+    "design"
+  ]
+}

--- a/icons/a-large-small.svg
+++ b/icons/a-large-small.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 14h-5" />
+  <path d="M16 16v-3.5a2.5 2.5 0 0 1 5 0V16" />
+  <path d="M4.5 13h6" />
+  <path d="m3 16 4.5-9 4.5 9" />
+</svg>


### PR DESCRIPTION
<img width="475" alt="image" src="https://user-images.githubusercontent.com/72697755/236627246-e642c6be-05bf-42d7-89c9-0e66ffad9363.png">

Similar to what Microsoft Word does:
<img width="232" alt="image" src="https://user-images.githubusercontent.com/72697755/236627338-75ddb9b0-b330-4a8f-9734-00ef04bbba93.png">

I haven't made any icons in a while so hopefully everything works properly with the new categories.