### PR TITLE
Export all types `lucide-react-native`

### DIFF
--- a/packages/lucide-react-native/src/createLucideIcon.ts
+++ b/packages/lucide-react-native/src/createLucideIcon.ts
@@ -3,7 +3,7 @@ import * as NativeSvg from 'react-native-svg';
 import defaultAttributes, { childDefaultAttributes } from './defaultAttributes';
 import type { SvgProps } from 'react-native-svg';
 
-type IconNode = [elementName: keyof ReactSVG, attrs: Record<string, string>][]
+export type IconNode = [elementName: keyof ReactSVG, attrs: Record<string, string>][]
 
 export interface LucideProps extends SvgProps {
   size?: string | number

--- a/packages/lucide-react-native/src/lucide-react-native.ts
+++ b/packages/lucide-react-native/src/lucide-react-native.ts
@@ -1,4 +1,9 @@
 export * from './icons';
 export * as icons from './icons';
 export * from './aliases';
-export { default as createLucideIcon } from './createLucideIcon';
+export {
+  default as createLucideIcon,
+  type IconNode,
+  type LucideProps,
+  type LucideIcon,
+} from './createLucideIcon';


### PR DESCRIPTION
Closes #1791

## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Exporting all types in the main entry files so these types can be used externally.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
