### PR TITLE
add missing key for default menu items

### DIFF
--- a/site/src/components/MobileMenu.tsx
+++ b/site/src/components/MobileMenu.tsx
@@ -53,7 +53,7 @@ const MobileMenu = ({ children }: { children?: ReactNode }): JSX.Element => {
                 );
               }
               return (
-                <NextLink href={menuItem.href} passHref>
+                <NextLink href={menuItem.href} passHref key={menuItem.name}>
                   <Link fontSize="lg" fontWeight="bold" display="block" mb={2}>
                     {menuItem.name}
                   </Link>

--- a/site/src/pages/docs/index.tsx
+++ b/site/src/pages/docs/index.tsx
@@ -42,7 +42,7 @@ const DocPage = ({ doc, data }) => {
         <Box maxWidth="xl" width='100%' marginX='auto'>
           <MDXRemote {...doc} data={data} components={mdxComponents} />
 
-          { nextPage.map((page, i) => (
+          { nextPage.map((page) => (
             <Link href={`docs/${page}`}>
               <Button
                 variant="ghost"
@@ -54,7 +54,7 @@ const DocPage = ({ doc, data }) => {
                 minWidth={240}
                 marginTop={6}
                 rightIcon={<ArrowRight />}
-                key={i}
+                key={page}
                 >
                   <Text fontSize={19} fontWeight="bold" textTransform="capitalize">
                     {page}

--- a/site/src/pages/docs/index.tsx
+++ b/site/src/pages/docs/index.tsx
@@ -42,7 +42,7 @@ const DocPage = ({ doc, data }) => {
         <Box maxWidth="xl" width='100%' marginX='auto'>
           <MDXRemote {...doc} data={data} components={mdxComponents} />
 
-          { nextPage.map((page) => (
+          { nextPage.map((page, i) => (
             <Link href={`docs/${page}`}>
               <Button
                 variant="ghost"
@@ -54,6 +54,7 @@ const DocPage = ({ doc, data }) => {
                 minWidth={240}
                 marginTop={6}
                 rightIcon={<ArrowRight />}
+                key={i}
                 >
                   <Text fontSize={19} fontWeight="bold" textTransform="capitalize">
                     {page}


### PR DESCRIPTION
The external `Link` has a `key` property ( https://github.com/lucide-icons/lucide/blob/main/site/src/components/MobileMenu.tsx#L49 ), but not the default `Link`, this can cause a warning (like: `Warning: Each child in a list should have a unique "key" prop.`).