### PR TITLE
fix(lucide-svelte): Revert shared package for `lucide-svelte`

### DIFF
--- a/packages/lucide-svelte/package.json
+++ b/packages/lucide-svelte/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@lucide/build-icons": "workspace:*",
-    "@lucide/shared": "workspace:*",
     "@sveltejs/package": "^2.2.3",
     "@sveltejs/vite-plugin-svelte": "^2.4.2",
     "@testing-library/jest-dom": "^6.1.4",

--- a/packages/lucide-svelte/src/Icon.svelte
+++ b/packages/lucide-svelte/src/Icon.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { mergeClasses } from '@lucide/shared'
   import defaultAttributes from './defaultAttributes'
   import type { IconNode } from './types';
 
@@ -9,6 +8,14 @@
   export let strokeWidth: number | string = 2
   export let absoluteStrokeWidth: boolean = false
   export let iconNode: IconNode
+
+  export const mergeClasses = <ClassType = string | undefined | null>(
+    ...classes: ClassType[]
+  ) => classes.filter((className, index, array) => {
+      return Boolean(className) && array.indexOf(className) === index;
+    })
+    .join(' ');
+
 </script>
 
 <svg

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,9 +589,6 @@ importers:
       '@lucide/build-icons':
         specifier: workspace:*
         version: link:../../tools/build-icons
-      '@lucide/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@sveltejs/package':
         specifier: ^2.2.3
         version: 2.2.6(svelte@4.1.2)(typescript@5.1.6)


### PR DESCRIPTION
closes: #2106 