### PR TITLE
fix: updateContributors adds trailing line to icon.json

### DIFF
--- a/scripts/updateContributors.mjs
+++ b/scripts/updateContributors.mjs
@@ -25,7 +25,7 @@ const getUserName = pMemoize(
     }
     return fetchedCommit?.author?.login;
   },
-  { cacheKey: ([commit]) => commit.author_email, cache },
+  { cacheKey: ([commit]) => commit.author_email, cache }
 );
 
 // Check that a commit changes more than just the icon name
@@ -51,7 +51,7 @@ const getContributors = async (file, includeCoAuthors) => {
       }
       if (includeCoAuthors) {
         const matches = commit.body.matchAll(
-          /(^Author:|^Co-authored-by:)\s+(?<author>[^<]+)\s+<(?<email>[^>]+)>/gm,
+          /(^Author:|^Co-authored-by:)\s+(?<author>[^<]+)\s+<(?<email>[^>]+)>/gm
         );
         // eslint-disable-next-line no-restricted-syntax
         for (const match of matches) {
@@ -99,8 +99,8 @@ await Promise.all(
           ...rest,
         },
         null,
-        2,
-      ),
+        2
+      ) + '\n'
     );
-  }),
+  })
 );


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Stops us from getting the diff error.

<img width="737" alt="image" src="https://github.com/lucide-icons/lucide/assets/25524993/871b5b6b-0a0c-47ac-aeb8-9fa80c76823a">


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
