### PR TITLE
Remove aliasesSupport flag from rollup.config.mjs

### DIFF
--- a/packages/lucide-preact/rollup.config.mjs
+++ b/packages/lucide-preact/rollup.config.mjs
@@ -22,32 +22,26 @@ const bundles = [
     format: 'cjs',
     inputs,
     outputDir,
-    aliasesSupport: true
   },
   {
     format: 'esm',
     inputs,
     outputDir,
     preserveModules: true,
-    aliasesSupport: true
   },
 ];
 
 const configs = bundles
-  .map(({ inputs, outputDir, format, minify, preserveModules, aliasesSupport }) =>
+  .map(({ inputs, outputDir, format, minify, preserveModules }) =>
     inputs.map(input => ({
       input,
       plugins: [
-        ...(
-          !aliasesSupport ? [
-            replace({
-              "export * from './aliases';": '',
-              "export * as icons from './icons';": '',
-              delimiters: ['', ''],
-              preventAssignment: false,
-            }),
-          ] : []
-        ),
+        replace({
+          "export * from './aliases';": '',
+          "export * as icons from './icons';": '',
+          delimiters: ['', ''],
+          preventAssignment: false,
+        }),
         ...plugins(pkg, minify)
       ],
       external: ['preact'],
@@ -81,4 +75,3 @@ const configs = bundles
     },
     ...configs
   ];
-

--- a/packages/lucide-preact/rollup.config.mjs
+++ b/packages/lucide-preact/rollup.config.mjs
@@ -35,15 +35,7 @@ const configs = bundles
   .map(({ inputs, outputDir, format, minify, preserveModules }) =>
     inputs.map(input => ({
       input,
-      plugins: [
-        replace({
-          "export * from './aliases';": '',
-          "export * as icons from './icons';": '',
-          delimiters: ['', ''],
-          preventAssignment: false,
-        }),
-        ...plugins(pkg, minify)
-      ],
+      plugins: plugins(pkg, minify),
       external: ['preact'],
       output: {
         name: packageName,

--- a/packages/lucide-react/rollup.config.mjs
+++ b/packages/lucide-react/rollup.config.mjs
@@ -54,15 +54,7 @@ const configs = bundles
   .map(({ inputs, outputDir, outputFile, format, minify, preserveModules, entryFileNames, external = [], paths }) =>
     inputs.map(input => ({
       input,
-      plugins: [
-        replace({
-          "export * from './aliases';": '',
-          "export * as icons from './icons';": '',
-          delimiters: ['', ''],
-          preventAssignment: false,
-        }),
-        ...plugins(pkg, minify)
-      ],
+      plugins: plugins(pkg, minify),
       external: [
         'react',
         'prop-types',

--- a/packages/lucide-react/rollup.config.mjs
+++ b/packages/lucide-react/rollup.config.mjs
@@ -25,7 +25,6 @@ const bundles = [
     format: 'cjs',
     inputs,
     outputDir,
-    aliasesSupport: true,
   },
   {
     format: 'esm',
@@ -35,13 +34,11 @@ const bundles = [
     ],
     outputDir,
     preserveModules: true,
-    aliasesSupport: true,
   },
   {
     format: 'esm',
     inputs: ['src/dynamicIconImports.ts'],
     outputFile: 'dynamicIconImports.js',
-    aliasesSupport: true,
     external: [/src/],
     paths: (id) => {
       if (id.match(/src/)) {
@@ -54,20 +51,16 @@ const bundles = [
 ];
 
 const configs = bundles
-  .map(({ inputs, outputDir, outputFile, format, minify, preserveModules, aliasesSupport, entryFileNames, external = [], paths }) =>
+  .map(({ inputs, outputDir, outputFile, format, minify, preserveModules, entryFileNames, external = [], paths }) =>
     inputs.map(input => ({
       input,
       plugins: [
-        ...(
-          !aliasesSupport ? [
-            replace({
-              "export * from './aliases';": '',
-              "export * as icons from './icons';": '',
-              delimiters: ['', ''],
-              preventAssignment: false,
-            }),
-          ] : []
-        ),
+        replace({
+          "export * from './aliases';": '',
+          "export * as icons from './icons';": '',
+          delimiters: ['', ''],
+          preventAssignment: false,
+        }),
         ...plugins(pkg, minify)
       ],
       external: [

--- a/packages/lucide-vue-next/rollup.config.mjs
+++ b/packages/lucide-vue-next/rollup.config.mjs
@@ -35,15 +35,7 @@ const configs = bundles
   .map(({ inputs, outputDir, format, minify, preserveModules }) =>
     inputs.map(input => ({
       input,
-      plugins: [
-        replace({
-          "export * from './aliases';": '',
-          "export * as icons from './icons';": '',
-          delimiters: ['', ''],
-          preventAssignment: false,
-        }),
-        ...plugins(pkg, minify)
-      ],
+      plugins: plugins(pkg, minify),
       external: ['vue'],
       output: {
         name: packageName,

--- a/packages/lucide-vue-next/rollup.config.mjs
+++ b/packages/lucide-vue-next/rollup.config.mjs
@@ -22,33 +22,26 @@ const bundles = [
     format: 'cjs',
     inputs,
     outputDir,
-    aliasesSupport: true
   },
   {
     format: 'esm',
     inputs,
     outputDir,
     preserveModules: true,
-    aliasesSupport: true
   },
 ];
 
 const configs = bundles
-  .map(({ inputs, outputDir, format, minify, preserveModules, aliasesSupport }) =>
+  .map(({ inputs, outputDir, format, minify, preserveModules }) =>
     inputs.map(input => ({
       input,
       plugins: [
-        // This for aliases, only for esm
-        ...(
-          !aliasesSupport ? [
-            replace({
-              "export * from './aliases';": '',
-              "export * as icons from './icons';": '',
-              delimiters: ['', ''],
-              preventAssignment: false,
-            }),
-          ] : []
-        ),
+        replace({
+          "export * from './aliases';": '',
+          "export * as icons from './icons';": '',
+          delimiters: ['', ''],
+          preventAssignment: false,
+        }),
         ...plugins(pkg, minify)
       ],
       external: ['vue'],
@@ -88,4 +81,3 @@ const configs = bundles
     },
     ...configs
   ];
-

--- a/packages/lucide-vue/rollup.config.mjs
+++ b/packages/lucide-vue/rollup.config.mjs
@@ -21,33 +21,26 @@ const bundles = [
     format: 'cjs',
     inputs,
     outputDir,
-    aliasesSupport: true
   },
   {
     format: 'esm',
     inputs,
     outputDir,
     preserveModules: true,
-    aliasesSupport: true
   },
 ];
 
 const configs = bundles
-  .map(({ inputs, outputDir, format, minify, preserveModules, aliasesSupport }) =>
+  .map(({ inputs, outputDir, format, minify, preserveModules }) =>
     inputs.map(input => ({
       input,
       plugins: [
-        // This for aliases, only for esm
-        ...(
-          !aliasesSupport ? [
-            replace({
-              "export * from './aliases';": '',
-              "export * as icons from './icons';": '',
-              delimiters: ['', ''],
-              preventAssignment: false,
-            }),
-          ] : []
-        ),
+        replace({
+          "export * from './aliases';": '',
+          "export * as icons from './icons';": '',
+          delimiters: ['', ''],
+          preventAssignment: false,
+        }),
         ...plugins(pkg, minify)
       ],
       external: ['vue'],

--- a/packages/lucide-vue/rollup.config.mjs
+++ b/packages/lucide-vue/rollup.config.mjs
@@ -34,15 +34,7 @@ const configs = bundles
   .map(({ inputs, outputDir, format, minify, preserveModules }) =>
     inputs.map(input => ({
       input,
-      plugins: [
-        replace({
-          "export * from './aliases';": '',
-          "export * as icons from './icons';": '',
-          delimiters: ['', ''],
-          preventAssignment: false,
-        }),
-        ...plugins(pkg, minify)
-      ],
+      plugins: plugins(pkg, minify),
       external: ['vue'],
       output: {
         name: packageName,


### PR DESCRIPTION
closes #1789 

## What is the purpose of this pull request?
- [x] Bug fix

### Description
Some UMD builds do not currently export icon aliases, this PR removes the `aliasesSupport` flag from rollup configs and turns the feature forcibly on by default.

## Before Submitting <!-- For every PR! -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
