### PR TITLE
Add caption icons

### DIFF
--- a/icons/captions-off.json
+++ b/icons/captions-off.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.captions-off.json",
+  "contributors": [
+    "defaultlp"
+  ],
+  "tags": [
+    "captions",
+	"closed captions",
+    "subtitles",
+	"accassibility"
+  ],
+  "categories": [
+    "multimedia"
+  ]
+}

--- a/icons/captions-off.svg
+++ b/icons/captions-off.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-captions-off"><path d="M7 15h4M7 11h2M2 2l20 20"/><path d="M17 11h-1M19 19H5s-2 0-2-2V7s-.28-2 2-2M21 16V7s0-2-2-2h-9"/></svg>

--- a/icons/captions.json
+++ b/icons/captions.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.captions.json",
+  "contributors": [
+    "defaultlp"
+  ],
+  "tags": [
+    "captions",
+	"closed captions",
+    "subtitles",
+	"accassibility"
+  ],
+  "categories": [
+    "multimedia"
+  ]
+}

--- a/icons/captions.svg
+++ b/icons/captions.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-captions"><rect width="18" height="14" x="3" y="5" rx="3" ry="3"/><path d="M7 15h4M15 15h2M7 11h2M13 11h4"/></svg>

--- a/icons/subtitles.json
+++ b/icons/subtitles.json
@@ -9,5 +9,7 @@
     "closed captions",
     "accessibility"
   ],
-  "categories": []
+  "categories": [
+	"multimedia"
+  ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
This PR adds two new icons. One for captions and one for disabled captions.

<img width="80" alt="inkscape_S5JHfobJL7" src="https://github.com/lucide-icons/lucide/assets/29122114/64873ece-4d14-405d-b541-d88bbfdd9e4c">

Additionally this PR adds the "multimedia" category to the subtitles icon. Same as these captions.

### Icon use case
Is it useful for any application that deals with videos. Whether that be streaming or editing, having an icon that represents one of the three major components of internet videos is always a good idea. 

I mainly did this because I needed a subtitles/captions icon that had an off/disabled variant since I'm building a SvelteKit UI that works with videos.

### Alternative icon designs

Off/disabled variant
<img width="80" alt="inkscape_ShBHixQJuk" src="https://github.com/lucide-icons/lucide/assets/29122114/d822a1ff-999e-4dad-9d5d-d15e359d9990">

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: subtitles
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to two points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
