### PR TITLE
feat(figma): add data API endpoint for new plugin

### DIFF
--- a/docs/.vitepress/api/data/index.get.ts
+++ b/docs/.vitepress/api/data/index.get.ts
@@ -1,0 +1,39 @@
+import { eventHandler, setResponseHeader } from 'h3';
+import { getAllCategoryFiles } from '../../lib/categories.ts';
+import iconNodes from '../../data/iconNodes';
+import { IconNodeWithKeys } from '../../theme/types.ts';
+import iconMetaData from '../../data/iconMetaData.ts';
+import releaseMeta from '../../data/releaseMetaData.json';
+
+export default eventHandler((event) => {
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=86400');
+  setResponseHeader(event, 'Access-Control-Allow-Origin', '*');
+
+  return {
+    icons: Object.entries(iconNodes).reduce((acc, [name, iconNode]) => {
+      const newIconNode = (iconNode as IconNodeWithKeys).map(([name, { key, ...attrs }]) => {
+        return [name, attrs];
+      });
+
+      acc[name] = {
+        iconNode: newIconNode,
+        aliases: (iconMetaData[name]?.aliases ?? []).map((alias) =>
+          typeof alias === 'string' ? alias : alias.name,
+        ),
+        tags: iconMetaData[name].tags ?? [],
+        categories: iconMetaData[name].categories ?? [],
+        ...releaseMeta[name],
+      };
+
+      return acc;
+    }, {}),
+    aliases: Object.entries(iconNodes).reduce((acc, [name]) => {
+      for (const alias of iconMetaData[name]?.aliases ?? []) {
+        acc[typeof alias === 'string' ? alias : alias.name] = name;
+      }
+
+      return acc;
+    }, {}),
+    categories: getAllCategoryFiles(),
+  };
+});

--- a/docs/.vitepress/api/data/index.get.ts
+++ b/docs/.vitepress/api/data/index.get.ts
@@ -1,39 +1,41 @@
 import { eventHandler, setResponseHeader } from 'h3';
-import { getAllCategoryFiles } from '../../lib/categories.ts';
 import iconNodes from '../../data/iconNodes';
 import { IconNodeWithKeys } from '../../theme/types.ts';
 import iconMetaData from '../../data/iconMetaData.ts';
 import releaseMeta from '../../data/releaseMetaData.json';
+import { getAllCategoryFiles } from '../../lib/categories.ts';
+
+const dataResponse = {
+  icons: Object.entries(iconNodes).reduce((acc, [name, iconNode]) => {
+    const newIconNode = (iconNode as IconNodeWithKeys).map(([name, { key, ...attrs }]) => {
+      return [name, attrs];
+    });
+
+    acc[name] = {
+      iconNode: newIconNode,
+      aliases: (iconMetaData[name]?.aliases ?? []).map((alias) =>
+        typeof alias === 'string' ? alias : alias.name,
+      ),
+      tags: iconMetaData[name].tags ?? [],
+      categories: iconMetaData[name].categories ?? [],
+      ...releaseMeta[name],
+    };
+
+    return acc;
+  }, {}),
+  aliases: Object.entries(iconNodes).reduce((acc, [name]) => {
+    for (const alias of iconMetaData[name]?.aliases ?? []) {
+      acc[typeof alias === 'string' ? alias : alias.name] = name;
+    }
+
+    return acc;
+  }, {}),
+  categories: getAllCategoryFiles(),
+};
 
 export default eventHandler((event) => {
   setResponseHeader(event, 'Cache-Control', 'public, max-age=86400');
   setResponseHeader(event, 'Access-Control-Allow-Origin', '*');
 
-  return {
-    icons: Object.entries(iconNodes).reduce((acc, [name, iconNode]) => {
-      const newIconNode = (iconNode as IconNodeWithKeys).map(([name, { key, ...attrs }]) => {
-        return [name, attrs];
-      });
-
-      acc[name] = {
-        iconNode: newIconNode,
-        aliases: (iconMetaData[name]?.aliases ?? []).map((alias) =>
-          typeof alias === 'string' ? alias : alias.name,
-        ),
-        tags: iconMetaData[name].tags ?? [],
-        categories: iconMetaData[name].categories ?? [],
-        ...releaseMeta[name],
-      };
-
-      return acc;
-    }, {}),
-    aliases: Object.entries(iconNodes).reduce((acc, [name]) => {
-      for (const alias of iconMetaData[name]?.aliases ?? []) {
-        acc[typeof alias === 'string' ? alias : alias.name] = name;
-      }
-
-      return acc;
-    }, {}),
-    categories: getAllCategoryFiles(),
-  };
+  return dataResponse;
 });


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Feature

### Description
This PR adds a new data API endpoint the new Figma plugin can use to fetch the icon nodes, categories, aliases et cetera all at once.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
