### PR TITLE
Fix lucide-vue-next stroke-width must be number bug

### DIFF
--- a/packages/lucide-vue-next/scripts/buildTypes.mjs
+++ b/packages/lucide-vue-next/scripts/buildTypes.mjs
@@ -30,7 +30,7 @@ declare module 'lucide-vue-next'
 // Create interface extending SVGAttributes
 export interface SVGProps extends Partial<SVGAttributes> {
   size?: 24 | number
-  strokeWidth?: number
+  strokeWidth?: number | string
   absoluteStrokeWidth?: boolean
 }
 


### PR DESCRIPTION
Fix ts compilation and ide prompt stroke-width must be number.
This is a new request. I screwed up the previous one.