### PR TITLE
Potential compatibility with shadow DOM

### DIFF
--- a/packages/lucide/src/lucide.ts
+++ b/packages/lucide/src/lucide.ts
@@ -5,25 +5,25 @@ import * as iconAndAliases from './iconsAndAliases';
  * Replaces all elements with matching nameAttr with the defined icons
  * @param {{ icons?: object, nameAttr?: string, attrs?: object }} options
  */
-const createIcons = ({ icons = {}, nameAttr = 'data-lucide', attrs = {} } = {}) => {
+const createIcons = ({ icons = {}, nameAttr = 'data-lucide', attrs = {}, rootElement = document } = {}) => {
   if (!Object.values(icons).length) {
     throw new Error(
       "Please provide an icons object.\nIf you want to use all the icons you can import it like:\n `import { createIcons, icons } from 'lucide';\nlucide.createIcons({icons});`",
     );
   }
 
-  if (typeof document === 'undefined') {
+  if (typeof rootElement === 'undefined') {
     throw new Error('`createIcons()` only works in a browser environment.');
   }
 
-  const elementsToReplace = document.querySelectorAll(`[${nameAttr}]`);
+  const elementsToReplace = rootElement.querySelectorAll(`[${nameAttr}]`);
   Array.from(elementsToReplace).forEach((element) =>
     replaceElement(element, { nameAttr, icons, attrs }),
   );
 
   /** @todo: remove this block in v1.0 */
   if (nameAttr === 'data-lucide') {
-    const deprecatedElements = document.querySelectorAll('[icon-name]');
+    const deprecatedElements = rootElement.querySelectorAll('[icon-name]');
     if (deprecatedElements.length > 0) {
       console.warn(
         '[Lucide] Some icons were found with the now deprecated icon-name attribute. These will still be replaced for backwards compatibility, but will no longer be supported in v1.0 and you should switch to data-lucide',


### PR DESCRIPTION
When using custom elements, needs to create icons again when inside of shadow DOM. Shadow DOM invisible from document selectors, so can't be replaced directly. **There is no new any icon.**

<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [x] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Adds `rootElement` field for `createIcons` (default, is `document`).

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
