### PR TITLE
Add `percent-*` (discount price tag) icons/improve metadata

### DIFF
--- a/icons/badge-percent.json
+++ b/icons/badge-percent.json
@@ -8,12 +8,17 @@
     "verified",
     "unverified",
     "sale",
-    "marketing"
+    "discount",
+    "offer",
+    "marketing",
+    "sticker",
+    "price tag"
   ],
   "categories": [
     "account",
     "social",
     "money",
+    "shopping",
     "maths",
     "shapes"
   ]

--- a/icons/percent-circle.json
+++ b/icons/percent-circle.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "verified",
+    "unverified",
+    "sale",
+    "discount",
+    "offer",
+    "marketing",
+    "sticker",
+    "price tag"
+  ],
+  "categories": [
+    "account",
+    "social",
+    "money",
+    "shopping",
+    "maths",
+    "shapes"
+  ]
+}

--- a/icons/percent-circle.svg
+++ b/icons/percent-circle.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="m15 9-6 6" />
+  <path d="M9 9h.01" />
+  <path d="M15 15h.01" />
+</svg>

--- a/icons/percent-diamond.json
+++ b/icons/percent-diamond.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "verified",
+    "unverified",
+    "sale",
+    "discount",
+    "offer",
+    "marketing",
+    "sticker",
+    "price tag"
+  ],
+  "categories": [
+    "account",
+    "social",
+    "money",
+    "shopping",
+    "maths",
+    "shapes"
+  ]
+}

--- a/icons/percent-diamond.svg
+++ b/icons/percent-diamond.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2.7 10.3a2.41 2.41 0 0 0 0 3.41l7.59 7.59a2.41 2.41 0 0 0 3.41 0l7.59-7.59a2.41 2.41 0 0 0 0-3.41L13.7 2.71a2.41 2.41 0 0 0-3.41 0Z" />
+  <path d="M9.2 9.2h.01" />
+  <path d="m14.5 9.5-5 5" />
+  <path d="M14.7 14.8h.01" />
+</svg>

--- a/icons/percent-square.json
+++ b/icons/percent-square.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "verified",
+    "unverified",
+    "sale",
+    "discount",
+    "offer",
+    "marketing",
+    "sticker",
+    "price tag"
+  ],
+  "categories": [
+    "account",
+    "social",
+    "money",
+    "shopping",
+    "maths",
+    "shapes"
+  ]
+}

--- a/icons/percent-square.svg
+++ b/icons/percent-square.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="m15 9-6 6" />
+  <path d="M9 9h.01" />
+  <path d="M15 15h.01" />
+</svg>

--- a/icons/percent.json
+++ b/icons/percent.json
@@ -5,15 +5,20 @@
     "ericfennis"
   ],
   "tags": [
-    "discount",
     "percentage",
     "modulo",
     "modulus",
     "remainder",
-    "%"
+    "%",
+    "sale",
+    "discount",
+    "offer",
+    "marketing"
   ],
   "categories": [
     "maths",
-    "development"
+    "development",
+    "money",
+    "shopping"
   ]
 }


### PR DESCRIPTION
Came across `percent-circle` in the wild the other day… Although others seem more appropriate representations of discount/price  tag…