### PR TITLE
feat: changed backdrop color for new icons in group to gray

### DIFF
--- a/docs/.vitepress/api/gh-icon/[...data].get.ts
+++ b/docs/.vitepress/api/gh-icon/[...data].get.ts
@@ -29,7 +29,13 @@ export default eventHandler((event) => {
     const svg = renderToStaticMarkup(createElement(LucideIcon));
     const backdropString = svg.replace(/<svg[^>]*>|<\/svg>/g, '');
 
-    children.push(createElement(Backdrop, { backdropString, src }));
+    children.push(
+      createElement(Backdrop, {
+        backdropString,
+        src,
+        color: name in iconNodes ? 'red' : '#777',
+      })
+    );
   }
 
   const svg = Buffer.from(

--- a/docs/.vitepress/lib/SvgPreview/Backdrop.tsx
+++ b/docs/.vitepress/lib/SvgPreview/Backdrop.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
 interface BackdropProps {
-  src: string
-  backdropString: string
+  src: string;
+  color?: string;
+  backdropString: string;
 }
 
-const Backdrop = ({ src, backdropString }: BackdropProps): JSX.Element => {
+const Backdrop = ({ src, color = 'red', backdropString }: BackdropProps): JSX.Element => {
   return (
     <>
       <defs xmlns="http://www.w3.org/2000/svg">
@@ -16,8 +17,8 @@ const Backdrop = ({ src, backdropString }: BackdropProps): JSX.Element => {
           patternUnits="userSpaceOnUse"
           patternTransform="rotate(45 50 50)"
         >
-          <line stroke="red" strokeWidth={0.1} y2={1} />
-          <line stroke="red" strokeWidth={0.1} y2={1} />
+          <line stroke={color} strokeWidth={0.1} y2={1} />
+          <line stroke={color} strokeWidth={0.1} y2={1} />
         </pattern>
       </defs>
       <mask id="svg-preview-backdrop-mask-outline" maskUnits="userSpaceOnUse">
@@ -29,20 +30,8 @@ const Backdrop = ({ src, backdropString }: BackdropProps): JSX.Element => {
         <g dangerouslySetInnerHTML={{ __html: src }} strokeWidth={2.05} />
         <g strokeWidth={1.75} dangerouslySetInnerHTML={{ __html: backdropString }} />
       </mask>
-      <g
-        strokeWidth={2.25}
-        stroke="url(#pattern)"
-        mask={'url(#svg-preview-backdrop-mask-outline)'}
-      >
-        <rect
-          x="0"
-          y="0"
-          width="24"
-          height="24"
-          fill="url(#pattern)"
-          opacity={0.5}
-          stroke="none"
-        />
+      <g strokeWidth={2.25} stroke="url(#pattern)" mask={'url(#svg-preview-backdrop-mask-outline)'}>
+        <rect x="0" y="0" width="24" height="24" fill="url(#pattern)" opacity={0.5} stroke="none" />
       </g>
       <rect
         x="0"
@@ -58,14 +47,13 @@ const Backdrop = ({ src, backdropString }: BackdropProps): JSX.Element => {
         y="0"
         width="24"
         height="24"
-        fill="red"
+        fill={color}
         opacity={0.5}
         stroke="none"
         mask={'url(#svg-preview-backdrop-mask-fill)'}
       />
     </>
-  )
-}
-
+  );
+};
 
 export default Backdrop;


### PR DESCRIPTION
Now it is red if the icon has changed and gray if the icon is a new icon in the same group.


## Example of adding a new icon that starts with `globe-`

<img src="https://github.com/lucide-icons/lucide/assets/25524993/758e921a-de80-40b4-933d-f0a339ed97bf" width="400px" height="400px"/>
