### PR TITLE
feat(site): adds virtual scrolling to icons grid and categories

### DIFF
--- a/docs/.vitepress/theme/components/icons/CategoryList.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryList.vue
@@ -21,9 +21,6 @@ const headers = computed(() => {
   const linkPrefix = page.value.relativePath.startsWith('icons/categories')
     ? '' : '/icons/categories'
 
-  console.log();
-
-
   return data.categories.map(({ name, title, iconCount }) => ({
     level: 2,
     link: `${linkPrefix}#${name}`,

--- a/docs/.vitepress/theme/components/icons/CategoryList.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryList.vue
@@ -25,7 +25,8 @@ const headers = computed(() => {
     level: 2,
     link: `${linkPrefix}#${name}`,
     title,
-    iconCount
+    iconCount,
+    name
   }))
 })
 

--- a/docs/.vitepress/theme/components/icons/CategoryList.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryList.vue
@@ -21,6 +21,9 @@ const headers = computed(() => {
   const linkPrefix = page.value.relativePath.startsWith('icons/categories')
     ? '' : '/icons/categories'
 
+  console.log();
+
+
   return data.categories.map(({ name, title, iconCount }) => ({
     level: 2,
     link: `${linkPrefix}#${name}`,

--- a/docs/.vitepress/theme/components/icons/CategoryList.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryList.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useData } from 'vitepress'
 import VPLink from 'vitepress/dist/client/theme-default/components/VPLink.vue'
 import { isActive } from 'vitepress/dist/client/shared'
 import { useActiveAnchor } from '../../composables/useActiveAnchor'
 import { data } from './CategoryList.data'
 import CategoryListItem from './CategoryListItem.vue'
+import { useCategoryView } from '../../composables/useCategoryView'
 
 const { page } = useData()
+const { categoryCounts } = useCategoryView();
 
 const categoriesIsActive = computed(() => {
   return isActive(page.value.relativePath, '/icons/categories');
@@ -25,7 +27,7 @@ const headers = computed(() => {
     level: 2,
     link: `${linkPrefix}#${name}`,
     title,
-    iconCount,
+    iconCount: categoryCounts.value[name] ?? iconCount,
     name
   }))
 })
@@ -33,7 +35,13 @@ const headers = computed(() => {
 const container = ref()
 const marker = ref()
 
-useActiveAnchor(container, marker)
+const { setActiveLinkDebounced } = useActiveAnchor(container, marker)
+
+watch(headers, () => {
+  setTimeout(() => {
+    setActiveLinkDebounced()
+  }, 200)
+})
 </script>
 
 <template>

--- a/docs/.vitepress/theme/components/icons/CategoryListItem.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryListItem.vue
@@ -15,7 +15,7 @@ type MenuItem = Omit<Header, 'slug' | 'children'> & {
   children?: MenuItem[];
 };
 
-const props = defineProps<{
+defineProps<{
   headers: MenuItem[];
   root?: boolean;
 }>();

--- a/docs/.vitepress/theme/components/icons/CategoryListItem.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryListItem.vue
@@ -29,6 +29,8 @@ function onClick(categoryName: string) {
 
   const heading = document.querySelector<HTMLAnchorElement>(categoryName);
   heading?.focus();
+
+  window.history.pushState({}, '', `/icons/categories#${categoryName}`)
 }
 </script>
 

--- a/docs/.vitepress/theme/components/icons/CategoryListItem.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryListItem.vue
@@ -35,7 +35,15 @@ function onClick(categoryName: string) {
 <template>
   <ul :class="root ? 'root' : 'nested'">
     <li v-for="{ children, link, title, iconCount, name } in headers">
-      <a class="outline-link" :href="link" @click="onClick(name)" :title="title">
+      <a
+        class="outline-link"
+        :href="link"
+        @click="onClick(name)"
+        :title="title"
+        :class="{
+          inactive: iconCount === 0,
+        }"
+      >
         <span>
           {{ title }}
         </span>
@@ -75,6 +83,10 @@ function onClick(categoryName: string) {
   transition: color 0.25s;
 }
 
+.outline-link.inactive {
+  color: var(--vp-c-text-4);
+}
+
 .outline-link.nested {
   padding-left: 13px;
 }
@@ -84,5 +96,9 @@ function onClick(categoryName: string) {
   margin-left: auto;
   font-size: 11px;
   font-weight: 400;
+}
+
+.outline-link.inactive .icon-count {
+  opacity: 0;
 }
 </style>

--- a/docs/.vitepress/theme/components/icons/CategoryListItem.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryListItem.vue
@@ -23,8 +23,6 @@ const props = defineProps<{
 const { selectedCategory } = useCategoryView();
 
 function onClick(categoryName: string) {
-  console.log('onClick', categoryName);
-
   selectedCategory.value = categoryName;
 
   const heading = document.querySelector<HTMLAnchorElement>(categoryName);

--- a/docs/.vitepress/theme/components/icons/CategoryListItem.vue
+++ b/docs/.vitepress/theme/components/icons/CategoryListItem.vue
@@ -7,6 +7,7 @@ interface Header {
   slug: string;
   iconCount: number;
   link: string;
+  name: string;
   children: Header[];
 }
 
@@ -21,29 +22,20 @@ const props = defineProps<{
 
 const { selectedCategory } = useCategoryView();
 
-function onClick(event: Event) {
-  const target =
-    (event.target as HTMLElement).nodeName === 'span'
-      ? (event.target as HTMLElement).parentNode
-      : (event.target as HTMLElement);
-  const href = (target as HTMLAnchorElement)?.href;
+function onClick(categoryName: string) {
+  console.log('onClick', categoryName);
 
-  if (href) {
-    const id = '#' + href.split('#')[1];
-    const decodedId = decodeURIComponent(id);
+  selectedCategory.value = categoryName;
 
-    selectedCategory.value = decodedId.replace('#', '');
-
-    const heading = document.querySelector<HTMLAnchorElement>(decodedId);
-    heading?.focus();
-  }
+  const heading = document.querySelector<HTMLAnchorElement>(categoryName);
+  heading?.focus();
 }
 </script>
 
 <template>
   <ul :class="root ? 'root' : 'nested'">
-    <li v-for="{ children, link, title, iconCount } in headers">
-      <a class="outline-link" :href="link" @click="onClick" :title="title">
+    <li v-for="{ children, link, title, iconCount, name } in headers">
+      <a class="outline-link" :href="link" @click="onClick(name)" :title="title">
         <span>
           {{ title }}
         </span>

--- a/docs/.vitepress/theme/components/icons/IconGrid.vue
+++ b/docs/.vitepress/theme/components/icons/IconGrid.vue
@@ -4,7 +4,7 @@ import IconItem from './IconItem.vue'
 
 const emit = defineEmits(['setActiveIcon'])
 
-const props = defineProps<{
+defineProps<{
   icons: IconEntity[]
   activeIcon?: string
   overlayMode?: boolean
@@ -40,7 +40,6 @@ function setActiveIcon(name: string) {
 .icons {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
-  /* padding: 32px 32px 96px; */
   gap: 8px;
   width: 100%;
 }

--- a/docs/.vitepress/theme/components/icons/IconsCategory.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategory.vue
@@ -1,43 +1,46 @@
+<script lang="ts">
+import { IconEntity } from '../../types';
+
+type CategoryNameRow = {
+  type: 'category';
+  title: string;
+  name: string;
+};
+
+type CategoryIconsRow = {
+  type: 'icons';
+  icons: IconEntity[];
+};
+
+export type CategoryRow = CategoryNameRow | CategoryIconsRow;
+</script>
+
 <script setup lang="ts">
-import { ref } from 'vue';
-import { Category } from '../../types';
 import IconGrid from './IconGrid.vue'
-import { vIntersectionObserver } from '@vueuse/components'
 
 defineProps<{
   activeIconName: string
-  category: Category
+  categoryRow: CategoryRow
 }>()
 
 const emit = defineEmits(['setActiveIcon'])
-
-const showIcons = ref(false)
-
-// Added intersection observer to improve performance
-const onIntersectionObserver: IntersectionObserverCallback = ([{ isIntersecting }]) => {
-  showIcons.value = isIntersecting
-}
 </script>
 
 <template>
-  <section
-    class="category"
-    :key="category.name"
-    :id="category.name"
-    v-intersection-observer="onIntersectionObserver"
+  <h2
+    v-if="categoryRow.type === 'category'"
+    class="title"
   >
-    <h2 class="title" >
-      <a class="header-anchor" :href="`#${category.name}`" :aria-label="`Permalink to &quot;${category.title}&quot;`">&ZeroWidthSpace;</a>
-      {{ category.title }}
-    </h2>
-    <IconGrid
-      :activeIcon="activeIconName"
-      :icons="category.icons"
-      @setActiveIcon="$event => $emit('setActiveIcon', $event)"
-      overlayMode
-      :hideIcons="!showIcons"
-    />
-  </section>
+    <a class="header-anchor" :href="`#${categoryRow.name}`" :aria-label="`Permalink to &quot;${categoryRow.title}&quot;`">&ZeroWidthSpace;</a>
+    {{ categoryRow.title }}
+  </h2>
+  <IconGrid
+    v-else-if="categoryRow.type === 'icons'"
+    :activeIcon="activeIconName"
+    :icons="categoryRow.icons"
+    @setActiveIcon="$event => $emit('setActiveIcon', $event)"
+    overlayMode
+  />
 </template>
 
 <style scoped>
@@ -47,5 +50,4 @@ const onIntersectionObserver: IntersectionObserverCallback = ([{ isIntersecting 
   font-weight: 500;
   padding: 24px 0 8px;
 }
-
 </style>

--- a/docs/.vitepress/theme/components/icons/IconsCategory.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategory.vue
@@ -9,7 +9,6 @@ defineProps<{
   category: Category
 }>()
 
-
 const emit = defineEmits(['setActiveIcon'])
 
 const showIcons = ref(false)
@@ -43,14 +42,14 @@ const onIntersectionObserver: IntersectionObserverCallback = ([{ isIntersecting 
 
 <style scoped>
 .title {
-  margin-bottom: 24px;
+  margin-bottom: 8px;
   font-size: 19px;
   font-weight: 500;
-  padding-top: 86px;
+  padding: 24px 0 8px;
   /* scroll-padding-top: 240px; */
 }
 
-.category {
+/* .category {
   margin-bottom: calc(-86px + 32px);
-}
+} */
 </style>

--- a/docs/.vitepress/theme/components/icons/IconsCategory.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategory.vue
@@ -46,10 +46,6 @@ const onIntersectionObserver: IntersectionObserverCallback = ([{ isIntersecting 
   font-size: 19px;
   font-weight: 500;
   padding: 24px 0 8px;
-  /* scroll-padding-top: 240px; */
 }
 
-/* .category {
-  margin-bottom: calc(-86px + 32px);
-} */
 </style>

--- a/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
@@ -158,6 +158,10 @@ onMounted(() => {
   }, 0)
 })
 
+watch(searchQueryDebounced, () => {
+  scrollTo(0)
+})
+
 
 </script>
 

--- a/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
@@ -23,7 +23,7 @@ const props = defineProps<{
 
 const activeIconName = ref(null);
 const { searchInput, searchQuery, searchQueryDebounced } = useSearchInput();
-const { selectedCategory } = useCategoryView();
+const { selectedCategory, categoryCounts } = useCategoryView();
 
 const isSearching = computed(() => !!searchQuery.value);
 
@@ -99,6 +99,16 @@ const categories = computed(() => {
         icons: searchedCategoryIcons,
       };
     })
+});
+
+watch(categories, (items) => {
+  categoryCounts.value = Object.fromEntries(
+    items.map(({ name, icons }) => [name, icons.length])
+  );
+})
+
+const categoriesList = computed(() => {
+  return categories.value
     .filter(({ icons }) => icons.length)
     .reduce<CategoryRow[]>((acc, category) => {
       acc.push({ type: 'category', title: category.title, name: category.name });
@@ -113,7 +123,7 @@ const categories = computed(() => {
 });
 
 const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(
-  categories,
+  categoriesList,
   {
     itemHeight: ICON_SIZE + ICON_GRID_GAP,
     overscan: 10
@@ -142,10 +152,12 @@ function scrollToSelectedCategory(selectedCategory: string) {
   const category = props.categories.find((category) => category.name === selectedCategory)
 
   if (category != null) {
-    const categoryRowIndex = categories.value.findIndex((row) => row.type === 'category' && row.name === selectedCategory)
+    const categoryRowIndex = categoriesList.value.findIndex((row) => row.type === 'category' && row.name === selectedCategory)
 
     if (categoryRowIndex !== -1) {
-      scrollTo(categoryRowIndex)
+      setTimeout(() => {
+        scrollTo(categoryRowIndex)
+      }, 0)
     }
   }
 }
@@ -161,8 +173,6 @@ onMounted(() => {
 watch(searchQueryDebounced, () => {
   scrollTo(0)
 })
-
-
 </script>
 
 <template>

--- a/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, defineAsyncComponent, onMounted, watchEffect, watch, nextTick } from 'vue';
+import { ref, computed, defineAsyncComponent, onMounted, watch } from 'vue';
 import type { IconEntity, Category } from '../../types';
 import useSearch from '../../composables/useSearch';
 import InputSearch from '../base/InputSearch.vue';
@@ -8,7 +8,7 @@ import StickyBar from './StickyBar.vue';
 import IconGrid from './IconGrid.vue'
 import useFetchTags from '../../composables/useFetchTags';
 import useFetchCategories from '../../composables/useFetchCategories';
-import { useElementSize, useEventListener, useVirtualList, useUrlSearchParams } from '@vueuse/core';
+import { useElementSize, useEventListener, useVirtualList } from '@vueuse/core';
 import chunkArray from '../../utils/chunkArray';
 import { useCategoryView } from '../../composables/useCategoryView';
 
@@ -150,8 +150,6 @@ function scrollToSelectedCategory(selectedCategory: string) {
   }
 }
 
-const listLoaded = ref(false)
-
 watch(selectedCategory, scrollToSelectedCategory)
 
 onMounted(() => {
@@ -193,13 +191,6 @@ onMounted(() => {
         />
       </template>
     </div>
-    <!-- <IconsCategory
-      v-for="category in categories"
-      :key="category.name"
-      :category="category"
-      :activeIconName="activeIconName"
-      @setActiveIcon="setActiveIconName"
-    /> -->
   </div>
   <IconDetailOverlay
     v-if="activeIconName != null"

--- a/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
@@ -146,7 +146,11 @@ const IconDetailOverlay = defineAsyncComponent(() => import('./IconDetailOverlay
         @focus="onFocusSearchInput"
       />
     </StickyBar>
-    <NoResults v-if="categories.length === 0" :searchQuery="searchQuery" @clear="searchQuery = ''" />
+    <NoResults
+      v-if="categories.length === 0"
+      :searchQuery="searchQuery"
+      @clear="searchQuery = ''"
+    />
     <div v-bind="wrapperProps">
       <IconsCategory
         v-for="{ index, data } in list"

--- a/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
@@ -145,37 +145,19 @@ function scrollToSelectedCategory(selectedCategory: string) {
     const categoryRowIndex = categories.value.findIndex((row) => row.type === 'category' && row.name === selectedCategory)
 
     if (categoryRowIndex !== -1) {
-      nextTick(() => {
-        scrollTo(categoryRowIndex)
-      })
+      scrollTo(categoryRowIndex)
     }
   }
 }
 
 const listLoaded = ref(false)
 
-watch(selectedCategory, scrollToSelectedCategory, {
-  immediate: true
-})
+watch(selectedCategory, scrollToSelectedCategory)
 
-watch(listLoaded, (loaded) => {
-  if (selectedCategory.value != null && loaded  ) {
-    nextTick(() => {
-      console.log('scrolling to selected category', selectedCategory.value);
-
-      scrollToSelectedCategory(selectedCategory.value)
-    })
-  }
-}, {
-  immediate: true
-})
-
-watch(list, (items) => {
-  if (items.length !== 0) {
-    listLoaded.value = true
-  }
-}, {
-  immediate: true
+onMounted(() => {
+  setTimeout(() => {
+    scrollToSelectedCategory(selectedCategory.value)
+  }, 0)
 })
 
 

--- a/docs/.vitepress/theme/components/icons/IconsOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsOverview.vue
@@ -117,6 +117,7 @@ watch(searchQueryDebounced, () => {
         :key="index"
         overlayMode
         :icons="icons"
+        :activeIcon="activeIconName"
         @setActiveIcon="setActiveIconName"
       />
     </div>

--- a/docs/.vitepress/theme/components/icons/IconsOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsOverview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, defineAsyncComponent, onMounted } from 'vue';
+import { ref, computed, defineAsyncComponent, onMounted, watch } from 'vue';
 import type { IconEntity } from '../../types';
 import { useElementSize, useEventListener, useVirtualList } from '@vueuse/core';
 import IconGrid from './IconGrid.vue';
@@ -59,7 +59,7 @@ const chunkedIcons = computed(() => {
   return chunkArray(searchResults.value, columnSize.value);
 });
 
-const { list, containerProps, wrapperProps } = useVirtualList(
+const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(
   chunkedIcons,
   {
     itemHeight: ICON_SIZE + ICON_GRID_GAP,
@@ -89,6 +89,10 @@ function onFocusSearchInput() {
 const NoResults = defineAsyncComponent(() => import('./NoResults.vue'));
 
 const IconDetailOverlay = defineAsyncComponent(() => import('./IconDetailOverlay.vue'));
+
+watch(searchQueryDebounced, () => {
+  scrollTo(0)
+})
 </script>
 
 <template>

--- a/docs/.vitepress/theme/components/icons/IconsOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsOverview.vue
@@ -14,8 +14,6 @@ import chunkArray from '../../utils/chunkArray';
 const ICON_SIZE = 56;
 const ICON_GRID_GAP = 8;
 
-const overviewEl = ref<HTMLElement | null>(null);
-
 const props = defineProps<{
   icons: IconEntity[];
 }>();
@@ -25,6 +23,7 @@ const activeIconName = ref(null);
 const { execute: fetchTags, data: tags } = useFetchTags();
 const { execute: fetchCategories, data: categories } = useFetchCategories();
 
+const overviewEl = ref<HTMLElement | null>(null);
 const { width: containerWidth } = useElementSize(overviewEl)
 
 const columnSize = computed(() => {
@@ -93,33 +92,31 @@ const IconDetailOverlay = defineAsyncComponent(() => import('./IconDetailOverlay
 </script>
 
 <template>
-  <div ref="overviewEl">
-
-
-  <StickyBar>
-    <InputSearch
-      :placeholder="`Search ${icons.length} icons ...`"
-      v-model="searchQuery"
-      ref="searchInput"
-      class="input-wrapper"
-      @focus="onFocusSearchInput"
-    />
-  </StickyBar>
+  <div ref="overviewEl" class="overview-container">
+    <StickyBar>
+      <InputSearch
+        :placeholder="`Search ${icons.length} icons ...`"
+        v-model="searchQuery"
+        ref="searchInput"
+        class="input-wrapper"
+        @focus="onFocusSearchInput"
+      />
+    </StickyBar>
     <NoResults
       v-if="list.length === 0"
       :searchQuery="searchQuery"
       @clear="searchQuery = ''"
     />
-    <div v-bind="wrapperProps">
-        <IconGrid
-          v-for="{ index, data: icons } in list"
-          :key="index"
-          overlayMode
-          :icons="icons"
-          @setActiveIcon="setActiveIconName"
-        />
+    <div v-bind="wrapperProps" class="icon">
+      <IconGrid
+        v-for="{ index, data: icons } in list"
+        :key="index"
+        overlayMode
+        :icons="icons"
+        @setActiveIcon="setActiveIconName"
+      />
     </div>
-</div>
+  </div>
 
   <IconDetailOverlay
     v-if="activeIconName != null"
@@ -130,10 +127,6 @@ const IconDetailOverlay = defineAsyncComponent(() => import('./IconDetailOverlay
 
 <style>
 .icons {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
-  gap: 8px;
-  width: 100%;
   margin-bottom: 8px;
 }
 
@@ -145,7 +138,7 @@ const IconDetailOverlay = defineAsyncComponent(() => import('./IconDetailOverlay
   width: 100%;
 }
 
-.bottom-page {
-  height: 288px;
+.overview-container {
+  padding-bottom: 288px;
 }
 </style>

--- a/docs/.vitepress/theme/components/icons/NoResults.vue
+++ b/docs/.vitepress/theme/components/icons/NoResults.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { bird } from '../../../data/iconNodes'
+import { ref, onMounted, computed } from 'vue'
+import { bird, squirrel, rabbit } from '../../../data/iconNodes'
 import createLucideIcon from 'lucide-vue-next/src/createLucideIcon'
 import {useEventListener} from '@vueuse/core'
 import VPButton from 'vitepress/dist/client/theme-default/components/VPButton.vue'
+import { IconNode } from '../../types'
 
 defineProps<{
   searchQuery: string
@@ -11,13 +12,16 @@ defineProps<{
 
 defineEmits(['clear'])
 
-const birdIcon = ref<HTMLElement>()
-const Bird = createLucideIcon('bird', bird)
+const animalIcon = ref<HTMLElement>()
+const randomAnimal = computed<IconNode>(() => {
+  return Math.random() > 0.5 ? squirrel : Math.random() > 0.5 ? rabbit : bird
+})
+const animalComponent = computed(() => createLucideIcon('animal', randomAnimal.value))
 const flip = ref(false)
 
 onMounted(() => {
   useEventListener(document, 'mousemove', (mouseEvent) => {
-    const {width, height, x, y} = birdIcon.value.getBoundingClientRect()
+    const {width, height, x, y} = animalIcon.value.getBoundingClientRect()
 
     const centerX = (width / 2) + x
 
@@ -29,16 +33,27 @@ onMounted(() => {
 
 <template>
   <div class="no-results">
-    <Bird class="bird-icon" ref="birdIcon" :class="{ flip }" :strokeWidth="1"/>
+    <component
+      :is="animalComponent"
+      class="animal-icon"
+      ref="animalIcon"
+      :class="{ flip }"
+      :strokeWidth="1"
+    />
     <h2 class="no-results-text">
       No icons found for '{{ searchQuery }}'
     </h2>
-    <VPButton text="Clear your search and try again" theme="alt" @click="$emit('clear')"/>
+    <VPButton
+      text="Clear your search and try again"
+      theme="alt"
+      @click="$emit('clear')"
+    />
     <span class="text-divider">or</span>
-    <VPButton text="Search on Github issues"
-              theme="alt"
-              :href="`https://github.com/lucide-icons/lucide/issues?q=is%3Aopen+${searchQuery}`"
-              target="_blank"
+    <VPButton
+      text="Search on Github issues"
+      theme="alt"
+      :href="`https://github.com/lucide-icons/lucide/issues?q=is%3Aopen+${searchQuery}`"
+      target="_blank"
     />
   </div>
 </template>
@@ -50,7 +65,7 @@ onMounted(() => {
   align-items: center;
 }
 
-.bird-icon {
+.animal-icon {
   width: 160px;
   height: 160px;
   color: var(--vp-c-neutral);
@@ -58,12 +73,12 @@ onMounted(() => {
   margin-top: 72px;
 }
 
-.bird-icon.flip {
+.animal-icon.flip {
   transform: rotateY(180deg);
 }
 
 @media (min-width: 960px) {
-  .bird-icon {
+  .animal-icon {
     width: 240px;
     height: 240px;
   }

--- a/docs/.vitepress/theme/components/icons/NoResults.vue
+++ b/docs/.vitepress/theme/components/icons/NoResults.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import {ref} from 'vue'
-import {bird} from '../../../data/iconNodes'
+import { ref, onMounted } from 'vue'
+import { bird } from '../../../data/iconNodes'
 import createLucideIcon from 'lucide-vue-next/src/createLucideIcon'
 import {useEventListener} from '@vueuse/core'
 import VPButton from 'vitepress/dist/client/theme-default/components/VPButton.vue'
@@ -15,12 +15,14 @@ const birdIcon = ref<HTMLElement>()
 const Bird = createLucideIcon('bird', bird)
 const flip = ref(false)
 
-useEventListener(document, 'mousemove', (mouseEvent) => {
-  const {width, height, x, y} = birdIcon.value.getBoundingClientRect()
+onMounted(() => {
+  useEventListener(document, 'mousemove', (mouseEvent) => {
+    const {width, height, x, y} = birdIcon.value.getBoundingClientRect()
 
-  const centerX = (width / 2) + x
+    const centerX = (width / 2) + x
 
-  flip.value = mouseEvent.x < centerX
+    flip.value = mouseEvent.x < centerX
+  })
 })
 
 </script>

--- a/docs/.vitepress/theme/composables/useActiveAnchor.ts
+++ b/docs/.vitepress/theme/composables/useActiveAnchor.ts
@@ -67,7 +67,7 @@ export function useActiveAnchor(container, marker) {
 
   return {
     setActiveLinkDebounced,
-  }
+  };
 }
 
 const PAGE_OFFSET = 128;

--- a/docs/.vitepress/theme/composables/useActiveAnchor.ts
+++ b/docs/.vitepress/theme/composables/useActiveAnchor.ts
@@ -66,7 +66,7 @@ export function useActiveAnchor(container, marker) {
   }
 }
 
-const PAGE_OFFSET = 64;
+const PAGE_OFFSET = 128;
 
 function getAnchorTop(anchor) {
   return anchor.parentElement.offsetTop - PAGE_OFFSET;
@@ -74,7 +74,7 @@ function getAnchorTop(anchor) {
 function isAnchorActive(index, anchor, nextAnchor) {
   const scrollTop = window.scrollY;
   if (index === 0 && scrollTop === 0) {
-    return [true, null];
+    return [true, anchor.hash];
   }
   if (scrollTop < getAnchorTop(anchor)) {
     return [false, null];

--- a/docs/.vitepress/theme/composables/useActiveAnchor.ts
+++ b/docs/.vitepress/theme/composables/useActiveAnchor.ts
@@ -6,18 +6,18 @@ import { throttleAndDebounce } from 'vitepress/dist/client/theme-default/support
  */
 
 export function useActiveAnchor(container, marker) {
-  const onScroll = throttleAndDebounce(setActiveLink, 100);
+  const setActiveLinkDebounced = throttleAndDebounce(setActiveLink, 100);
   let prevActiveLink = null;
   onMounted(() => {
     requestAnimationFrame(setActiveLink);
-    window.addEventListener('scroll', onScroll);
+    window.addEventListener('scroll', setActiveLinkDebounced);
   });
   onUpdated(() => {
     // sidebar update means a route change
     activateLink(location.hash);
   });
   onUnmounted(() => {
-    window.removeEventListener('scroll', onScroll);
+    window.removeEventListener('scroll', setActiveLinkDebounced);
   });
   function setActiveLink() {
     const links = [].slice.call(container.value.querySelectorAll('.outline-link'));
@@ -63,6 +63,10 @@ export function useActiveAnchor(container, marker) {
       marker.value.style.top = '33px';
       marker.value.style.opacity = '0';
     }
+  }
+
+  return {
+    setActiveLinkDebounced,
   }
 }
 

--- a/docs/.vitepress/theme/composables/useCategoryView.ts
+++ b/docs/.vitepress/theme/composables/useCategoryView.ts
@@ -30,6 +30,7 @@ export function useCategoryView(): CategoryViewContext {
   watch(route, (currentRoute) => {
     if (currentRoute.path !== '/icons/categories') {
       context.selectedCategory.value = '';
+      context.categoryCounts.value = {};
     }
   })
 

--- a/docs/.vitepress/theme/composables/useCategoryView.ts
+++ b/docs/.vitepress/theme/composables/useCategoryView.ts
@@ -28,11 +28,9 @@ export function useCategoryView(): CategoryViewContext {
   })
 
   watch(route, (currentRoute) => {
-
     if (currentRoute.path !== '/icons/categories') {
       context.selectedCategory.value = '';
     }
-
   })
 
   return context;

--- a/docs/.vitepress/theme/composables/useCategoryView.ts
+++ b/docs/.vitepress/theme/composables/useCategoryView.ts
@@ -1,4 +1,5 @@
-import { ref, inject, Ref } from 'vue';
+import { useRoute } from 'vitepress';
+import { ref, inject, Ref, onMounted, watch } from 'vue';
 
 export const CATEGORY_VIEW_CONTEXT = Symbol('categoryView');
 
@@ -8,16 +9,31 @@ interface CategoryViewContext {
 }
 
 export const categoryViewContext = {
-  selectedCategory: ref(''),
+  selectedCategory: ref(),
   categoryCounts: ref({}),
 };
 
 export function useCategoryView(): CategoryViewContext {
   const context = inject<CategoryViewContext>(CATEGORY_VIEW_CONTEXT);
+  const route = useRoute();
 
   if (!context) {
     throw new Error('useCategoryView must be used with categoryView context');
   }
+
+  onMounted(() => {
+    if (window.location.hash) {
+      context.selectedCategory.value = decodeURIComponent(window.location.hash.slice(1));
+    }
+  })
+
+  watch(route, (currentRoute) => {
+
+    if (currentRoute.path !== '/icons/categories') {
+      context.selectedCategory.value = '';
+    }
+
+  })
 
   return context;
 }

--- a/docs/.vitepress/theme/composables/useCategoryView.ts
+++ b/docs/.vitepress/theme/composables/useCategoryView.ts
@@ -25,14 +25,14 @@ export function useCategoryView(): CategoryViewContext {
     if (window.location.hash) {
       context.selectedCategory.value = decodeURIComponent(window.location.hash.slice(1));
     }
-  })
+  });
 
   watch(route, (currentRoute) => {
     if (currentRoute.path !== '/icons/categories') {
       context.selectedCategory.value = '';
       context.categoryCounts.value = {};
     }
-  })
+  });
 
   return context;
 }

--- a/docs/.vitepress/theme/composables/useScrollToCategory.ts
+++ b/docs/.vitepress/theme/composables/useScrollToCategory.ts
@@ -1,0 +1,54 @@
+import { Ref, onMounted, watch } from "vue";
+import { CategoryRow } from "../components/icons/IconsCategory.vue";
+import { Category } from "../types"
+import { useCategoryView } from "./useCategoryView";
+
+interface UseScrollToCategory {
+  categories: Ref<Pick<Category, 'name' | 'icons'>[]>,
+  categoriesList: Ref<CategoryRow[]>,
+  scrollTo: (index: number) => void,
+  searchQueryDebounced: Ref<string>
+}
+
+export default function useScrollToCategory({
+  categories,
+  categoriesList,
+  scrollTo,
+  searchQueryDebounced,
+}: UseScrollToCategory) {
+  const { selectedCategory, categoryCounts } = useCategoryView();
+
+  function scrollToSelectedCategory(selectedCategory: string) {
+    const category = categories.value.find((category) => category.name === selectedCategory)
+
+    if (category != null) {
+      const categoryRowIndex = categoriesList.value.findIndex(
+        (row) => row.type === 'category' && row.name === selectedCategory
+      )
+
+      if (categoryRowIndex !== -1) {
+        setTimeout(() => {
+          scrollTo(categoryRowIndex)
+        }, 0)
+      }
+    }
+  }
+
+  watch(selectedCategory, scrollToSelectedCategory)
+
+  onMounted(() => {
+    setTimeout(() => {
+      scrollToSelectedCategory(selectedCategory.value)
+    }, 0)
+  })
+
+  watch(searchQueryDebounced, () => {
+    scrollTo(0)
+  })
+
+  watch(categories, (items) => {
+    categoryCounts.value = Object.fromEntries(
+      items.map(({ name, icons }) => [name, icons.length])
+    );
+  })
+}

--- a/docs/.vitepress/theme/composables/useScrollToCategory.ts
+++ b/docs/.vitepress/theme/composables/useScrollToCategory.ts
@@ -1,13 +1,13 @@
-import { Ref, onMounted, watch } from "vue";
-import { CategoryRow } from "../components/icons/IconsCategory.vue";
-import { Category } from "../types"
-import { useCategoryView } from "./useCategoryView";
+import { Ref, onMounted, watch } from 'vue';
+import { CategoryRow } from '../components/icons/IconsCategory.vue';
+import { Category } from '../types';
+import { useCategoryView } from './useCategoryView';
 
 interface UseScrollToCategory {
-  categories: Ref<Pick<Category, 'name' | 'icons'>[]>,
-  categoriesList: Ref<CategoryRow[]>,
-  scrollTo: (index: number) => void,
-  searchQueryDebounced: Ref<string>
+  categories: Ref<Pick<Category, 'name' | 'icons'>[]>;
+  categoriesList: Ref<CategoryRow[]>;
+  scrollTo: (index: number) => void;
+  searchQueryDebounced: Ref<string>;
 }
 
 export default function useScrollToCategory({
@@ -19,36 +19,34 @@ export default function useScrollToCategory({
   const { selectedCategory, categoryCounts } = useCategoryView();
 
   function scrollToSelectedCategory(selectedCategory: string) {
-    const category = categories.value.find((category) => category.name === selectedCategory)
+    const category = categories.value.find((category) => category.name === selectedCategory);
 
     if (category != null) {
       const categoryRowIndex = categoriesList.value.findIndex(
-        (row) => row.type === 'category' && row.name === selectedCategory
-      )
+        (row) => row.type === 'category' && row.name === selectedCategory,
+      );
 
       if (categoryRowIndex !== -1) {
         setTimeout(() => {
-          scrollTo(categoryRowIndex)
-        }, 0)
+          scrollTo(categoryRowIndex);
+        }, 0);
       }
     }
   }
 
-  watch(selectedCategory, scrollToSelectedCategory)
+  watch(selectedCategory, scrollToSelectedCategory);
 
   onMounted(() => {
     setTimeout(() => {
-      scrollToSelectedCategory(selectedCategory.value)
-    }, 0)
-  })
+      scrollToSelectedCategory(selectedCategory.value);
+    }, 0);
+  });
 
   watch(searchQueryDebounced, () => {
-    scrollTo(0)
-  })
+    scrollTo(0);
+  });
 
   watch(categories, (items) => {
-    categoryCounts.value = Object.fromEntries(
-      items.map(({ name, icons }) => [name, icons.length])
-    );
-  })
+    categoryCounts.value = Object.fromEntries(items.map(({ name, icons }) => [name, icons.length]));
+  });
 }

--- a/docs/.vitepress/theme/composables/useSearch.ts
+++ b/docs/.vitepress/theme/composables/useSearch.ts
@@ -20,7 +20,7 @@ const useSearch = <T>(
       return index.value.search(query.value).map((result) => result.item);
     }
 
-    if(keys.length !== 0) {
+    if (keys.length !== 0) {
       const mainKey = keys[0].name;
 
       return collection.value.sort((a, b) => {

--- a/docs/.vitepress/theme/composables/useSearch.ts
+++ b/docs/.vitepress/theme/composables/useSearch.ts
@@ -22,6 +22,7 @@ const useSearch = <T>(
 
     if(keys.length !== 0) {
       const mainKey = keys[0].name;
+
       return collection.value.sort((a, b) => {
         const aString = a[mainKey as keyof T] as string;
         const bString = b[mainKey as keyof T] as string;

--- a/docs/.vitepress/theme/composables/useSearch.ts
+++ b/docs/.vitepress/theme/composables/useSearch.ts
@@ -4,7 +4,7 @@ import { shallowRef, computed, Ref } from 'vue';
 const useSearch = <T>(
   query: Ref<string>,
   collection: Ref<T[]>,
-  keys: Fuse.FuseOptionKey<T>[] = [],
+  keys: Fuse.FuseOptionKeyObject<T>[] = [],
 ) => {
   const index = shallowRef(
     new Fuse(collection.value, {
@@ -18,6 +18,15 @@ const useSearch = <T>(
 
     if (query.value) {
       return index.value.search(query.value).map((result) => result.item);
+    }
+
+    if(keys.length !== 0) {
+      const mainKey = keys[0].name;
+      return collection.value.sort((a, b) => {
+        const aString = a[mainKey as keyof T] as string;
+        const bString = b[mainKey as keyof T] as string;
+        return aString.localeCompare(bString);
+      });
     }
 
     return collection.value;

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -23,6 +23,8 @@
   --vp-code-editor-property: #005cc5;
   --vp-code-editor-static: #f78c6c;
   --vp-code-editor-string: #032f62;
+
+  --vp-c-text-4: rgba(60, 60, 67, 0.32);
 }
 
 .dark {
@@ -38,6 +40,8 @@
   --vp-code-editor-property: #79b8ff;
   --vp-code-editor-static: #f78c6c;
   --vp-code-editor-string: #9ecbff;
+
+  --vp-c-text-4: rgba(235, 235, 245, 0.16);
 }
 
 .VPNavBarTitle .logo {

--- a/docs/.vitepress/theme/utils/chunkArray.ts
+++ b/docs/.vitepress/theme/utils/chunkArray.ts
@@ -1,10 +1,9 @@
 const chunkArray = <ArrayType>(stream: ArrayType, size: number) => {
   return stream.reduce<ArrayType[][]>(
     (chunks, item, idx, arr) =>
-    (idx % size == 0)
-      ? [...chunks, arr.slice(idx, idx + size)]
-      : chunks,
-    []);
-}
+      idx % size == 0 ? [...chunks, arr.slice(idx, idx + size)] : chunks,
+    [],
+  );
+};
 
-export default chunkArray
+export default chunkArray;

--- a/docs/.vitepress/theme/utils/chunkArray.ts
+++ b/docs/.vitepress/theme/utils/chunkArray.ts
@@ -1,0 +1,10 @@
+const chunkArray = <ArrayType>(stream: ArrayType, size: number) => {
+  return stream.reduce<ArrayType[][]>(
+    (chunks, item, idx, arr) =>
+    (idx % size == 0)
+      ? [...chunks, arr.slice(idx, idx + size)]
+      : chunks,
+    []);
+}
+
+export default chunkArray


### PR DESCRIPTION
Also closes #1724 

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- Site update

### Description
- Improves scrolling with the use of virtual scrolling. Especially performant on mobile.
- Improves list rendering on the category page, when navigating to a category there is a bit of a lag.
- Improves floating marker position in the sidebar when scrolling through categories
- Fixes list rendering when resetting search.
- Sorting icons on category, closes #1724 
- Showing icon count per category in the sidebar when searching:
![image](https://github.com/lucide-icons/lucide/assets/11825403/ae3ded1d-7a18-451d-814c-334dd21e3a36)
