### PR TITLE
Update `file-output` icon

### DIFF
--- a/icons/file-output.json
+++ b/icons/file-output.json
@@ -4,7 +4,8 @@
     "Andreto",
     "ericfennis",
     "karsa-mistmere",
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "document"

--- a/icons/file-output.svg
+++ b/icons/file-output.svg
@@ -9,8 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M4 22h14a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v4" />
   <path d="M14 2v4a2 2 0 0 0 2 2h4" />
-  <path d="M2 15h10" />
-  <path d="m5 12-3 3 3 3" />
+  <path d="M4 7V4a2 2 0 0 1 2-2 2 2 0 0 0-2 2" />
+  <path d="M4.063 20.999a2 2 0 0 0 2 1L18 22a2 2 0 0 0 2-2V7l-5-5H6" />
+  <path d="m5 11-3 3" />
+  <path d="m5 17-3-3h10" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
This aligns the design with the suggested change of folder-output in #1619

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.