### PR TITLE
Export all types from lucide-svelte

### DIFF
--- a/packages/lucide-svelte/src/lucide-svelte.ts
+++ b/packages/lucide-svelte/src/lucide-svelte.ts
@@ -2,4 +2,4 @@ export * from './icons/index.js';
 export * as icons from './icons/index.js';
 export * from './aliases.js';
 export { default as defaultAttributes } from './defaultAttributes.js';
-export type { Icon } from './types.js';
+export * from './types.js';

--- a/packages/lucide-svelte/src/types.ts
+++ b/packages/lucide-svelte/src/types.ts
@@ -13,11 +13,11 @@ export interface IconProps extends Attrs {
   class?: string;
 }
 
-type IconEvents = {
+export type IconEvents = {
   [evt: string]: CustomEvent<any>;
 };
 
-type IconSlots = {
+export type IconSlots = {
   default: {};
 };
 


### PR DESCRIPTION
closes #1776

## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update

### Description
For some reason not all types where exported in the main entry files

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
