### PR TITLE
fix(packages/lucide): exports aliases from `lucide` package

### DIFF
--- a/packages/lucide/src/lucide.ts
+++ b/packages/lucide/src/lucide.ts
@@ -47,6 +47,7 @@ export { default as createElement } from './createElement';
 */
 export { iconAndAliases as icons };
 export * from './icons';
+export * from './aliases';
 
 /*
  Types exports.


### PR DESCRIPTION
closes #1975

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Bug fix

### Description
Aliases aren't directly exported from `lucide`, this PR fixes this issue so that the package remains backwards compatible.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
