### PR TITLE
fix(icons/cpu): add guideline compliant rounding to CPU center

### DIFF
--- a/icons/cpu.svg
+++ b/icons/cpu.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="4" y="4" width="16" height="16" rx="2" />
-  <rect x="9" y="9" width="6" height="6" />
+  <rect width="16" height="16" x="4" y="4" rx="2" />
+  <rect width="6" height="6" x="9" y="9" rx="1" />
   <path d="M15 2v2" />
   <path d="M15 20v2" />
   <path d="M2 15h2" />


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] Bug fix

### Description
CPU is missing the mandatory 1px rounding as dictated by our design guidelines.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
