### PR TITLE
docs: Add Lucide-Svelte icon import instructions and type definitions

### DIFF
--- a/docs/guide/packages/lucide-svelte.md
+++ b/docs/guide/packages/lucide-svelte.md
@@ -95,13 +95,13 @@ The package includes type definitions for all icons. This is useful if you want 
   import type { ComponentType } from 'svelte';
   import type { Icon } from 'lucide-svelte';
 
-  type Route = {
+  type MenuItem = {
     name: string;
     href: string;
     icon: ComponentType<Icon>;
   }
 
-  const menuItems: Route[] = [
+  const menuItems: MenuItem[] = [
     {
       name: 'Home',
       href: '/',
@@ -137,13 +137,13 @@ The package includes type definitions for all icons. This is useful if you want 
   import Cog from 'lucide-svelte/icons/cog';
 
   /**
-   * @typedef {Object} Route
+   * @typedef {Object} MenuItem
    * @property {string} name
    * @property {string} href
    * @property {import('svelte').ComponentType<import('lucide-svelte').Icon>} icon
    */
 
-  /** @type {Route[]} */
+  /** @type {MenuItem[]} */
   const menuItems = [
     {
       name: 'Home',

--- a/docs/guide/packages/lucide-svelte.md
+++ b/docs/guide/packages/lucide-svelte.md
@@ -48,14 +48,24 @@ Additional props can be passed to adjust the icon:
 <Camera color="#ff3e98" />
 ```
 
+For faster builds and load times, you can import icons directly from the `lucide-svelte/icons` directory:
+
+```svelte
+<script>
+  import AlertCircle from 'lucide-svelte/icons/alert-circle';
+</script>
+
+<AlertCircle color="#ff3e98" />
+```
+
 ## Props
 
 | name                  | type      | default      |
 | --------------------- | --------- | ------------ |
-| `size`                | *number*  | 24           |
-| `color`               | *string*  | currentColor |
-| `strokeWidth`         | *number*  | 2            |
-| `absoluteStrokeWidth` | *boolean* | false        |
+| `size`                | _number_  | 24           |
+| `color`               | _string_  | currentColor |
+| `strokeWidth`         | _number_  | 2            |
+| `absoluteStrokeWidth` | _boolean_ | false        |
 
 ### Applying props
 
@@ -70,6 +80,90 @@ To customize the appearance of an icon, you can pass custom properties as props 
 ```
 
 This results a filled phone icon.
+
+## Types
+
+The package includes type definitions for all icons. This is useful if you want to dynamically load icons.
+
+### TypeScript Example
+
+```svelte
+<script lang="ts">
+  import type { ComponentType } from 'svelte';
+  import { Home, Library, Cog } from 'lucide-svelte';
+  import type { Icon } from 'lucide-svelte';
+
+  type Route = {
+    name: string;
+    href: string;
+    icon: ComponentType<Icon>;
+  }
+
+  const routes: Route[] = [
+    {
+      name: 'Home',
+      href: '/',
+      icon: Home,
+    },
+    {
+      name: 'Blog',
+      href: '/blog',
+      icon: Library,
+    },
+    {
+      name: 'Projects',
+      href: '/projects',
+      icon: Cog,
+    }
+  ];
+</script>
+
+...
+{#each routes as route}
+  <a href={route.href}>
+   <svelte:component this={route.icon} />
+    <span>{route.name}</span>
+  </a>
+{/each}
+...
+```
+
+### JSDoc Example
+
+```svelte
+<script>
+  import { Home, Library, Cog } from 'lucide-svelte';
+
+  /**
+   * @typedef {Object} Route
+   * @property {string} name
+   * @property {string} href
+   * @property {import('svelte').ComponentType<import('lucide-svelte').Icon>} icon
+   */
+
+  /** @type {Route[]} */
+  const routes = [
+    {
+      name: 'Home',
+      href: '/',
+      icon: Home,
+    },
+    {
+      name: 'Blog',
+      href: '/blog',
+      icon: Library,
+    },
+    {
+      name: 'Projects',
+      href: '/projects',
+      icon: Cog,
+    }
+  ];
+</script>
+
+...
+
+```
 
 ## One generic icon component
 
@@ -99,4 +193,3 @@ The example below imports all ES Modules, so exercise caution when using it. Imp
 
 <LucideIcon name="Menu" />
 ```
-

--- a/docs/guide/packages/lucide-svelte.md
+++ b/docs/guide/packages/lucide-svelte.md
@@ -89,7 +89,9 @@ The package includes type definitions for all icons. This is useful if you want 
 
 ```svelte
 <script lang="ts">
-  import { Home, Library, Cog } from 'lucide-svelte';
+  import Home from 'lucide-svelte/icons/home';
+  import Library from 'lucide-svelte/icons/library';
+  import Cog from 'lucide-svelte/icons/cog';
   import type { ComponentType } from 'svelte';
   import type { Icon } from 'lucide-svelte';
 
@@ -99,7 +101,7 @@ The package includes type definitions for all icons. This is useful if you want 
     icon: ComponentType<Icon>;
   }
 
-  const routes: Route[] = [
+  const menuItems: Route[] = [
     {
       name: 'Home',
       href: '/',
@@ -118,10 +120,10 @@ The package includes type definitions for all icons. This is useful if you want 
   ];
 </script>
 
-{#each routes as route}
-  <a href={route.href}>
-   <svelte:component this={route.icon} />
-    <span>{route.name}</span>
+{#each menuItems as item}
+  <a href={item.href}>
+   <svelte:component this={item.icon} />
+    <span>{item.name}</span>
   </a>
 {/each}
 ```
@@ -130,7 +132,9 @@ The package includes type definitions for all icons. This is useful if you want 
 
 ```svelte
 <script>
-  import { Home, Library, Cog } from 'lucide-svelte';
+  import Home from 'lucide-svelte/icons/home';
+  import Library from 'lucide-svelte/icons/library';
+  import Cog from 'lucide-svelte/icons/cog';
 
   /**
    * @typedef {Object} Route
@@ -140,7 +144,7 @@ The package includes type definitions for all icons. This is useful if you want 
    */
 
   /** @type {Route[]} */
-  const routes = [
+  const menuItems = [
     {
       name: 'Home',
       href: '/',

--- a/docs/guide/packages/lucide-svelte.md
+++ b/docs/guide/packages/lucide-svelte.md
@@ -83,14 +83,14 @@ This results a filled phone icon.
 
 ## Types
 
-The package includes type definitions for all icons. This is useful if you want to dynamically load icons.
+The package includes type definitions for all icons. This is useful if you want to dynamically load icons with the `svelte:component` directive whether you are using TypeScript or JSDoc.
 
 ### TypeScript Example
 
 ```svelte
 <script lang="ts">
-  import type { ComponentType } from 'svelte';
   import { Home, Library, Cog } from 'lucide-svelte';
+  import type { ComponentType } from 'svelte';
   import type { Icon } from 'lucide-svelte';
 
   type Route = {
@@ -118,14 +118,12 @@ The package includes type definitions for all icons. This is useful if you want 
   ];
 </script>
 
-...
 {#each routes as route}
   <a href={route.href}>
    <svelte:component this={route.icon} />
     <span>{route.name}</span>
   </a>
 {/each}
-...
 ```
 
 ### JSDoc Example
@@ -160,10 +158,9 @@ The package includes type definitions for all icons. This is useful if you want 
     }
   ];
 </script>
-
-...
-
 ```
+
+For more details about typing the `svelte:component` directive, see the [Svelte documentation](https://svelte.dev/docs/typescript#types-componenttype).
 
 ## One generic icon component
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description
Following the conversations in #1761 & #1585, this improves the docs around the areas of type definitions and import statements.

If there are any modifications you wish for me to carry out, please let me know. 🙂 

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
