### PR TITLE
Remove conflicting alias: `slash`

### DIFF
--- a/icons/ban.json
+++ b/icons/ban.json
@@ -3,7 +3,6 @@
   "contributors": [
     "danielbayley"
   ],
-  "aliases": ["slash"],
   "tags": [
     "cancel",
     "no",


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update

### Description
After merging #1241 we have a conflict with alias in `ban.json`. So this is removing this alias.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
