### PR TITLE
fix(icons): added rounding to `coffee` icon

### DIFF
--- a/icons/coffee.json
+++ b/icons/coffee.json
@@ -5,7 +5,8 @@
     "csandman",
     "mittalyashu",
     "ericfennis",
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "drink",

--- a/icons/coffee.svg
+++ b/icons/coffee.svg
@@ -9,9 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M17 8h1a4 4 0 1 1 0 8h-1" />
-  <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z" />
-  <line x1="6" x2="6" y1="2" y2="4" />
-  <line x1="10" x2="10" y1="2" y2="4" />
-  <line x1="14" x2="14" y1="2" y2="4" />
+  <path d="M10 2v2" />
+  <path d="M14 2v2" />
+  <path d="M16 8a1 1 0 0 1 1 1v8a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V9a1 1 0 0 1 1-1h14a4 4 0 1 1 0 8h-1" />
+  <path d="M6 2v2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Added roundness, manual operations where needed.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.