### PR TITLE
fix: Exports `Icon` type 

### DIFF
--- a/packages/lucide-svelte/src/defaultAttributes.ts
+++ b/packages/lucide-svelte/src/defaultAttributes.ts
@@ -1,4 +1,4 @@
-import type { Attrs } from "./types";
+import type { Attrs } from './types.js';
 
 const defaultAttributes: Attrs = {
   xmlns: 'http://www.w3.org/2000/svg',

--- a/packages/lucide-svelte/src/lucide-svelte.ts
+++ b/packages/lucide-svelte/src/lucide-svelte.ts
@@ -2,3 +2,4 @@ export * from './icons/index.js';
 export * as icons from './icons/index.js';
 export * from './aliases.js';
 export { default as defaultAttributes } from './defaultAttributes.js';
+export type { Icon } from './types.js';

--- a/packages/lucide-svelte/src/types.ts
+++ b/packages/lucide-svelte/src/types.ts
@@ -1,13 +1,24 @@
+import type { SvelteComponent } from 'svelte';
 import type { SVGAttributes, SvelteHTMLElements } from 'svelte/elements';
 
-type SVGAttrs = SVGAttributes<SVGSVGElement>;
+export type Attrs = SVGAttributes<SVGSVGElement>;
 
-export type IconNode = [elementName: keyof SvelteHTMLElements, attrs: SVGAttrs][];
+export type IconNode = [elementName: keyof SvelteHTMLElements, attrs: Attrs][];
 
-export interface IconProps extends SVGAttrs {
+export interface IconProps extends Attrs {
   color?: string;
   size?: number | string;
   strokeWidth?: number | string;
   absoluteStrokeWidth?: boolean;
   class?: string;
 }
+
+type IconEvents = {
+  [evt: string]: CustomEvent<any>;
+};
+
+type IconSlots = {
+  default: {};
+};
+
+export type Icon = SvelteComponent<IconProps, IconEvents, IconSlots>;


### PR DESCRIPTION
Closes #1761 

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
`scripts/buildTypes.mjs` previously would add the `Icon` type into `lucide-svelte.d.ts` file during builds. This PR simply adds the type and exports it normally. I also noticed that the import path for `Attrs` didn't have an extension, so I added it there as well.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
