### PR TITLE
Optimize russian-ruble.svg

### DIFF
--- a/icons/russian-ruble.svg
+++ b/icons/russian-ruble.svg
@@ -9,9 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M14 11c5.333 0 5.333-8 0-8" />
-  <path d="M6 11h8" />
+  <path d="M6 11h8a4 4 0 0 0 0-8H9v18" />
   <path d="M6 15h8" />
-  <path d="M9 21V3" />
-  <path d="M9 3h5" />
 </svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] Other: optimization

### Description
I've simply optimised the `russian-ruble` icon, as it was made up of too many path parts.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
