### PR TITLE
Cleanup tools

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,4 +7,5 @@ node_modules
 .eslintrc.js
 docs/images
 docs/guide/basics/examples
+docs/guide/advanced/examples
 packages/lucide-react/dynamicIconImports.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,20 +7,12 @@ module.exports = {
     node: true,
   },
   extends: ['airbnb-base', 'prettier'],
-  plugins: ['import', 'prettier', '@html-eslint'],
+  plugins: ['import', '@html-eslint'],
   rules: {
     'no-console': 'off',
     'no-param-reassign': 'off',
     'no-shadow': 'off',
     'no-use-before-define': 'off',
-    'prettier/prettier': [
-      'error',
-      {
-        singleQuote: true,
-        trailingComma: 'all',
-        printWidth: 100
-      },
-    ],
     'import/no-extraneous-dependencies': [
       'error',
       { devDependencies: ['**/*.test.js', '**/*.spec.js', './scripts/**'] },
@@ -46,7 +38,6 @@ module.exports = {
       files: ['./icons/*.svg'],
       parser: '@html-eslint/parser',
       rules: {
-        'prettier/prettier': 'off',
         '@html-eslint/require-doctype': 'off',
         '@html-eslint/no-duplicate-attrs': 'error',
         '@html-eslint/no-inline-styles': 'error',

--- a/.github/actions/build-and-test.yml
+++ b/.github/actions/build-and-test.yml
@@ -18,7 +18,7 @@ runs:
       name: Install pnpm
       id: pnpm-install
       with:
-        version: 7
+        version: 8
         run_install: false
 
     - name: Get pnpm store directory

--- a/.github/actions/check-icons.yml
+++ b/.github/actions/check-icons.yml
@@ -18,7 +18,7 @@ runs:
       name: Install pnpm
       id: pnpm-install
       with:
-        version: 7
+        version: 8
         run_install: false
 
     - name: Get pnpm store directory

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,16 @@
 pnpm-lock.yaml
+
+# lucide-angular
+packages/lucide-angular/.angular/cache
+
+# lucide-static
+packages/lucide-static/icons
+packages/lucide-static/lib
+packages/lucide-static/sprite.svg
+packages/lucide-static/tags.json
+packages/lucide-static/icon-nodes.json
+packages/lucide-static/font
+
+# lucide-svelte
+packages/lucide-svelte/src/icons/*.svelte
+packages/lucide-svelte/.svelte-kit

--- a/docs/guide/advanced/examples/global-styling-absolute-strokewidth-example/icon.css
+++ b/docs/guide/advanced/examples/global-styling-absolute-strokewidth-example/icon.css
@@ -11,6 +11,6 @@
 .app {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 1fr 1fr 1fr
+  grid-template-rows: 1fr 1fr 1fr;
   gap: 6px;
 }

--- a/docs/guide/advanced/examples/global-styling-css-example/icon.css
+++ b/docs/guide/advanced/examples/global-styling-css-example/icon.css
@@ -9,6 +9,6 @@
 .app {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 1fr 1fr 1fr
+  grid-template-rows: 1fr 1fr 1fr;
   gap: 6px;
 }

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,23 @@
+/**
+ * @param {string[]} filenames
+ * @returns {string}
+ */
+const filenamesToAjvOption = (filenames) => filenames.map((filename) => `-d ${filename}`).join(' ');
+
+/** @satisfies {import('lint-staged').Config} */
+const config = {
+  'icons/*.svg': [
+    'node ./scripts/optimizeStagedSvgs.mjs',
+    'node ./scripts/generateNextJSAliases.mjs',
+  ],
+  'icons/*.json': (filenames) => [
+    `ajv --spec=draft2020 -s icon.schema.json ${filenamesToAjvOption(filenames)}`,
+    `prettier --write ${filenames.join(' ')}`,
+  ],
+  'categories/*.json': (filenames) => [
+    `ajv --spec=draft2020 -s category.schema.json ${filenamesToAjvOption(filenames)}`,
+    `prettier --write ${filenames.join(' ')}`,
+  ],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
     "generate:nextJSAliases": "node ./scripts/generateNextJSAliases.mjs",
     "postinstall": "husky install",
     "lint:es": "eslint .",
+    "lint:format": "prettier \"**/*.{js,mjs,ts,jsx,tsx,html,css,scss,json,yml,yaml}\" --write",
     "lint:json:icons": "ajv --spec=draft2020 -s icon.schema.json -d 'icons/*.json' > /dev/null",
     "lint:json:categories": "ajv --spec=draft2020 -s category.schema.json -d 'categories/*.json' > /dev/null",
     "lint:json": "pnpm run lint:json:icons && pnpm run lint:json:categories",
-    "lint": "pnpm lint:es && pnpm lint:json",
+    "lint": "pnpm lint:es && pnpm lint:format && pnpm lint:json",
     "prepare": "husky install",
     "gi": "node ./scripts/generate/generateIcons.mjs"
   },
@@ -52,7 +53,6 @@
     "eslint-import-resolver-custom-alias": "^1.3.2",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.3",
     "lint-staged": "^13.3.0",
     "minimist": "^1.2.8",
@@ -71,11 +71,11 @@
     ],
     "icons/*.json": [
       "ajv --spec=draft2020 -s icon.schema.json -d",
-      "prettier --write --print-width=0"
+      "prettier --write"
     ],
     "categories/*.json": [
       "ajv --spec=draft2020 -s category.schema.json -d",
-      "prettier --write --print-width=0"
+      "prettier --write"
     ]
   },
   "packageManager": "pnpm@8.7.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "svgo": "^3.1.0",
     "svgson": "^5.3.1"
   },
-  "packageManager": "pnpm@8.7.1",
+  "packageManager": "pnpm@8.13.1+sha256.9e5f62ce5f2b7d4ceb3c2848f41cf0b33032c24d683c7088b53f62b1885fb246",
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/package.json
+++ b/package.json
@@ -64,20 +64,6 @@
     "svgo": "^3.1.0",
     "svgson": "^5.3.1"
   },
-  "lint-staged": {
-    "icons/*.svg": [
-      "node ./scripts/optimizeStagedSvgs.mjs",
-      "node ./scripts/generateNextJSAliases.mjs"
-    ],
-    "icons/*.json": [
-      "ajv --spec=draft2020 -s icon.schema.json -d",
-      "prettier --write"
-    ],
-    "categories/*.json": [
-      "ajv --spec=draft2020 -s category.schema.json -d",
-      "prettier --write"
-    ]
-  },
   "packageManager": "pnpm@8.7.1",
   "pnpm": {
     "peerDependencyRules": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "minimist": "^1.2.8",
     "node-fetch": "^3.3.2",
     "p-memoize": "^7.1.1",
-    "prettier": "2.7.1",
+    "prettier": "3.1.1",
     "semver": "^7.5.4",
     "simple-git": "^3.21.0",
     "svgo": "^3.1.0",

--- a/packages/lucide-angular/package.json
+++ b/packages/lucide-angular/package.json
@@ -34,7 +34,6 @@
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "test:watch": "ng test",
     "lint": "npx eslint 'src/**/*.{js,jsx,ts,tsx,html,css,scss}' --quiet --fix",
-    "format": "npx prettier 'src/**/*.{js,jsx,ts,tsx,html,css,scss}' --write",
     "e2e": "ng e2e",
     "version": "pnpm version --git-tag-version=false"
   },
@@ -59,7 +58,6 @@
     "@typescript-eslint/parser": "5.48.2",
     "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-prettier": "^4.2.1",
     "jasmine-core": "~4.0.0",
     "jasmine-spec-reporter": "~7.0.0",
     "karma": "~6.3.0",

--- a/packages/lucide-vue/src/createVueComponent.ts
+++ b/packages/lucide-vue/src/createVueComponent.ts
@@ -59,7 +59,7 @@ export default (iconName: string, iconNode: IconNode): Component => ({
     return createElement(
       'svg',
       {
-        // eslint-disable-next-line prettier/prettier
+        // prettier-ignore
         class: [defaultClass, data.class, data.staticClass, data.attrs && data.attrs.class].filter(Boolean),
         style: [data.style, data.staticStyle, data.attrs && data.attrs.style].filter(Boolean),
         attrs: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,6 @@ importers:
       eslint-plugin-import:
         specifier: ^2.29.1
         version: 2.29.1(@typescript-eslint/parser@6.14.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.56.0)(prettier@2.7.1)
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -272,9 +269,6 @@ importers:
       eslint-config-prettier:
         specifier: ^8.5.0
         version: 8.9.0(eslint@8.46.0)
-      eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.9.0)(eslint@8.46.0)(prettier@2.8.8)
       jasmine-core:
         specifier: ~4.0.0
         version: 4.0.1
@@ -3336,26 +3330,6 @@ packages:
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
     dev: true
 
-  /@babel/plugin-transform-classes@7.22.6:
-    resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.22.15
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
-      '@babel/helper-split-export-declaration': 7.22.6
-      globals: 11.12.0
-    dev: true
-
   /@babel/plugin-transform-classes@7.22.6(@babel/core@7.16.12):
     resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
     engines: {node: '>=6.9.0'}
@@ -3389,8 +3363,8 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.22.15
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
@@ -3703,7 +3677,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-compilation-targets': 7.22.15
-      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -3929,7 +3903,7 @@ packages:
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.16.12)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.22.15
     dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.22.9):
@@ -11240,12 +11214,12 @@ packages:
       '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-classes': 7.22.6
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.22.9)
       '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.23.3)
       '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.16.12)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.22.9)
@@ -14272,40 +14246,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.10.0)(eslint@8.56.0)(prettier@2.7.1):
-    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      eslint: '>=7.28.0'
-      eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.56.0
-      eslint-config-prettier: 8.10.0(eslint@8.56.0)
-      prettier: 2.7.1
-      prettier-linter-helpers: 1.0.0
-    dev: true
-
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.9.0)(eslint@8.46.0)(prettier@2.8.8):
-    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      eslint: '>=7.28.0'
-      eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.46.0
-      eslint-config-prettier: 8.9.0(eslint@8.46.0)
-      prettier: 2.8.8
-      prettier-linter-helpers: 1.0.0
-    dev: true
-
   /eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -14726,10 +14666,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
-
-  /fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
     dev: true
 
   /fast-fifo@1.3.2:
@@ -17586,6 +17522,7 @@ packages:
   /lru-cache@10.0.3:
     resolution: {integrity: sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==}
     engines: {node: 14 || >=16.14}
+    dev: false
 
   /lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
@@ -17938,12 +17875,12 @@ packages:
       '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.22.9)
-      '@babel/plugin-transform-classes': 7.22.6
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.22.9)
       '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.23.3)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.16.12)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.22.9)
@@ -20512,13 +20449,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      fast-diff: 1.3.0
-    dev: true
-
   /prettier@2.7.1:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
@@ -21459,19 +21389,6 @@ packages:
       '@types/node': 12.20.55
       rollup: 2.79.1
       source-map-resolve: 0.6.0
-    dev: true
-
-  /rollup-plugin-svelte@7.1.6(rollup@3.27.0)(svelte@4.1.2):
-    resolution: {integrity: sha512-nVFRBpGWI2qUY1OcSiEEA/kjCY2+vAjO9BI8SzA7NRrh2GTunLd6w2EYmnMt/atgdg8GvcNjLsmZmbQs/u4SQA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      rollup: '>=2.0.0'
-      svelte: '>=3.5.0'
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      resolve.exports: 2.0.2
-      rollup: 3.27.0
-      svelte: 4.1.2
     dev: true
 
   /rollup-plugin-visualizer@5.11.0(rollup@3.29.4):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1
       prettier:
-        specifier: 2.7.1
-        version: 2.7.1
+        specifier: 3.1.1
+        version: 3.1.1
       semver:
         specifier: ^7.5.4
         version: 7.5.4
@@ -3919,7 +3919,7 @@ packages:
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.22.20
     dev: true
 
   /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.16.12):
@@ -20457,6 +20457,12 @@ packages:
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
+  /prettier@3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: true
 

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,15 @@
+const config = {
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+  overrides: [
+    {
+      files: ['icons/*.json', 'categories/*.json'],
+      options: {
+        printWidth: 0,
+      },
+    },
+  ],
+};
+
+module.exports = config;

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,3 +1,4 @@
+/** @satisfies {import('prettier').Config} */
 const config = {
   singleQuote: true,
   trailingComma: 'all',
@@ -12,4 +13,4 @@ const config = {
   ],
 };
 
-module.exports = config;
+export default config;

--- a/scripts/generateSuperSVG.mjs
+++ b/scripts/generateSuperSVG.mjs
@@ -1,6 +1,6 @@
 import path from 'path';
 import { stringify, parseSync } from 'svgson';
-import prettier from 'prettier';
+import * as prettier from 'prettier';
 import { appendFile, readSvgDirectory, getCurrentDirPath } from './helpers.mjs';
 
 import readSvgs from '../packages/lucide-static/scripts/readSvgs.mjs';
@@ -10,7 +10,7 @@ const currentDir = getCurrentDirPath(import.meta.url);
 const ICONS_DIR = path.resolve('icons');
 const PACKAGE_DIR = path.resolve(currentDir);
 
-export default function generateSprite(svgs, packageDir) {
+async function generateSprite(svgs, packageDir) {
   const symbols = svgs.map(({ parsedSvg }, index) => {
     const itemsPerRow = 10;
     const numInRow = index % itemsPerRow;
@@ -37,7 +37,7 @@ export default function generateSprite(svgs, packageDir) {
   };
 
   const spriteSvg = stringify(spriteSvgObject);
-  const prettifiedSprite = prettier.format(spriteSvg, { parser: 'babel' }).replace(/;/g, '');
+  const prettifiedSprite = (await prettier.format(spriteSvg, { parser: 'babel' })).replace(/;/g, '');
 
   const xmlMeta = `<?xml version="1.0" encoding="utf-8"?>\n`;
 
@@ -54,4 +54,4 @@ const parsedSvgs = svgs.map(({ name, contents }) => ({
   parsedSvg: parseSync(contents),
 }));
 
-generateSprite(parsedSvgs, PACKAGE_DIR);
+await generateSprite(parsedSvgs, PACKAGE_DIR);

--- a/scripts/render/processSvg.mjs
+++ b/scripts/render/processSvg.mjs
@@ -1,5 +1,5 @@
 import {optimize} from 'svgo';
-import prettier from 'prettier';
+import * as prettier from 'prettier';
 import {parseSync, stringify} from 'svgson';
 import DEFAULT_ATTRS from './default-attrs.json' assert { type: 'json' };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: Clean up about tools

### Description
I haven't applied formatting yet to make it easier to view the diff. If you agree with this PR, I can also include formatting in the commit.
- Bump pnpm version
- Use prettier instead of eslint-plugin-prettier for formatting (It is possible to format files other than JS as well)
- Upgrade root prettier version to 3
- Fix some errors about tools

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
