### PR TITLE
fix(icons/concierge-bell): Adds missing rounding from bottom part

### DIFF
--- a/icons/concierge-bell.svg
+++ b/icons/concierge-bell.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M2 18a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v2H2v-2Z" />
+  <path d="M3 20a1 1 0 0 1-1-1v-1a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v1a1 1 0 0 1-1 1Z" />
   <path d="M20 16a8 8 0 1 0-16 0" />
   <path d="M12 4v4" />
   <path d="M10 4h4" />


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Bug fix

### Description
#1896 and #1895 fixed some other guideline offenders, `concierge-bell` uses the same shape so it should also be fixed.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
