### PR TITLE
fix: Prevent internal router from handling external links

### DIFF
--- a/docs/.vitepress/theme/components/base/Badge.vue
+++ b/docs/.vitepress/theme/components/base/Badge.vue
@@ -7,7 +7,16 @@ const props = defineProps<{
   href?: string
 }>()
 
+const isExternal = computed(() => props.href?.startsWith('http') ?? false)
+
 const component = computed(() => props.href ? 'a' : 'div')
+const target = computed(() => isExternal.value ? '_blank' : undefined)
+const rel = computed(() => isExternal.value ? 'noreferrer noopener' : undefined)
+
+const onClick = computed(() => {
+  if(!props.href || isExternal) return
+  return go(props.href)
+})
 </script>
 
 <template>
@@ -15,7 +24,9 @@ const component = computed(() => props.href ? 'a' : 'div')
     :is="component"
     :href="href"
     class="badge"
-    @click="props?.href ? go(href) : undefined"
+    :target="target"
+    :rel="rel"
+    @click="onClick"
   >
     <slot/>
   </component>

--- a/docs/.vitepress/theme/components/home/HomeHeroBefore.vue
+++ b/docs/.vitepress/theme/components/home/HomeHeroBefore.vue
@@ -8,8 +8,6 @@ import { data } from './HomeHeroBefore.data'
   <HomeContainer class="container">
     <Badge
       :href="`https://github.com/lucide-icons/lucide/releases/tag/${data.version}`"
-      target="_blank"
-      rel="noreferrer noopener"
     >v{{ data.version }}</Badge>
   </HomeContainer>
 </template>

--- a/docs/.vitepress/theme/components/icons/IconDetailOverlay.vue
+++ b/docs/.vitepress/theme/components/icons/IconDetailOverlay.vue
@@ -55,8 +55,6 @@ const Expand = createLucideIcon('Expand', expand)
             v-if="icon.createdRelease"
             class="version"
             :href="releaseTagLink(icon.createdRelease.version)"
-            target="_blank"
-            rel="noreferrer noopener"
           >v{{ icon.createdRelease.version }}</Badge>
           <IconButton  @click="go(`/icons/${icon.name}`)">
             <component :is="Expand" />

--- a/docs/icons/[name].md
+++ b/docs/icons/[name].md
@@ -69,8 +69,6 @@ function releaseTagLink(version) {
           <Label>Created:</Label>
           <Badge
             :href="releaseTagLink(params.createdRelease.version)"
-            target="_blank"
-            rel="noreferrer noopener"
           >
             v{{params.createdRelease.version}}
           </Badge>
@@ -82,8 +80,6 @@ function releaseTagLink(version) {
           <Label>Last changed:</Label>
           <Badge
             :href="releaseTagLink(params.changedRelease.version)"
-            target="_blank"
-            rel="noreferrer noopener"
           >
             v{{params.changedRelease.version}}
           </Badge>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
closes #2086

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Links in badges that open externally would also be picked up by the Vue Router, resulting in a 404-page. 

Detection for external links is added in the Badge component, simultaneously adding the appropriate anchor tag attributes, as well as preventing the Vue Router from navigating. 

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
