### PR TITLE
Add alternative arrow icons

### DIFF
--- a/icons/move-down-left.json
+++ b/icons/move-down-left.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "direction"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/move-down-left.svg
+++ b/icons/move-down-left.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-<path d="M11 19H5V13"/>
-<path d="M19 5L5 19"/>
+  <path d="M11 19H5V13" />
+  <path d="M19 5L5 19" />
 </svg>

--- a/icons/move-down-left.svg
+++ b/icons/move-down-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M11 19H5V13"/>
+<path d="M19 5L5 19"/>
+</svg>

--- a/icons/move-down-right.json
+++ b/icons/move-down-right.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "direction"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/move-down-right.svg
+++ b/icons/move-down-right.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-<path d="M19 13V19H13"/>
-<path d="M5 5L19 19"/>
+  <path d="M19 13V19H13" />
+  <path d="M5 5L19 19" />
 </svg>

--- a/icons/move-down-right.svg
+++ b/icons/move-down-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M19 13V19H13"/>
+<path d="M5 5L19 19"/>
+</svg>

--- a/icons/move-down.json
+++ b/icons/move-down.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "direction",
+    "downwards",
+    "south"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/move-down.svg
+++ b/icons/move-down.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-<path d="M8 18L12 22L16 18"/>
-<path d="M12 2V22"/>
+  <path d="M8 18L12 22L16 18" />
+  <path d="M12 2V22" />
 </svg>

--- a/icons/move-down.svg
+++ b/icons/move-down.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M8 18L12 22L16 18"/>
+<path d="M12 2V22"/>
+</svg>

--- a/icons/move-left.json
+++ b/icons/move-left.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "direction",
+    "back",
+    "west"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/move-left.svg
+++ b/icons/move-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M6 8L2 12L6 16"/>
+<path d="M2 12H22"/>
+</svg>

--- a/icons/move-left.svg
+++ b/icons/move-left.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-<path d="M6 8L2 12L6 16"/>
-<path d="M2 12H22"/>
+  <path d="M6 8L2 12L6 16" />
+  <path d="M2 12H22" />
 </svg>

--- a/icons/move-right.json
+++ b/icons/move-right.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "direction",
+    "trend flat",
+    "east"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/move-right.svg
+++ b/icons/move-right.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-<path d="M18 8L22 12L18 16"/>
-<path d="M2 12H22"/>
+  <path d="M18 8L22 12L18 16" />
+  <path d="M2 12H22" />
 </svg>

--- a/icons/move-right.svg
+++ b/icons/move-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M18 8L22 12L18 16"/>
+<path d="M2 12H22"/>
+</svg>

--- a/icons/move-up-left.json
+++ b/icons/move-up-left.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "direction"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/move-up-left.svg
+++ b/icons/move-up-left.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-<path d="M5 11V5H11"/>
-<path d="M5 5L19 19"/>
+  <path d="M5 11V5H11" />
+  <path d="M5 5L19 19" />
 </svg>

--- a/icons/move-up-left.svg
+++ b/icons/move-up-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M5 11V5H11"/>
+<path d="M5 5L19 19"/>
+</svg>

--- a/icons/move-up-right.json
+++ b/icons/move-up-right.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "direction"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/move-up-right.svg
+++ b/icons/move-up-right.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-<path d="M13 5H19V11"/>
-<path d="M19 5L5 19"/>
+  <path d="M13 5H19V11" />
+  <path d="M19 5L5 19" />
 </svg>

--- a/icons/move-up-right.svg
+++ b/icons/move-up-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M13 5H19V11"/>
+<path d="M19 5L5 19"/>
+</svg>

--- a/icons/move-up.json
+++ b/icons/move-up.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "arrow",
+    "direction",
+    "upwards",
+    "north"
+  ],
+  "categories": [
+    "arrows"
+  ]
+}

--- a/icons/move-up.svg
+++ b/icons/move-up.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-<path d="M8 6L12 2L16 6"/>
-<path d="M12 2V22"/>
+  <path d="M8 6L12 2L16 6" />
+  <path d="M12 2V22" />
 </svg>

--- a/icons/move-up.svg
+++ b/icons/move-up.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+<path d="M8 6L12 2L16 6"/>
+<path d="M12 2V22"/>
+</svg>


### PR DESCRIPTION
These icons are a second arrow variant that are a bit longer and consistent with the other move icons.

closes https://github.com/lucide-icons/lucide/issues/1226