### PR TITLE
Fix plus/minus sign size in `shield-plus`/`shield-minus`

### DIFF
--- a/icons/shield-minus.svg
+++ b/icons/shield-minus.svg
@@ -10,5 +10,5 @@
   stroke-linejoin="round"
 >
   <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10" />
-  <path d="M8 11h8" />
+  <path d="M9 11h6" />
 </svg>

--- a/icons/shield-plus.svg
+++ b/icons/shield-plus.svg
@@ -10,6 +10,6 @@
   stroke-linejoin="round"
 >
   <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10" />
-  <path d="M8 11h8" />
-  <path d="M12 15V7" />
+  <path d="M9 11h6" />
+  <path d="M12 8v6" />
 </svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] Icon improvement

### Description
This PR updates `shield-plus` and `shield-minus` to better match other similar icons, e.g. `bell-plus`, `book-plus`, `file-plus`, `clipboard-plus` etc.

### Author, credits & license<!-- ONLY for new icons. -->
- [x] I've based them on the following Lucide icons: `shield`, `file-plus`, `file-minus`

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
