### PR TITLE
Fix `circle-dot` icons metadata❗️

### DIFF
--- a/icons/circle-dashed.json
+++ b/icons/circle-dashed.json
@@ -7,11 +7,11 @@
     "issue",
     "draft",
     "code",
+    "coding",
     "version control"
   ],
   "categories": [
     "development",
-    "coding",
     "shapes"
   ]
 }

--- a/icons/circle-dot-dashed.json
+++ b/icons/circle-dot-dashed.json
@@ -7,11 +7,11 @@
     "issue",
     "draft",
     "code",
+    "coding",
     "version control"
   ],
   "categories": [
     "development",
-    "coding",
     "shapes"
   ]
 }

--- a/icons/circle-dot.json
+++ b/icons/circle-dot.json
@@ -9,6 +9,7 @@
     "progress",
     "issue",
     "code",
+    "coding",
     "version control",
     "choices",
     "multiple choice",
@@ -16,7 +17,6 @@
   ],
   "categories": [
     "development",
-    "coding",
     "shapes"
   ]
 }

--- a/icons/refresh-ccw-dot.json
+++ b/icons/refresh-ccw-dot.json
@@ -10,13 +10,13 @@
     "cycle",
     "issue",
     "code",
+    "coding",
     "version control",
     "dashed"
   ],
   "categories": [
     "arrows",
     "development",
-    "coding",
     "shapes"
   ]
 }


### PR DESCRIPTION
Currently breaking the `pre-commit` hook, because the `coding` category was removed since these were originally created, but before they were merged.