### PR TITLE
Add `play-square` icon

### DIFF
--- a/icons/play-square.json
+++ b/icons/play-square.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "music",
+    "audio",
+    "video",
+    "start",
+    "run"
+  ],
+  "categories": [
+    "arrows",
+    "multimedia"
+  ]
+}

--- a/icons/play-square.svg
+++ b/icons/play-square.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <polygon points="9 8 15 12 9 16" />
+</svg>

--- a/icons/play-square.svg
+++ b/icons/play-square.svg
@@ -10,5 +10,5 @@
   stroke-linejoin="round"
 >
   <rect width="18" height="18" x="3" y="3" rx="2" />
-  <polygon points="9 8 15 12 9 16" />
+  <path d="m9 8 6 4-6 4Z" />
 </svg>

--- a/icons/play.json
+++ b/icons/play.json
@@ -2,6 +2,8 @@
   "$schema": "../icon.schema.json",
   "tags": [
     "music",
+    "audio",
+    "video",
     "start",
     "run"
   ],


### PR DESCRIPTION
Generic ‘play video’ icon, especially since https://lucide.dev/icon/youtube will be [removed soon](https://github.com/lucide-icons/lucide/issues/94)…