### PR TITLE
fix(scripts): fixes writeIconRelatedIcons.mjs

### DIFF
--- a/scripts/writeIconRelatedIcons.mjs
+++ b/scripts/writeIconRelatedIcons.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { readSvgDirectory } from './helpers.mjs';
+import {readSvgDirectory} from './helpers.mjs';
 
 const currentDir = process.cwd();
 const ICONS_DIR = path.resolve(currentDir, '../icons');
@@ -41,8 +41,8 @@ const nameParts = (icon) =>
 const getRelatedIcons = (currentIcon, icons) => {
   const iconSimilarity = (item) =>
     nameWeight * arrayMatches(nameParts(item), nameParts(currentIcon)) +
-    categoryWeight * arrayMatches(item.categories, currentIcon.categories) +
-    tagWeight * arrayMatches(item.tags, currentIcon.tags);
+    categoryWeight * arrayMatches(item.categories ?? [], currentIcon.categories ?? []) +
+    tagWeight * arrayMatches(item.tags ?? [], currentIcon.tags ?? []);
   return icons
     .filter((i) => i.name !== currentIcon.name)
     .map((icon) => ({ icon, similarity: iconSimilarity(icon) }))
@@ -54,9 +54,7 @@ const getRelatedIcons = (currentIcon, icons) => {
 
 const iconsMetaDataPromises = svgFiles.map(async (iconName) => {
   // eslint-disable-next-line import/no-dynamic-require, global-require
-  const metaData = await import(`../icons/${iconName}`, {
-    assert: { type: 'json' },
-  });
+  const metaData = JSON.parse(fs.readFileSync(`../icons/${iconName}`));
 
   const name = iconName.replace('.json', '');
 

--- a/scripts/writeIconRelatedIcons.mjs
+++ b/scripts/writeIconRelatedIcons.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {readSvgDirectory} from './helpers.mjs';
+import { readSvgDirectory } from './helpers.mjs';
 
 const currentDir = process.cwd();
 const ICONS_DIR = path.resolve(currentDir, '../icons');


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Bugfix

## Description

Running `prebuild:relatedIcons` results in an error:

```log
. prebuild:relatedIcons$ node ../scripts/writeIconRelatedIcons.mjs
│ node:internal/modules/esm/assert:88
│         throw new ERR_IMPORT_ATTRIBUTE_MISSING(url, 'type', validType);
│               ^
│ TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module "file:///Users/karsa/Projects/lucide/icons/a-arrow-up.json" needs an import attribute of "type: json"
│     at validateAttributes (node:internal/modules/esm/assert:88:15)
[1 lines collapsed]
│     at async ModuleLoader.load (node:internal/modules/esm/loader:555:7)
│     at async ModuleLoader.moduleProvider (node:internal/modules/esm/loader:436:45)
│     at async ModuleJob._link (node:internal/modules/esm/module_job:106:19) {
│2  code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
│               ^
│ TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module "file:///Users/karsa/Projects/lucide/icons/a-arrow-up.json" needs an import attribute of "type: json"
│ node:internal/modules/esm/assert:88ernal/modules/esm/assert:88:15)
│         throw new ERR_IMPORT_ATTRIBUTE_MISSING(url, 'type', validType);
│               ^
│ TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module "file:///Users/karsa/Projects/lucide/icons/a-arrow-up.json" needs an import attribute of "type: json"
│     at validateAttributes (node:internal/modules/esm/assert:88:15):106:19) {
│     at defaultLoad (node:internal/modules/esm/load:143:3)
│     at async ModuleLoader.load (node:internal/modules/esm/loader:555:7)
│     at async ModuleLoader.moduleProvider (node:internal/modules/esm/loader:436:45)
│     at async ModuleJob._link (node:internal/modules/esm/module_job:106:19) {
│   code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
│ }
│ Node.js v22.2.0
└─ Failed in 351ms at /Users/karsa/Projects/lucide/docs
. prebuild:iconDetails$ node ../scripts/writeIconDetails.mjs
└─ Running...
. prebuild:api$ npx nitropack prepare
└─ Running...
 ELIFECYCLE  Command failed with exit code 1.
```

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
