### PR TITLE
fix: readded gap between x-ray preview comment icons.

### DIFF
--- a/scripts/generateChangedIconsCommentMarkup.mjs
+++ b/scripts/generateChangedIconsCommentMarkup.mjs
@@ -26,7 +26,7 @@ const getImageTagsByFiles = (files, getBaseUrl, width) =>
 
       return `<img title="${file}" alt="${file}" ${widthAttr} src="${url}/${base64}.svg"/>`;
     })
-    .join('');
+    .join(width.includes('%') ? ' ' : '');
 
 const svgFiles = readSvgDirectory(ICONS_DIR).map((file) => `icons/${file}`);
 
@@ -66,7 +66,7 @@ const changeFilesXRayImageTags = getImageTagsByFiles(
 
     return `${BASE_URL}/${iconName}`;
   },
-  400,
+  '48%',
 );
 
 const commentMarkup = `\


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: Preview comment improvement

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

There used to be a gap between icons in the x-ray section.

But it is gone, and it doesn't look great to have them bud against each other.

Example:
<img width="237" alt="image" src="https://github.com/lucide-icons/lucide/assets/25524993/39cbcffc-8f66-41eb-8555-aac62a1899ab">



## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
