### PR TITLE
fix(icons): `play` icon uncentered

### DIFF
--- a/icons/play.svg
+++ b/icons/play.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polygon points="5 3 19 12 5 21 5 3" />
+  <polygon points="7 3 21 12 7 21 7 3" />
 </svg>

--- a/icons/play.svg
+++ b/icons/play.svg
@@ -9,5 +9,5 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polygon points="7 3 21 12 7 21 7 3" />
+  <polygon points="6 3 20 12 6 21 6 3" />
 </svg>


### PR DESCRIPTION
Fix https://github.com/lucide-icons/lucide/issues/1832

Lucide (black) vs Phosphor (red) now:
![image](https://github.com/lucide-icons/lucide/assets/351125/760ec321-bb60-41b6-ac3a-f7722d7fc8a2)


## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

