### PR TITLE
Aliases redirect on site

### DIFF
--- a/scripts/writeIconDetails.mjs
+++ b/scripts/writeIconDetails.mjs
@@ -28,7 +28,7 @@ import iconNode from '../iconNodes/${iconName}.node.json'
 import metaData from '../../../../icons/${iconName}.json'
 import releaseData from '../releaseMetadata/${iconName}.json'
 
-const { tags, categories, contributors } = metaData
+const { tags, categories, contributors, aliases } = metaData
 
 const iconDetails = {
   name: '${iconName}',
@@ -36,6 +36,7 @@ const iconDetails = {
   contributors,
   tags,
   categories,
+  aliases,
   ...releaseData,
 }
 

--- a/scripts/writeVercelOutput.mjs
+++ b/scripts/writeVercelOutput.mjs
@@ -1,7 +1,15 @@
 import path from 'path';
 import fs from 'fs';
+// eslint-disable-next-line import/no-named-as-default, import/no-named-as-default-member
+import getIconMetaData from '../tools/build-icons/utils/getIconMetaData.mjs';
+import { getCurrentDirPath } from './helpers.mjs';
 
 const currentDir = process.cwd();
+const scriptDir = getCurrentDirPath(import.meta.url);
+
+// const iconMetaData = await getIconMetaData(path.resolve(scriptDir, '../icons'));
+
+// console.log(iconMetaData);
 
 const vercelRouteConfig = {
   version: 3,
@@ -15,6 +23,12 @@ const vercelRouteConfig = {
       src: '(?<url>/api/.*)',
       dest: '/__nitro?url=$url',
     },
+    {
+      "src": "(?<url>/icons/grid)",
+      "status": 302,
+      "headers": {
+        "Location": "/grid-3x3" }
+    }
     // {
     //   source: '/icon/:path*',
     //   destination: '/icons/:path*',
@@ -30,6 +44,6 @@ const vercelRouteConfig = {
 
 const output = JSON.stringify(vercelRouteConfig, null, 2);
 
-const vercelOutputJosn = path.resolve(currentDir, '.vercel/output/config.json');
+const vercelOutputJSON = path.resolve(currentDir, '.vercel/output/config.json');
 
-fs.writeFileSync(vercelOutputJosn, output, 'utf-8');
+fs.writeFileSync(vercelOutputJSON, output, 'utf-8');

--- a/scripts/writeVercelOutput.mjs
+++ b/scripts/writeVercelOutput.mjs
@@ -9,7 +9,19 @@ const scriptDir = getCurrentDirPath(import.meta.url);
 
 const iconMetaData = await getIconMetaData(path.resolve(scriptDir, '../icons'));
 
-console.log(iconMetaData);
+const iconAliasesRedirectRoutes = Object.entries(iconMetaData)
+  .filter(([, { aliases }]) => aliases?.length)
+  .map(([iconName, { aliases }]) => {
+    const aliasRouteMatches = aliases.join('|');
+
+    return {
+      src: `/icons/(${aliasRouteMatches})`,
+      status: 302,
+      headers: {
+        Location: `/icons/${iconName}`,
+      },
+    };
+})
 
 const vercelRouteConfig = {
   version: 3,
@@ -23,13 +35,7 @@ const vercelRouteConfig = {
       src: '(?<url>/api/.*)',
       dest: '/__nitro?url=$url',
     },
-    {
-      src: "/icons/(grid|grid-4x4)",
-      status: 302,
-      headers: {
-        Location: "/icons/grid-3x3"
-      }
-    }
+    ...iconAliasesRedirectRoutes
   ],
 };
 

--- a/scripts/writeVercelOutput.mjs
+++ b/scripts/writeVercelOutput.mjs
@@ -21,7 +21,7 @@ const iconAliasesRedirectRoutes = Object.entries(iconMetaData)
         Location: `/icons/${iconName}`,
       },
     };
-})
+  });
 
 const vercelRouteConfig = {
   version: 3,
@@ -35,7 +35,7 @@ const vercelRouteConfig = {
       src: '(?<url>/api/.*)',
       dest: '/__nitro?url=$url',
     },
-    ...iconAliasesRedirectRoutes
+    ...iconAliasesRedirectRoutes,
   ],
 };
 

--- a/scripts/writeVercelOutput.mjs
+++ b/scripts/writeVercelOutput.mjs
@@ -7,9 +7,9 @@ import { getCurrentDirPath } from './helpers.mjs';
 const currentDir = process.cwd();
 const scriptDir = getCurrentDirPath(import.meta.url);
 
-// const iconMetaData = await getIconMetaData(path.resolve(scriptDir, '../icons'));
+const iconMetaData = await getIconMetaData(path.resolve(scriptDir, '../icons'));
 
-// console.log(iconMetaData);
+console.log(iconMetaData);
 
 const vercelRouteConfig = {
   version: 3,
@@ -24,21 +24,12 @@ const vercelRouteConfig = {
       dest: '/__nitro?url=$url',
     },
     {
-      "src": "(?<url>/icons/grid)",
-      "status": 302,
-      "headers": {
-        "Location": "/grid-3x3" }
+      src: "/icons/(grid|grid-4x4)",
+      status: 302,
+      headers: {
+        Location: "/icons/grid-3x3"
+      }
     }
-    // {
-    //   source: '/icon/:path*',
-    //   destination: '/icons/:path*',
-    //   permanent: true,
-    // },
-    // {
-    //   src: '/(.*)',
-    //   status: 404,
-    //   dest: '/static/404.html',
-    // },
   ],
 };
 


### PR DESCRIPTION
Adds redirects for icon aliases

## What is the purpose of this pull request?
- Site update

### Description
When icons get renamed we add aliases for these. But currently on the site old names can't be resolved and results in a 404.

# Example not working
https://lucide.dev/icons/edit-3

# Example with these redirect config
https://lucide-36pmn4tea-lucide.vercel.app/icons/edit-3