### PR TITLE
Add `slash` icon/improve [`*-`]`slash` metadata

### DIFF
--- a/icons/circle-slash-2.json
+++ b/icons/circle-slash-2.json
@@ -11,6 +11,11 @@
     "null",
     "void",
     "ban",
+    "maths",
+    "divide",
+    "division",
+    "half",
+    "split",
     "/"
   ],
   "categories": [

--- a/icons/circle-slash.json
+++ b/icons/circle-slash.json
@@ -21,9 +21,14 @@
     "mistake",
     "wrong",
     "failure",
+    "divide",
+    "division",
+    "or",
     "/"
   ],
   "categories": [
-    "shapes"
+    "shapes",
+    "development",
+    "maths"
   ]
 }

--- a/icons/copy-slash.json
+++ b/icons/copy-slash.json
@@ -18,10 +18,12 @@
     "divide",
     "division",
     "split",
+    "or",
     "/"
   ],
   "categories": [
     "text",
+    "development",
     "maths"
   ]
 }

--- a/icons/slash.json
+++ b/icons/slash.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "divide",
+    "division",
+    "or",
+    "/"
+  ],
+  "categories": [
+    "development",
+    "maths"
+  ]
+}

--- a/icons/slash.svg
+++ b/icons/slash.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 2 2 22" />
+</svg>

--- a/icons/square-slash.json
+++ b/icons/square-slash.json
@@ -12,10 +12,12 @@
     "divide",
     "division",
     "shortcut",
-    "/"
+    "or",
+    "/"    
   ],
   "categories": [
     "shapes",
+    "development",
     "maths"
   ]
 }


### PR DESCRIPTION
Or, maybe it should match the slash/divide of https://lucide.dev/icon/equal-not …?