### PR TITLE
Add copy component name

### DIFF
--- a/docs/.vitepress/theme/components/icons/CopyCodeButton.vue
+++ b/docs/.vitepress/theme/components/icons/CopyCodeButton.vue
@@ -39,6 +39,12 @@ function copyJSX() {
   navigator.clipboard.writeText(code)
 }
 
+function copyComponentName() {
+  const code = componentName.value
+
+  navigator.clipboard.writeText(code)
+}
+
 function copyVue() {
   let attrs = ['']
 
@@ -101,6 +107,7 @@ function copyAngular() {
     :popoverPosition="popoverPosition"
     :options="[
       { text: 'Copy JSX' , onClick: copyJSX },
+      { text: 'Copy Component Name' , onClick: copyComponentName },
       { text: 'Copy Vue' , onClick: copyVue },
       { text: 'Copy Svelte' , onClick: copyJSX },
       { text: 'Copy Angular' , onClick: copyAngular },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Add Copy component feature. It's very useful when you want to use the component name in your code other than the jsx code




## Before Submitting 
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
