### PR TITLE
Fix `text` icon alignment/add `text-keyword` icon

### DIFF
--- a/icons/text-keyword.json
+++ b/icons/text-keyword.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "find",
+    "search",
+    "selection",
+    "replace"
+  ],
+  "categories": [
+    "text",
+    "cursors"
+  ]
+}

--- a/icons/text-keyword.svg
+++ b/icons/text-keyword.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="6" height="4" x="3" y="4" rx="1" />
-  <path d="M17 6h-4" />
-  <path d="M21 12H3" />
-  <path d="M15 18H3" />
+  <path d="M17 6H3" />
+  <rect width="8" height="4" x="3" y="10" rx="1" />
+  <path d="M21 12h-6" />
+  <path d="M15.1 18H3" />
 </svg>

--- a/icons/text-keyword.svg
+++ b/icons/text-keyword.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="6" height="4" x="3" y="4" rx="1" />
+  <path d="M17 6h-4" />
+  <path d="M21 12H3" />
+  <path d="M15 18H3" />
+</svg>

--- a/icons/text-keyword.svg
+++ b/icons/text-keyword.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M17 6H3" />
+  <path d="M21 6H3" />
   <rect width="8" height="4" x="3" y="10" rx="1" />
   <path d="M21 12h-6" />
-  <path d="M15.1 18H3" />
+  <path d="M21 18H3" />
 </svg>

--- a/icons/text.svg
+++ b/icons/text.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M17 6.1H3" />
-  <path d="M21 12.1H3" />
-  <path d="M15.1 18H3" />
+  <path d="M17 6H3" />
+  <path d="M21 12H3" />
+  <path d="M15 18H3" />
 </svg>


### PR DESCRIPTION
Fixes https://lucide.dev/icon/text, and `text-keyword` like `symbol-keyword` from [codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html).