### PR TITLE
fix(icons): Add axis tag to scale-3d

### DIFF
--- a/icons/scale-3d.json
+++ b/icons/scale-3d.json
@@ -3,8 +3,7 @@
   "contributors": [
     "lscheibel",
     "ericfennis",
-    "jguddas",
-    "gurtt"
+    "jguddas"
   ],
   "tags": [
     "gizmo",

--- a/icons/scale-3d.json
+++ b/icons/scale-3d.json
@@ -3,12 +3,14 @@
   "contributors": [
     "lscheibel",
     "ericfennis",
-    "jguddas"
+    "jguddas",
+    "gurtt"
   ],
   "tags": [
     "gizmo",
     "transform",
-    "size"
+    "size",
+    "axis"
   ],
   "categories": [
     "design"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Add `axis` tag to `scale-3d`, bringing it in line with similar `axis-3d` and `move-3d`.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
