### PR TITLE
fix(lucide-svelte): Remove export mergeClasses in svelte Icon

### DIFF
--- a/packages/lucide-svelte/src/Icon.svelte
+++ b/packages/lucide-svelte/src/Icon.svelte
@@ -10,11 +10,11 @@
   export let iconNode: IconNode
 
   const mergeClasses = <ClassType = string | undefined | null>(
-      ...classes: ClassType[]
-    ) => classes.filter((className, index, array) => {
-        return Boolean(className) && array.indexOf(className) === index;
-      })
-      .join(' ');
+    ...classes: ClassType[]
+  ) => classes.filter((className, index, array) => {
+      return Boolean(className) && array.indexOf(className) === index;
+    })
+    .join(' ');
 
 </script>
 

--- a/packages/lucide-svelte/src/Icon.svelte
+++ b/packages/lucide-svelte/src/Icon.svelte
@@ -9,12 +9,12 @@
   export let absoluteStrokeWidth: boolean = false
   export let iconNode: IconNode
 
-  export const mergeClasses = <ClassType = string | undefined | null>(
-    ...classes: ClassType[]
-  ) => classes.filter((className, index, array) => {
-      return Boolean(className) && array.indexOf(className) === index;
-    })
-    .join(' ');
+  const mergeClasses = <ClassType = string | undefined | null>(
+      ...classes: ClassType[]
+    ) => classes.filter((className, index, array) => {
+        return Boolean(className) && array.indexOf(className) === index;
+      })
+      .join(' ');
 
 </script>
 


### PR DESCRIPTION
fixes: #2114 

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Removes export keyword.