### PR TITLE
Optimise `gem` icon/improve metadata

### DIFF
--- a/icons/gem.json
+++ b/icons/gem.json
@@ -2,12 +2,22 @@
   "$schema": "../icon.schema.json",
   "tags": [
     "diamond",
+    "crystal",
+    "ruby",
+    "jewellery",
     "price",
     "special",
-    "present"
+    "present",
+    "gift",
+    "ring",
+    "wedding",
+    "proposal",
+    "marriage",
+    "rubygems"
   ],
   "categories": [
     "gaming",
-    "money"
+    "money",
+    "development"
   ]
 }

--- a/icons/gem.svg
+++ b/icons/gem.svg
@@ -9,8 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polygon points="6 3 18 3 22 9 12 22 2 9" />
-  <path d="m12 22 4-13-3-6" />
-  <path d="M12 22 8 9l3-6" />
+  <path d="M6 3h12l4 6-10 13L2 9Z" />
+  <path d="M11 3 8 9l4 13 4-13-3-6" />
   <path d="M2 9h20" />
 </svg>


### PR DESCRIPTION
Explored `gem` variants, for reference…

![preview](https://github.com/lucide-icons/lucide/assets/7797479/576b77ca-1437-4a72-b501-0761c2131925)
