### PR TITLE
fix(icons): fix incorrect category name for diamond-plus/minus

### DIFF
--- a/icons/diamond-minus.json
+++ b/icons/diamond-minus.json
@@ -30,7 +30,7 @@
   ],
   "categories": [
     "multimedia",
-    "shape",
+    "shapes",
     "photography",
     "tools",
     "devices"

--- a/icons/diamond-plus.json
+++ b/icons/diamond-plus.json
@@ -25,7 +25,7 @@
   ],
   "categories": [
     "multimedia",
-    "shape",
+    "shapes",
     "photography",
     "tools",
     "devices"


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Bug fix

### Description

An incorrect category was supplied in `diamond-plus` and `diamond-minus`, having been merged this now results in all pre commit hooks failing. 

> Icon 'diamond-minus' refers to the non-existing category 'shape'.
> Icon 'diamond-plus' refers to the non-existing category 'shape'.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
