### PR TITLE
fix(icons): added rounding to `pause` icon

### DIFF
--- a/icons/pause.json
+++ b/icons/pause.json
@@ -2,7 +2,8 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "colebemis",
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "music",

--- a/icons/pause.svg
+++ b/icons/pause.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="4" height="16" x="6" y="4" />
-  <rect width="4" height="16" x="14" y="4" />
+  <rect x="14" y="4" width="4" height="16" rx="1" />
+  <rect x="6" y="4" width="4" height="16" rx="1" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Added rounding

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.