### PR TITLE
Optimise/add missing `check`[`-*`] icon/s

### DIFF
--- a/icons/check-circle-2.svg
+++ b/icons/check-circle-2.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z" />
+  <circle cx="12" cy="12" r="10" />
   <path d="m9 12 2 2 4-4" />
 </svg>

--- a/icons/check-circle.svg
+++ b/icons/check-circle.svg
@@ -10,5 +10,5 @@
   stroke-linejoin="round"
 >
   <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-  <polyline points="22 4 12 14.01 9 11.01" />
+  <path d="m9 11 3 3L22 4" />
 </svg>

--- a/icons/check-square-2.json
+++ b/icons/check-square-2.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "done",
+    "todo",
+    "tick",
+    "complete",
+    "task"
+  ],
+  "categories": [
+    "notifications",
+    "shapes"
+  ]
+}

--- a/icons/check-square-2.svg
+++ b/icons/check-square-2.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="m9 12 2 2 4-4" />
+</svg>

--- a/icons/check-square.svg
+++ b/icons/check-square.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="9 11 12 14 22 4" />
+  <path d="m9 11 3 3L22 4" />
   <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
 </svg>

--- a/icons/check.svg
+++ b/icons/check.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="20 6 9 17 4 12" />
+  <path d="M20 6 9 17l-5-5" />
 </svg>


### PR DESCRIPTION
`check-square`[`-2`] was missing, plus these were inconsistent with other `check-`[`*`/`2`] icons, in that the `-2` variation is for when the check extends outside of it’s shape, as opposed to the original where it should be contained inside…