### PR TITLE
fix: icon preview comment

### DIFF
--- a/scripts/generateChangedIconsCommentMarkup.mjs
+++ b/scripts/generateChangedIconsCommentMarkup.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { shuffle, readSvgDirectory, getCurrentDirPath } from './helpers.mjs';
+import { shuffle, readSvgDirectory, getCurrentDirPath, minifySvg } from './helpers.mjs';
 
 const currentDir = getCurrentDirPath(import.meta.url);
 const ICONS_DIR = path.resolve(currentDir, '../icons');
@@ -17,11 +17,10 @@ const getImageTagsByFiles = (files, getBaseUrl, width) =>
   files
     .map((file) => {
       const svgContent = fs.readFileSync(path.join(process.cwd(), file), 'utf-8');
-      const strippedAttrsSVG = svgContent
-        .replace(/<svg[^>]*>/, '<svg>')
-        .replaceAll(/\n| {2}|\t/g, '');
+      const strippedAttrsSVG = svgContent.replace(/<svg[^>]*>/, '<svg>')
+      const minifiedSvg = minifySvg(strippedAttrsSVG)
 
-      const base64 = Buffer.from(strippedAttrsSVG).toString('base64');
+      const base64 = Buffer.from(minifiedSvg).toString('base64');
       const url = getBaseUrl(file);
       const widthAttr = width ? `width="${width}"` : '';
 

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -208,3 +208,17 @@ export const shuffle = (array) => {
   }
   return array;
 };
+
+/**
+ * Minifies SVG
+ *
+ * @param {string} string
+ * @returns string
+ */
+export function minifySvg(string){
+  return string ? string
+    .replace(/\>[\r\n ]+</g, "><")
+    .replace(/(<.*?>)|\s+/g, (m, $1) => $1 || ' ')
+    .trim()
+    : ""
+}


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Looks like the preview was not working in #1820. Looked into it, and the stripping whitespace regex was not working well. Replaced it with a minify function. tested it locally.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
