### PR TITLE
Fix Cursor for Customize and Small Icon Buttons; Reverse Sidebar Open/Close Icon; Remove Unnecessary Customize Button on Mobile Header

### DIFF
--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Link, WrapItem, Text, Wrap, Heading, Box } from '@chakra-ui/react';
+import { Button, Flex, Link, WrapItem, Text, Wrap, Heading, Box, Hide } from '@chakra-ui/react';
 import download from 'downloadjs';
 import { Download, Github } from 'lucide-react';
 import NextLink from 'next/link';
@@ -166,9 +166,11 @@ const Header = ({ data }: HeaderProps) => {
               Download all
             </Button>
           </WrapItem>
-          <WrapItem>
-            <IconCustomizerDrawer />
-          </WrapItem>
+          <Hide below='md'>
+            <WrapItem>
+                <IconCustomizerDrawer />
+            </WrapItem>
+          </Hide>
           <WrapItem>
             <Button
               as="a"

--- a/site/src/components/IconCustomizerDrawer.tsx
+++ b/site/src/components/IconCustomizerDrawer.tsx
@@ -43,6 +43,7 @@ export const IconCustomizerDrawer = (props: ButtonProps) => {
           as="a"
           leftIcon={<Edit />}
           size="lg"
+          cursor={'pointer'}
           onClick={() => setShowCustomize(true)}
           {...props}
         >Customize</Button>
@@ -52,6 +53,7 @@ export const IconCustomizerDrawer = (props: ButtonProps) => {
           aria-label='Customize'
           variant="solid"
           color="current"
+          cursor={'pointer'}
           onClick={() => setShowCustomize(true)}
           icon={<Edit />}
           {...props}

--- a/site/src/components/IconOverview.tsx
+++ b/site/src/components/IconOverview.tsx
@@ -32,7 +32,7 @@ const IconOverview = ({ data, categories }: IconOverviewProps): JSX.Element => {
     }
   }, [])
 
-  const SidebarIcon = sidebarOpen ? SidebarClose : SidebarOpen;
+  const SidebarIcon = typeof sidebarOpen !== 'undefined' ? (sidebarOpen ? SidebarClose : SidebarOpen) : SidebarClose;
 
   const searchResults = useSearch(query, data, [
     { name: 'name', weight: 2 },

--- a/site/src/components/IconOverview.tsx
+++ b/site/src/components/IconOverview.tsx
@@ -32,7 +32,7 @@ const IconOverview = ({ data, categories }: IconOverviewProps): JSX.Element => {
     }
   }, [])
 
-  const SidebarIcon = sidebarOpen ? SidebarOpen : SidebarClose;
+  const SidebarIcon = sidebarOpen ? SidebarClose : SidebarOpen;
 
   const searchResults = useSearch(query, data, [
     { name: 'name', weight: 2 },

--- a/site/src/components/IconOverview.tsx
+++ b/site/src/components/IconOverview.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, IconButton, HStack } from '@chakra-ui/react';
+import { Box, Text, IconButton, HStack, useBreakpointValue } from '@chakra-ui/react';
 import React, { memo, useEffect, useState } from 'react';
 import useSearch from '../lib/useSearch';
 import IconList from './IconList';
@@ -32,7 +32,8 @@ const IconOverview = ({ data, categories }: IconOverviewProps): JSX.Element => {
     }
   }, [])
 
-  const SidebarIcon = typeof sidebarOpen !== 'undefined' ? (sidebarOpen ? SidebarClose : SidebarOpen) : SidebarClose;
+  const breakpointValue = useBreakpointValue({ base: false, md: true });
+  const SidebarIcon = sidebarOpen || (breakpointValue && sidebarOpen === undefined) ? SidebarClose : SidebarOpen;
 
   const searchResults = useSearch(query, data, [
     { name: 'name', weight: 2 },


### PR DESCRIPTION
Hey,

the `Customize` Button had not the right cursor (same for the small Icon Button).

Before:
![image](https://github.com/lucide-icons/lucide/assets/987947/84c3f91d-997b-49b1-9e6c-2c7546eab472)
![image](https://github.com/lucide-icons/lucide/assets/987947/9554d39e-6313-47e2-908c-09a4ca85e47f)


After:
![image](https://github.com/lucide-icons/lucide/assets/987947/5b203d17-f057-49f8-93ac-8c5bb5bb8247)
![image](https://github.com/lucide-icons/lucide/assets/987947/17e1ef72-6841-41ff-beec-945e885a9e2e)

And I reversed the Sidebar Open/Close Icon, since it makes more sense this way.

**Before:**

To open the sidebar:
![image](https://github.com/lucide-icons/lucide/assets/987947/ddddc66f-00d0-4724-b398-a3e0b14cdf07)
To close the sidebar:
![image](https://github.com/lucide-icons/lucide/assets/987947/7ba71342-1267-4912-b8f2-fc5b303fb7a3)


**After:**

To open the sidebar:
![image](https://github.com/lucide-icons/lucide/assets/987947/01335dea-c253-45d8-b0c6-654a9d0240bb)
To close the sidebar: 
![image](https://github.com/lucide-icons/lucide/assets/987947/fa1874d5-eae9-4759-a89a-d8fd765cfa31)


Before/After:
![before](https://github.com/lucide-icons/lucide/assets/987947/18dcfdaa-a622-4951-8d1c-4802b2130338)
![after](https://github.com/lucide-icons/lucide/assets/987947/c105ba88-447b-472e-9895-91745e5dd625)

I also think that the `Customize` Button in the `Header` is not necessary (on mobile), because only the Icon is shown with a different button height, this looks weird and there is also a second `Customize` Button just below, with the same functionality.

Before:
![image](https://github.com/lucide-icons/lucide/assets/987947/8abc808c-2585-43f1-871f-82ee3397d76c)

After:
![image](https://github.com/lucide-icons/lucide/assets/987947/6b07b3af-d35a-4a1f-a59c-97e6fcc6fc22)
