### PR TITLE
Optimise/refine/add `*box`/`chest` icons

### DIFF
--- a/icons/briefcase-plus.json
+++ b/icons/briefcase-plus.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "healthcare",
+    "first aid kit",
+    "paramedic",
+    "medkit",
+    "medikit",
+    "medpack",
+    "medicine",
+    "pharmacy",
+    "pharmaceutical",
+    "add",
+    "cross",
+    "box"
+  ],
+  "categories": [
+    "medical",
+    "gaming"
+  ]
+}

--- a/icons/briefcase-plus.svg
+++ b/icons/briefcase-plus.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  <rect width="20" height="14" x="2" y="7" rx="2" />
+  <path d="M15 14H9" />
+  <path d="M12 11v6" />
+</svg>

--- a/icons/chest.json
+++ b/icons/chest.json
@@ -7,6 +7,7 @@
     "gold",
     "toybox",
     "toolbox",
+    "tool chest",
     "3d",
     "perspective"
   ],

--- a/icons/chest.json
+++ b/icons/chest.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "trunk",
+    "treasure",
+    "loot",
+    "gold",
+    "toybox",
+    "toolbox",
+    "3d",
+    "perspective"
+  ],
+  "categories": [
+    "tools",
+    "gaming"
+  ]
+}

--- a/icons/chest.json
+++ b/icons/chest.json
@@ -8,8 +8,8 @@
     "toybox",
     "toolbox",
     "tool chest",
-    "3d",
-    "perspective"
+    "storage",
+    "container"
   ],
   "categories": [
     "tools",

--- a/icons/chest.svg
+++ b/icons/chest.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M2 10h20" />
-  <path d="M6.5 5H18a4 4 0 0 1 4 4v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9.5a4.5 4.5 0 1 1 9 0V17a2 2 0 0 1-2 2" />
-  <path d="M6 14h1" />
+  <path d="M8 19a2 2 0 0 0 2-2V9a4 4 0 0 0-8 0v8a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a4 4 0 0 0-4-4H6" />
+  <path d="M2 11h20" />
+  <path d="M16 11v3" />
 </svg>

--- a/icons/chest.svg
+++ b/icons/chest.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 10h20" />
+  <path d="M6.5 5H18a4 4 0 0 1 4 4v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9.5a4.5 4.5 0 1 1 9 0V17a2 2 0 0 1-2 2" />
+  <path d="M6 14h1" />
+</svg>

--- a/icons/cross-square.json
+++ b/icons/cross-square.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "healthcare",
+    "first aid kit",
+    "paramedic",
+    "medkit",
+    "medikit",
+    "medpack",
+    "medicine",
+    "pharmacy",
+    "pharmaceutical",
+    "add",
+    "cross",
+    "box"
+  ],
+  "categories": [
+    "medical",
+    "gaming"
+  ]
+}

--- a/icons/cross-square.svg
+++ b/icons/cross-square.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="20" x="2" y="2" rx="3" />
+  <path d="M14 10V7c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v3H7c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1h3v3c0 .6.4 1 1 1h2c.6 0 1-.4 1-1v-3h3c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1Z" />
+</svg>

--- a/icons/cross.json
+++ b/icons/cross.json
@@ -2,9 +2,16 @@
   "$schema": "../icon.schema.json",
   "tags": [
     "healthcare",
-    "first aid"
+    "first aid",
+    "medicine",
+    "pharmacy",
+    "pharmaceutical",
+    "plus",
+    "add"
   ],
   "categories": [
-    "shapes"
+    "shapes",
+    "medical",
+    "maths"
   ]
 }

--- a/icons/lunch-box.json
+++ b/icons/lunch-box.json
@@ -3,7 +3,7 @@
   "tags": [
     "trunk",
     "toolbox",
-    "tool chest",
+    "chest",
     "storage",
     "container",
     "snack",

--- a/icons/lunch-box.json
+++ b/icons/lunch-box.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "trunk",
+    "toolbox",
+    "tool chest",
+    "storage",
+    "container",
+    "snack",
+    "meal",
+    "brunch"
+  ],
+  "categories": [
+    "tools",
+    "food-beverage"
+  ]
+}

--- a/icons/lunch-box.svg
+++ b/icons/lunch-box.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M9 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-  <path d="M6.5 7H18a4 4 0 0 1 4 4v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-7.5a4.5 4.5 0 1 1 9 0V19a2 2 0 0 1-2 2" />
-  <path d="M2 12h20" />
+  <path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  <path d="M8 21a2 2 0 0 0 2-2v-8a4 4 0 0 0-8 0v8a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-8a4 4 0 0 0-4-4H6" />
+  <path d="M2 13h20" />
 </svg>

--- a/icons/lunch-box.svg
+++ b/icons/lunch-box.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  <path d="M6.5 7H18a4 4 0 0 1 4 4v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-7.5a4.5 4.5 0 1 1 9 0V19a2 2 0 0 1-2 2" />
+  <path d="M2 12h20" />
+</svg>

--- a/icons/mailbox-flag.json
+++ b/icons/mailbox-flag.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "post",
+    "inbox",
+    "emails",
+    "messages",
+    "letters",
+    "mailing list",
+    "newsletter"
+  ],
+  "categories": [
+    "mail"
+  ]
+}

--- a/icons/mailbox-flag.svg
+++ b/icons/mailbox-flag.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 5.5A4 4 0 0 1 22 9v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a4 4 0 0 1 8 0v8a2 2 0 0 1-2 2" />
+  <path d="M6 5h4" />
+  <path d="M14 9V5h2v1h-2" />
+</svg>

--- a/icons/mailbox.json
+++ b/icons/mailbox.json
@@ -5,7 +5,9 @@
     "messages",
     "letters",
     "mailing list",
-    "newsletter"
+    "newsletter",
+    "3d",
+    "perspective"
   ],
   "categories": [
     "mail"

--- a/icons/mailbox.json
+++ b/icons/mailbox.json
@@ -1,13 +1,13 @@
 {
   "$schema": "../icon.schema.json",
   "tags": [
+    "post",
+    "inbox",
     "emails",
     "messages",
     "letters",
     "mailing list",
-    "newsletter",
-    "3d",
-    "perspective"
+    "newsletter"
   ],
   "categories": [
     "mail"

--- a/icons/mailbox.svg
+++ b/icons/mailbox.svg
@@ -9,8 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M22 17a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9.5C2 7 4 5 6.5 5H18c2.2 0 4 1.8 4 4v8Z" />
-  <polyline points="15,9 18,9 18,11" />
-  <path d="M6.5 5C9 5 11 7 11 9.5V17a2 2 0 0 1-2 2v0" />
-  <line x1="6" x2="7" y1="10" y2="10" />
+  <path d="M6.5 5H18a4 4 0 0 1 4 4v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9.5a4.5 4.5 0 1 1 9 0V17a2 2 0 0 1-2 2" />
+  <path d="M15 9h3v2" />
+  <path d="M6 10h1" />
 </svg>

--- a/icons/mailbox.svg
+++ b/icons/mailbox.svg
@@ -9,7 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M6.5 5H18a4 4 0 0 1 4 4v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9.5a4.5 4.5 0 1 1 9 0V17a2 2 0 0 1-2 2" />
-  <path d="M15 9h3v2" />
-  <path d="M6 10h1" />
+  <path d="M8 19a2 2 0 0 0 2-2V9a4 4 0 0 0-8 0v8a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a4 4 0 0 0-4-4H6" />
+  <path d="M14 9h4v2h-1V9" />
 </svg>

--- a/icons/toolbox-2.json
+++ b/icons/toolbox-2.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "tools",
+    "trunk",
+    "chest",
+    "storage",
+    "utility",
+    "utilities",
+    "container",
+    "kit",
+    "set"
+  ],
+  "categories": [
+    "tools",
+    "home"
+  ]
+}

--- a/icons/toolbox-2.svg
+++ b/icons/toolbox-2.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  <path d="M4 21a2 2 0 0 1-2-2v-7c0-.6.3-1.3.7-1.7l2.6-2.6C5.7 7.3 6.4 7 7 7h10c.6 0 1.3.3 1.7.7l2.6 2.6c.4.4.7 1.2.7 1.7v7a2 2 0 0 1-2 2Z" />
+  <path d="M2 14h20" />
+  <path d="M9 16v-4" />
+  <path d="M15 16v-4" />
+</svg>

--- a/icons/toolbox.json
+++ b/icons/toolbox.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "tools",
+    "trunk",
+    "chest",
+    "storage",
+    "utility",
+    "utilities",
+    "container",
+    "kit",
+    "set"
+  ],
+  "categories": [
+    "tools",
+    "home"
+  ]
+}

--- a/icons/toolbox.svg
+++ b/icons/toolbox.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  <path d="M8 21a2 2 0 0 0 2-2v-8a4 4 0 0 0-8 0v8a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-8a4 4 0 0 0-4-4H6" />
+  <path d="M2 13h20" />
+  <path d="M14 15v-4" />
+  <path d="M18 15v-4" />
+</svg>


### PR DESCRIPTION
Bunch of options… See column:

1. `briefcase-plus` (first aid kit)
2. `lunch-box`
3. `toolbox`
4. `chest`
5. … `mailbox`

<img width="827" alt="Untitled" src="https://github.com/lucide-icons/lucide/assets/7797479/f4709eec-496a-45a8-96fc-89731525b9ef">
<img width="262" alt="Artboard 1@2x" src="https://github.com/lucide-icons/lucide/assets/7797479/f23c2d82-3260-4421-a92d-65269f65f56b">