### PR TITLE
fix(icons): [circle-slash] Fix missing line when using `fill` as a background

### DIFF
--- a/icons/circle-slash.svg
+++ b/icons/circle-slash.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="9" x2="15" y1="15" y2="9" />
   <circle cx="12" cy="12" r="10" />
+  <line x1="9" x2="15" y1="15" y2="9" />
 </svg>


### PR DESCRIPTION
Having <line> after <circle> allows to set `fill` as a background and line would still be visible

## What is the purpose of this pull request?

- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Currently, when you set `fill` property on svg, `<line>` won't be visible, as `<circle>` will cover it. Switching order allows to add background to the icon without losing `<line>`

Before:
<img width="90" alt="image" src="https://github.com/lucide-icons/lucide/assets/35103924/8d008001-8480-49db-908e-dcbb672bd7b8">

After:
<img width="100" alt="image" src="https://github.com/lucide-icons/lucide/assets/35103924/39a6f357-0a29-4839-8f30-f6fafb0d9de3">


## Before Submitting <!-- For every PR! -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
