### PR TITLE
docs(react-native): fix generic icon import

### DIFF
--- a/docs/guide/packages/lucide-react-native.md
+++ b/docs/guide/packages/lucide-react-native.md
@@ -72,7 +72,7 @@ The example below imports all ES Modules, so exercise caution when using it. Imp
 ### Icon Component Example
 
 ```jsx
-import { icons } from 'lucide-react';
+import { icons } from 'lucide-react-native';
 
 const Icon = ({ name, color, size }) => {
   const LucideIcon = icons[name];


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Change incorrect import path in Lucide `React Native -> One generic icon component` docs section

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
