### PR TITLE
feat: added 16px low dpi preview

### DIFF
--- a/docs/.vitepress/api/gh-icon/dpi/[...data].get.ts
+++ b/docs/.vitepress/api/gh-icon/dpi/[...data].get.ts
@@ -8,9 +8,9 @@ export default eventHandler(async (event) => {
   const { params = {} } = event.context;
   await initializedResvg;
 
-  const imageSize = 96;
   const [iconSizeString, svgData] = params.data.split('/');
   const iconSize = parseInt(iconSizeString, 10);
+  const imageSize = iconSize * 4;
   const data = svgData.slice(0, -4);
 
   const src = Buffer.from(data, 'base64').toString('utf8');
@@ -25,7 +25,7 @@ export default eventHandler(async (event) => {
   viewBox="0 0 24 24"
   fill="none"
   stroke="#fff"
-  stroke-width="2"
+  stroke-width="${48 / iconSize}"
   stroke-linecap="round"
   stroke-linejoin="round"
 `,

--- a/scripts/generateChangedIconsCommentMarkup.mjs
+++ b/scripts/generateChangedIconsCommentMarkup.mjs
@@ -57,7 +57,14 @@ const changeFiles3pxStrokeImageTags = getImageTagsByFiles(
   () => `${BASE_URL}/stroke-width/3`,
 );
 
-const changeFilesLowDPIImageTags = getImageTagsByFiles(changedFiles, () => `${BASE_URL}/dpi/24`);
+const changeFiles24pxLowDPIImageTags = getImageTagsByFiles(
+  changedFiles,
+  () => `${BASE_URL}/dpi/24`,
+);
+const changeFiles16pxLowDPIImageTags = getImageTagsByFiles(
+  changedFiles,
+  () => `${BASE_URL}/dpi/32`,
+);
 
 const changeFilesXRayImageTags = getImageTagsByFiles(
   changedFiles,
@@ -85,8 +92,12 @@ ${changeFiles2pxStrokeImageTags}<br/>
 ${changeFiles3pxStrokeImageTags}<br/>
 </details>
 <details>
-<summary>DPI Preview (24px)</summary>
-${changeFilesLowDPIImageTags}<br/>
+<summary>DPI Preview (24px/2px)</summary>
+${changeFiles24pxLowDPIImageTags}<br/>
+</details>
+<details>
+<summary>DPI Preview (16px/1.5px)</summary>
+${changeFiles16pxLowDPIImageTags}<br/>
 </details>
 <details>
 <summary>Icon X-rays</summary>

--- a/scripts/generateChangedIconsCommentMarkup.mjs
+++ b/scripts/generateChangedIconsCommentMarkup.mjs
@@ -60,10 +60,12 @@ const changeFiles3pxStrokeImageTags = getImageTagsByFiles(
 const changeFiles24pxLowDPIImageTags = getImageTagsByFiles(
   changedFiles,
   () => `${BASE_URL}/dpi/24`,
+  96,
 );
 const changeFiles16pxLowDPIImageTags = getImageTagsByFiles(
   changedFiles,
   () => `${BASE_URL}/dpi/32`,
+  96,
 );
 
 const changeFilesXRayImageTags = getImageTagsByFiles(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: Preview Comment Workflow

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Allows us to check if the icon is also sharp at 66%/16x16 scale.

### Examples

#### `square-x` sharp both at 24 and 16px
![square24](https://github.com/lucide-icons/lucide/assets/25524993/6a2bee11-4b30-4c79-823e-0f503153a116) ![square32](https://github.com/lucide-icons/lucide/assets/25524993/747803ac-3fcf-452b-950d-36105c1d9158)

#### `archive` sharp only at 24px

![archive24](https://github.com/lucide-icons/lucide/assets/25524993/a45ebfe5-02d2-45f8-a8f8-fdbdab6daf38) ![archive32](https://github.com/lucide-icons/lucide/assets/25524993/2e689f62-3b7a-4d5f-bde8-76ff7ca06aaf)



## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
