### PR TITLE
meta(icons): Add axis tag to rotate-3d

### DIFF
--- a/icons/rotate-3d.json
+++ b/icons/rotate-3d.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "lscheibel",
+    "lscheibel"
   ],
   "tags": [
     "gizmo",

--- a/icons/rotate-3d.json
+++ b/icons/rotate-3d.json
@@ -2,7 +2,6 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "lscheibel",
-    "gurtt"
   ],
   "tags": [
     "gizmo",

--- a/icons/rotate-3d.json
+++ b/icons/rotate-3d.json
@@ -1,13 +1,15 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "lscheibel"
+    "lscheibel",
+    "gurtt"
   ],
   "tags": [
     "gizmo",
     "transform",
     "orientation",
-    "orbit"
+    "orbit",
+    "axis"
   ],
   "categories": [
     "design"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Add `axis` tag to `rotate-3d`, bringing it in line with similar `axis-3d` and `move-3d`.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
