### PR TITLE
fix(icons): optimized `keyboard` icon for better figma support

### DIFF
--- a/icons/keyboard.svg
+++ b/icons/keyboard.svg
@@ -9,13 +9,13 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="20" height="16" x="2" y="4" rx="2" ry="2" />
-  <path d="M6 8h.001" />
-  <path d="M10 8h.001" />
-  <path d="M14 8h.001" />
-  <path d="M18 8h.001" />
-  <path d="M8 12h.001" />
-  <path d="M12 12h.001" />
-  <path d="M16 12h.001" />
+  <path d="M10 8h.01" />
+  <path d="M12 12h.01" />
+  <path d="M14 8h.01" />
+  <path d="M16 12h.01" />
+  <path d="M18 8h.01" />
+  <path d="M6 8h.01" />
   <path d="M7 16h10" />
+  <path d="M8 12h.01" />
+  <rect x="2" y="4" width="20" height="16" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Ran optimization

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.