### PR TITLE
Add shipping/`container` (Docker) icons

### DIFF
--- a/icons/arrows-up-from-line.json
+++ b/icons/arrows-up-from-line.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley",
+    "ericfennis"
+  ],
+  "tags": [
+    "direction",
+    "orientation",
+    "this way up",
+    "vertical",
+    "package",
+    "box",
+    "fragile",
+    "postage",
+    "shipping"
+  ],
+  "categories": [
+    "arrows",
+    "transportation",
+    "mail"
+  ]
+}

--- a/icons/arrows-up-from-line.svg
+++ b/icons/arrows-up-from-line.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m4 6 3-3 3 3" />
+  <path d="M7 17V3" />
+  <path d="m14 6 3-3 3 3" />
+  <path d="M17 17V3" />
+  <path d="M4 21h16" />
+</svg>

--- a/icons/container.json
+++ b/icons/container.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "tags": [
+    "storage",
+    "shipping",
+    "freight",
+    "supply chain",
+    "docker",
+    "environment",
+    "devops",
+    "code",
+    "coding"
+  ],
+  "categories": [
+    "development",
+    "transportation",
+    "mail"
+  ]
+}

--- a/icons/container.svg
+++ b/icons/container.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 7.7c0-.6-.4-1.2-.8-1.5l-6.3-3.9a1.72 1.72 0 0 0-1.7 0l-10.3 6c-.5.2-.9.8-.9 1.4v6.6c0 .5.4 1.2.8 1.5l6.3 3.9a1.72 1.72 0 0 0 1.7 0l10.3-6c.5-.3.9-1 .9-1.5Z" />
+  <path d="M10 21.9V14L2.1 9.1" />
+  <path d="m10 14 11.9-6.9" />
+  <path d="M14 19.8v-8.1" />
+  <path d="M18 17.5V9.4" />
+</svg>


### PR DESCRIPTION
Shipping/Docker `container` like from [octicons](https://primer.style/design/foundations/icons/container-16). Reuses `cuboid` (brick) from #1142.

`arrows-up-from-line` commonly found on boxes to indicate package orientation. Often paired with a cracked glass icon to indicate fragile… See also `goblet-crack` in https://github.com/lucide-icons/lucide/pull/1374#issuecomment-1595896191.