### PR TITLE
fix(packages/lucide-solid): use jsx extension for solid build

### DIFF
--- a/packages/lucide-solid/rollup.config.mjs
+++ b/packages/lucide-solid/rollup.config.mjs
@@ -30,7 +30,7 @@ const configs = bundles
       input,
       plugins: [
         babel({
-          extensions: ['.ts', '.tsx', '.js'],
+          extensions: ['.ts', '.tsx', '.js', '.jsx'],
           babelHelpers: 'bundled',
           presets: [
             'babel-preset-solid',
@@ -50,10 +50,14 @@ const configs = bundles
                 esbuild.build({
                   entryPoints: ['./src/**/*.tsx', './src/**/*.ts'],
                   outdir: './dist/source',
+                  outExtension: {
+                    '.js': '.jsx',
+                  },
                   loader: {
                     '.js': 'jsx',
                   },
                   jsx: 'preserve',
+                  jsxImportSource: 'solid-js',
                   bundle: true,
                   format: 'esm',
                   sourcemap: true,


### PR DESCRIPTION
closes https://github.com/lucide-icons/lucide/issues/1962

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Bug fix

### Description
Our Solid export uses JS extensions, some frameworks, such as Tauri mistakenly use these sources as JS files, this PR updates our build flow so that these Solid exports are exported as JSX.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
