### PR TITLE
fix(lucide-solid): use jsx for exports too

### DIFF
--- a/packages/lucide-solid/package.json
+++ b/packages/lucide-solid/package.json
@@ -33,7 +33,7 @@
   "exports": {
     ".": {
       "types": "./dist/types/lucide-solid.d.ts",
-      "solid": "./dist/source/lucide-solid.js",
+      "solid": "./dist/source/lucide-solid.jsx",
       "import": "./dist/esm/lucide-solid.js",
       "browser": "./dist/esm/lucide-solid.js",
       "require": "./dist/cjs/lucide-solid.js",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
In #1964, the build output was specified as .jsx, but it was not modified in package.json.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
