### PR TITLE
feat(icons): add projection-first and projection-third

### DIFF
--- a/icons/projection-first.json
+++ b/icons/projection-first.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "gurtt"
+  ],
+  "tags": [
+    "drawing",
+    "layout",
+    "angle"
+  ],
+  "categories": [
+    "maths",
+    "shapes"
+  ]
+}

--- a/icons/projection-first.svg
+++ b/icons/projection-first.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M8 7v10l-6-3v-4z" />
+  <circle cx="17" cy="12" r="1" />
+  <circle cx="17" cy="12" r="5" />
+</svg>

--- a/icons/projection-first.svg
+++ b/icons/projection-first.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M8 7v10l-6-3v-4z" />
+  <path d="M7.276 7.362A.5.5 0 0 1 8 7.809v8.382a.5.5 0 0 1-.724.447l-5-2.5A.5.5 0 0 1 2 13.691v-3.382a.5.5 0 0 1 .276-.447z" />
   <circle cx="17" cy="12" r="1" />
   <circle cx="17" cy="12" r="5" />
 </svg>

--- a/icons/projection-third.json
+++ b/icons/projection-third.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "gurtt"
+  ],
+  "tags": [
+    "drawing",
+    "layout",
+    "angle"
+  ],
+  "categories": [
+    "maths",
+    "shapes"
+  ]
+}

--- a/icons/projection-third.svg
+++ b/icons/projection-third.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 7v10l-6-3v-4z" />
+  <circle cx="7" cy="12" r="1" />
+  <circle cx="7" cy="12" r="5" />
+</svg>

--- a/icons/projection-third.svg
+++ b/icons/projection-third.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M22 7v10l-6-3v-4z" />
+  <path d="M21.276 7.362a.5.5 0 0 1 .724.447v8.382a.5.5 0 0 1-.724.447l-5-2.5a.5.5 0 0 1-.276-.447v-3.382a.5.5 0 0 1 .276-.447z" />
   <circle cx="7" cy="12" r="1" />
   <circle cx="7" cy="12" r="5" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Adds icons for the standard symbols representing first and third angle projections.

### Icon use case <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
These symbols are used:
* in technical drawings to indicate the projection method
* in some mathematical contexts for a similar purpose
* in some 3D applications for a similar purpose

### Alternative icon designs <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- If you have any alternative icon designs, please attach them here. -->
![first-angle-alt](https://github.com/lucide-icons/lucide/assets/6712553/d5b5a4a0-6c40-406e-88dc-c4adbb98a851)
![third-angle-alt](https://github.com/lucide-icons/lucide/assets/6712553/4a16c1a6-95dc-466b-9b58-b226f3d64f4c)

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [x] I've based them on the following design: ISO 128-30:2001 A.2, ISO 128-30:2001 B.2

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
