### PR TITLE
fix: jsx type for icons in vue 3

### DIFF
--- a/packages/lucide-vue-next/scripts/buildTypes.mjs
+++ b/packages/lucide-vue-next/scripts/buildTypes.mjs
@@ -24,7 +24,7 @@ const TYPES_FILE = 'lucide-vue-next.d.ts';
 
 // Generates header of d.ts file include some types and functions
 let declarationFileContent = `\
-import { SVGAttributes, FunctionalComponent } from 'vue';
+import { SVGAttributes, DefineComponent } from 'vue';
 declare module 'lucide-vue-next'
 
 // Create interface extending SVGAttributes
@@ -34,7 +34,7 @@ export interface SVGProps extends Partial<SVGAttributes> {
   absoluteStrokeWidth?: boolean
 }
 
-export type Icon = (props: SVGProps) => FunctionalComponent<SVGProps>
+export type Icon = DefineComponent<SVGProps>
 
 // Generated icons
 `;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
Closes #548

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description

Declaring a component as `DefineComponent<Props>` can be correctly recognized by the IDE as a JSX element and provide autocompletion of props.

![usage](https://github.com/lucide-icons/lucide/assets/5101076/be09b7b7-1ac8-46fd-bde8-fcbca17c9d11)

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
