### PR TITLE
replaced SvelteComponentTyped with SvelteComponent

### DIFF
--- a/packages/lucide-svelte/scripts/buildTypes.mjs
+++ b/packages/lucide-svelte/scripts/buildTypes.mjs
@@ -18,7 +18,7 @@ const writeDeclarationFile = (typesFile, directory, content) => {
 };
 
 const getComponentImport = (componentName) =>
-  `export declare class ${componentName} extends SvelteComponentTyped<IconProps, IconEvents, {}> {}\n`;
+  `export declare class ${componentName} extends SvelteComponent<IconProps, IconEvents, {}> {}\n`;
 
 const ICONS_DIR = path.resolve(currentDir, '../../../icons');
 const TYPES_FILE = 'lucide-svelte.d.ts';
@@ -27,7 +27,7 @@ const TYPES_FILE = 'lucide-svelte.d.ts';
 let declarationFileContent = `\
 /// <reference types="svelte" />
 /// <reference types="svelte-check/dist/src/svelte-jsx" />
-import { SvelteComponentTyped } from "svelte";
+import { SvelteComponent } from "svelte";
 
 interface IconProps extends Partial<svelte.JSX.SVGProps<SVGSVGElement>> {
   color?: string
@@ -41,7 +41,7 @@ interface IconEvents {
   [evt: string]: CustomEvent<any>;
 }
 
-export type Icon = SvelteComponentTyped<IconProps, IconEvents, {}>
+export type Icon = SvelteComponent<IconProps, IconEvents, {}>
 
 // Generated icons
 `;


### PR DESCRIPTION
Closes #1507 

Build it and linked it to a small demo repo and it seems to work as before. 
Maybe we would need to change some documentation for some edge cases? @ericfennis 

On the same note: `SvgProps` is also [deprecated](https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#im-getting-deprecation-warnings-for-sveltejsx--i-want-to-migrate-to-the-new-typings):
<img width="794" alt="image" src="https://github.com/lucide-icons/lucide/assets/72730682/3313fccf-616a-4115-8ac7-59ed3f7d56a8">

Just taking a quick look but couldn't find a replacement in `svelte/elements` so that's something we could add to this PR as well once we find it.