### PR TITLE
Add bot-off icon

### DIFF
--- a/icons/bot-off.json
+++ b/icons/bot-off.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "taichimaeda"
+  ],
+  "tags": [
+    "robot",
+    "ai",
+    "chat",
+    "assistant"
+  ],
+  "categories": [
+    "development",
+    "social"
+  ]
+}

--- a/icons/bot-off.json
+++ b/icons/bot-off.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "taichimaeda"
+    "taichimaeda",
+    "ericfennis"
   ],
   "tags": [
     "robot",

--- a/icons/bot-off.svg
+++ b/icons/bot-off.svg
@@ -1,0 +1,20 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 8V4H8" />
+  <path d="M2 14h2" />
+  <path d="M20 14h2" />
+  <path d="M15 13v2" />
+  <path d="M9 13v2" />
+  <path d="M2 2L12 12L22 22" />
+  <path d="M8 8H6C5 8 4 8 4 10C4 12 4 16 4 18C4 18 4 19 4 19C4 19 5 20 6 20C7 20 14 20 18 20C18 20 19 20 19 19" />
+  <path d="M12 8H18C18 8 20 8 20 10C20 11 20 15 20 16" />
+</svg>

--- a/icons/bot-off.svg
+++ b/icons/bot-off.svg
@@ -9,12 +9,11 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 8V4H8" />
+  <path d="M13.67 8H18a2 2 0 0 1 2 2v4.33" />
   <path d="M2 14h2" />
   <path d="M20 14h2" />
-  <path d="M15 13v2" />
+  <path d="M22 22 2 2" />
+  <path d="M8 8H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 1.414-.586" />
   <path d="M9 13v2" />
-  <path d="M2 2L12 12L22 22" />
-  <path d="M8 8H6C5 8 4 8 4 10C4 12 4 16 4 18C4 18 4 19 4 19C4 19 5 20 6 20C7 20 14 20 18 20C18 20 19 20 19 19" />
-  <path d="M12 8H18C18 8 20 8 20 10C20 11 20 15 20 16" />
+  <path d="M9.67 4H12v2.33" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

### Icon use case <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->

I'm currently developing an Obsidian plugin that has similar UI/UX to GitHub Copilot VSCode.

I need this `bot-off` icon for a Ribbon action item for this plugin, which shows the status of inline completions (i.e. enabled or disabled).

It will look something like this in VSCode:

<img width="482" alt="Pasted_Image_17_04_2024__15_04" src="https://github.com/lucide-icons/lucide/assets/28210288/145786be-bb2c-49e7-a0a3-774ce7bcbf7c">

The plugin uses the [`bot` icon](https://lucide.dev/icons/bot) for indicating that inline completions are enabled, and this `bot-off` icon will provide the counterpart for when they are disabled.

Or more generally speaking, this icon could be used in a status bar of any Web/native application which has some form of AI-powered features but allows its users to disable them for whatever the reasons.

### Alternative icon designs <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- If you have any alternative icon designs, please attach them here. -->

As I mentioned earlier, I've made this icon based off the [`bot` icon](https://lucide.dev/icons/bot) - I believe this is the most reasonable design in that it simply adds a diagonal line + some gap on top, like many other icons that has `-off` prefix e.g. [`eye-off` icon](https://lucide.dev/icons/eye-off)

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: `bot`
- [x] I've based them on the following design: `eye-off`

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
