### PR TITLE
fix(preview-comment): Add escape characters to package compatibility list

### DIFF
--- a/scripts/generateChangedIconsCommentMarkup.mjs
+++ b/scripts/generateChangedIconsCommentMarkup.mjs
@@ -122,7 +122,7 @@ ${
 `
 }
 Only working for:
-`lucide-react`, `lucide-react-native`, `lucide-preact`, `lucide-vue-next`
+\`lucide-react\`, \`lucide-react-native\`, \`lucide-preact\`, \`lucide-vue-next\`
 \`\`\`ts
 ${readyToUseCode}
 \`\`\`${readyToUseCode.split('/n').length < 20 ? '' : '\n\n</details>'}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Fixes a regression introduced in 69e2ec0e1c8002f02854a373ab923eab9e460836.

Adds escape characters to fix failed runs on workflows using the `generate-changed-icons-comment` job, for example on #2032.

This change has been tested and works as demonstrated on [gurtt/lucide #2](https://github.com/gurtt/lucide/pull/2).

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
