### PR TITLE
Fix: prettier fails on updateContributors.mjs 

### DIFF
--- a/scripts/updateContributors.mjs
+++ b/scripts/updateContributors.mjs
@@ -25,7 +25,7 @@ const getUserName = pMemoize(
     }
     return fetchedCommit?.author?.login;
   },
-  { cacheKey: ([commit]) => commit.author_email, cache }
+  { cacheKey: ([commit]) => commit.author_email, cache },
 );
 
 // Check that a commit changes more than just the icon name
@@ -51,7 +51,7 @@ const getContributors = async (file, includeCoAuthors) => {
       }
       if (includeCoAuthors) {
         const matches = commit.body.matchAll(
-          /(^Author:|^Co-authored-by:)\s+(?<author>[^<]+)\s+<(?<email>[^>]+)>/gm
+          /(^Author:|^Co-authored-by:)\s+(?<author>[^<]+)\s+<(?<email>[^>]+)>/gm,
         );
         // eslint-disable-next-line no-restricted-syntax
         for (const match of matches) {
@@ -99,8 +99,8 @@ await Promise.all(
           ...rest,
         },
         null,
-        2
-      ) + '\n'
+        2,
+      ) + '\n',
     );
-  })
+  }),
 );


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Bug fix

### Description

Prettier currently fails on updateContributors.mjs because of some missing end line commas, see https://github.com/lucide-icons/lucide/actions/runs/7875122496/job/21486295061?pr=1843

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
