### PR TITLE
feat(icons): added image frame icon

### DIFF
--- a/icons/image-frame.json
+++ b/icons/image-frame.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "gooyoung"
+  ],
+  "tags": [
+    "picture",
+    "photo",
+    "frame"
+  ],
+  "categories": [
+    "photography",
+    "text",
+    "multimedia",
+    "files"
+  ]
+}

--- a/icons/image-frame.svg
+++ b/icons/image-frame.svg
@@ -1,0 +1,14 @@
+<svg 
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 7V5a2 2 0 0 1 2-2h2m10 0h2a2 2 0 0 1 2 2v2m0 10v2a2 2 0 0 1-2 2h-2M7 21H5a2 2 0 0 1-2-2v-2M16.67 6H7.33C6.6 6 6 6.6 6 7.33v9.34C6 17.4 6.6 18 7.33 18h9.34c.73 0 1.33-.6 1.33-1.33V7.33C18 6.6 17.4 6 16.67 6Z"/>
+  <path d="M9.38 10.5c.62 0 1.12-.34 1.12-.75S10 9 9.37 9c-.62 0-1.12.34-1.12.75s.5.75 1.13.75ZM18 13.35l-2-2.4a1.2 1.2 0 0 0-.93-.45c-.34 0-.67.16-.91.45L8.25 18"/>
+</svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Icon

## Icon Design Checklist

### Concept <!-- ONLY for new icons -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
- [x] I've based them on the following Lucide icons: `image`

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
