### PR TITLE
fix(icons): fixed `align-vertical-distribute-center` icon

### DIFF
--- a/icons/align-vertical-distribute-center.json
+++ b/icons/align-vertical-distribute-center.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "items",

--- a/icons/align-vertical-distribute-center.svg
+++ b/icons/align-vertical-distribute-center.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="14" height="6" x="5" y="14" rx="2" />
-  <rect width="10" height="6" x="7" y="4" rx="2" />
-  <path d="M22 7h-5" />
-  <path d="M7 7H1" />
   <path d="M22 17h-3" />
+  <path d="M22 7h-5" />
   <path d="M5 17H2" />
+  <path d="M7 7H2" />
+  <rect x="5" y="14" width="14" height="6" rx="2" />
+  <rect x="7" y="4" width="10" height="6" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Fix 1px border violation

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.