### PR TITLE
Add `touch-select` icons

### DIFF
--- a/icons/touch-select-text.json
+++ b/icons/touch-select-text.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "selection",
+    "drag",
+    "highlight",
+    "paragraph",
+    "mobile",
+    "lines"
+  ],
+  "categories": [
+    "text",
+    "tools",
+    "cursors"
+  ]
+}

--- a/icons/touch-select-text.svg
+++ b/icons/touch-select-text.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="4" cy="4" r="2" />
+  <path d="M20 18H6a2 2 0 0 1-2-2V6h14a2 2 0 0 1 2 2Z" />
+  <circle cx="20" cy="20" r="2" />
+  <path d="M12 10H8" />
+  <path d="M16 14H8" />
+</svg>

--- a/icons/touch-select.json
+++ b/icons/touch-select.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley"
+  ],
+  "tags": [
+    "selection",
+    "drag",
+    "highlight",
+    "paragraph",
+    "mobile",
+    "lines"
+  ],
+  "categories": [
+    "text",
+    "tools",
+    "cursors"
+  ]
+}

--- a/icons/touch-select.svg
+++ b/icons/touch-select.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="4" cy="4" r="2" />
+  <path d="M20 18H6a2 2 0 0 1-2-2V6h14a2 2 0 0 1 2 2Z" />
+  <circle cx="20" cy="20" r="2" />
+</svg>


### PR DESCRIPTION
Similar/inspired by ChatGPT mobile…

![IMG_5010](https://github.com/lucide-icons/lucide/assets/7797479/e1efcf11-253d-4492-ba4a-3e7e0a73601e)

---

alts:

![preview](https://github.com/lucide-icons/lucide/assets/7797479/6e5c663f-30f2-4f06-bf0b-fe7bf0531168)
