### PR TITLE
Adjust name from "data-lucide-name" to "data-lucide" in documentation

### DIFF
--- a/docs/.vitepress/lib/createCodeExamples.ts
+++ b/docs/.vitepress/lib/createCodeExamples.ts
@@ -24,7 +24,7 @@ const getIconCodes = (): CodeExampleType => {
       codes: [
         {
           language: 'html',
-          code: `<i data-lucide-name="Name"></i>
+          code: `<i data-lucide="Name"></i>
 `,
         },
       ],


### PR DESCRIPTION
Closes #1523 

## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description
Update the HTML examples in the documentation to use the `data-lucide` instead of the deprecated `data-lucide-name` attribute. (updated see #1169)

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
