### PR TITLE
Add strokeWidth type for lucide-vue-next types

### DIFF
--- a/packages/lucide-vue-next/scripts/buildTypes.mjs
+++ b/packages/lucide-vue-next/scripts/buildTypes.mjs
@@ -30,6 +30,7 @@ declare module 'lucide-vue-next'
 // Create interface extending SVGAttributes
 export interface SVGProps extends Partial<SVGAttributes> {
   size?: 24 | number
+  strokeWidth?: number
   absoluteStrokeWidth?: boolean
 }
 


### PR DESCRIPTION
According to the Discord thread. 
`strokeWidth` should be added to the types, because Vue is converting attributes from kebabcase to camelcase.

<img width="750" alt="image" src="https://github.com/lucide-icons/lucide/assets/11825403/6a619ec2-050c-499e-bdf9-5373feabf39b">
