### PR TITLE
Optimise/add `table` icons/simplify metadata

### DIFF
--- a/icons/table-2.json
+++ b/icons/table-2.json
@@ -6,9 +6,8 @@
     "ericfennis"
   ],
   "tags": [
-    "sheet",
-    "grid",
-    "spreadsheet"
+    "spreadsheet",
+    "grid"
   ],
   "categories": [
     "text",

--- a/icons/table-properties.json
+++ b/icons/table-properties.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "property list",
+    "plist",
+    "spreadsheet",
+    "grid",
+    "dictionary",
+    "object",
+    "hash"
+  ],
+  "categories": [
+    "text",
+    "development",
+    "files"
+  ]
+}

--- a/icons/table-properties.svg
+++ b/icons/table-properties.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 3v18" />
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M21 9H3" />
+  <path d="M21 15H3" />
+</svg>

--- a/icons/table.json
+++ b/icons/table.json
@@ -8,9 +8,8 @@
     "mittalyashu"
   ],
   "tags": [
-    "sheet",
-    "grid",
-    "spreadsheet"
+    "spreadsheet",
+    "grid"
   ],
   "categories": [
     "text",

--- a/icons/table.svg
+++ b/icons/table.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
-  <line x1="3" x2="21" y1="9" y2="9" />
-  <line x1="3" x2="21" y1="15" y2="15" />
-  <line x1="12" x2="12" y1="3" y2="21" />
+  <path d="M12 3v18" />
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M3 9h18" />
+  <path d="M3 15h18" />
 </svg>


### PR DESCRIPTION
`table-properties` is property list (`.plist` file—see below…) But also can more generically represent a table of properties in general…

![plist](https://i0.wp.com/apptyrant.com/wordpress/wp-content/uploads/2023/05/Plistdocumenticonimage.png.webp?resize=300%2C300&ssl=1)