### PR TITLE
hotfix(icons): remove circle-ellipsis alias from circle-ellipsis

### DIFF
--- a/icons/circle-ellipsis.json
+++ b/icons/circle-ellipsis.json
@@ -26,8 +26,5 @@
     "layout",
     "development",
     "shapes"
-  ],
-  "aliases": [
-    "circle-ellipsis"
   ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
