### PR TITLE
Update README.md

### DIFF
--- a/packages/lucide-static/README.md
+++ b/packages/lucide-static/README.md
@@ -135,7 +135,7 @@ and update the svg as follows
 ### Icon Font
 
 ```css
-@import ('~lucide-static/font/Lucide.css');
+@import ('~lucide-static/font/lucide.css');
 ```
 
 ```html


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description

The readme lists the url below with uppercase L while the file is lowercase lucide.css making it fail on certain loaders like the one used by Storybook on MacOS.
```
@import ('~lucide-static/font/Lucide.css');
```
The fix is simply to use the correct name.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
