### PR TITLE
fix(icons): added rounding to `monitor-stop` icon

### DIFF
--- a/icons/monitor-stop.svg
+++ b/icons/monitor-stop.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect x="9" y="7" width="6" height="6" />
-  <rect width="20" height="14" x="2" y="3" rx="2" />
   <path d="M12 17v4" />
   <path d="M8 21h8" />
+  <rect x="2" y="3" width="20" height="14" rx="2" />
+  <rect x="9" y="7" width="6" height="6" rx="1" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Added rounding

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.