### PR TITLE
feat(icons): adds microchip icon

### DIFF
--- a/icons/microchip.json
+++ b/icons/microchip.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "karsa-mistmere",
+    "colebemis",
+    "ericfennis"
+  ],
+  "tags": [
+    "processor",
+    "cores",
+    "technology",
+    "computer",
+    "chip",
+    "integrated circuit",
+    "memory",
+    "ram",
+    "specs",
+    "gpu",
+    "gigahertz",
+    "ghz"
+  ],
+  "categories": [
+    "devices"
+  ]
+}

--- a/icons/microchip.svg
+++ b/icons/microchip.svg
@@ -8,4 +8,14 @@
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
-/>
+>
+  <path d="M18 12h2" />
+  <path d="M18 18h2" />
+  <path d="M18 6h2" />
+  <path d="M4 12h2" />
+  <path d="M4 18h2" />
+  <path d="M4 6h2" />
+  <rect width="4" height="4" x="10" y="14" rx="1" />
+  <rect width="4" height="4" x="10" y="6" rx="1" />
+  <rect width="12" height="20" x="6" y="2" rx="2" />
+</svg>

--- a/icons/microchip.svg
+++ b/icons/microchip.svg
@@ -1,0 +1,11 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+/>

--- a/icons/microchip.svg
+++ b/icons/microchip.svg
@@ -10,12 +10,14 @@
   stroke-linejoin="round"
 >
   <path d="M18 12h2" />
-  <path d="M18 18h2" />
-  <path d="M18 6h2" />
+  <path d="M18 16h2" />
+  <path d="M18 20h2" />
+  <path d="M18 4h2" />
+  <path d="M18 8h2" />
   <path d="M4 12h2" />
-  <path d="M4 18h2" />
-  <path d="M4 6h2" />
-  <rect width="4" height="4" x="10" y="14" rx="1" />
-  <rect width="4" height="4" x="10" y="6" rx="1" />
-  <rect width="12" height="20" x="6" y="2" rx="2" />
+  <path d="M4 16h2" />
+  <path d="M4 20h2" />
+  <path d="M4 4h2" />
+  <path d="M4 8h2" />
+  <path d="M8 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2h-1.5c-.276 0-.494.227-.562.495a2 2 0 0 1-3.876 0C9.994 2.227 9.776 2 9.5 2z" />
 </svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Icon

### Description
We do not currently have an icon that could represent GPUs, this PR adds a `microchip` icon that could stand in for either GPUs or RAM.

### Icon use case
- gpu
- ram
- microchip

### Alternative icon designs <!-- ONLY for new icons, remove this part if not icon PR -->
![image](https://github.com/lucide-icons/lucide/assets/17746067/f8f546b8-462b-4c92-8cbb-91e514711f51)

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] I've based them on the following Lucide icons: `cpu`

### Naming <!-- ONLY for new icons -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to two points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
