### PR TITLE
Added keys to elements in iconNode map

### DIFF
--- a/packages/lucide-react/src/Icon.ts
+++ b/packages/lucide-react/src/Icon.ts
@@ -49,7 +49,7 @@ const Icon = forwardRef<SVGSVGElement, IconComponentProps>(
         ...rest,
       },
       [
-        ...iconNode.map(([tag, attrs]) => createElement(tag, attrs)),
+        ...iconNode.map(([tag, attrs], index) => createElement(tag, { key: index, ...attrs })),
         ...(Array.isArray(children) ? children : [children]),
       ],
     );

--- a/packages/lucide-react/tests/Icon.spec.tsx
+++ b/packages/lucide-react/tests/Icon.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { getAllByRole, render } from '@testing-library/react';
 
-import { airVent } from './testIconNodes';
+import { airVent, airVentNotKeys } from './testIconNodes';
 import { Icon } from '../src/lucide-react';
 
 describe('Using Icon Component', () => {
@@ -16,6 +16,44 @@ describe('Using Icon Component', () => {
     );
 
     expect(container.firstChild).toBeDefined();
+  });
+
+  it('Should automatically assign key if key not exists', async () => {
+    const { container } = render(
+      <Icon
+        iconNode={airVentNotKeys}
+        size={48}
+        stroke="red"
+        absoluteStrokeWidth
+      />,
+    );
+
+    container.firstChild?.childNodes.forEach((child, index) => {
+      Object.values(child).forEach((node) => {
+        if ('elementType' in node) {
+          expect(node.key).toBe(index.toString());
+        }
+      });
+    });
+  });
+
+  it('Should not automatically assign key if key already exists', async () => {
+    const { container } = render(
+      <Icon
+        iconNode={airVent}
+        size={48}
+        stroke="red"
+        absoluteStrokeWidth
+      />,
+    );
+
+    container.firstChild?.childNodes.forEach((child, index) => {
+      Object.values(child).forEach((node) => {
+        if ('elementType' in node) {
+          expect(node.key).not.toBe(index.toString());
+        }
+      });
+    });
   });
 
   it('should render icon and match snapshot', async () => {

--- a/packages/lucide-react/tests/testIconNodes.ts
+++ b/packages/lucide-react/tests/testIconNodes.ts
@@ -13,6 +13,18 @@ export const airVent: IconNode = [
   ['path', { d: 'M6.6 15.6A2 2 0 1 0 10 17v-5', key: 't9h90c' }],
 ];
 
+export const airVentNotKeys: IconNode = [
+  [
+    'path',
+    {
+      d: 'M6 12H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2',
+    },
+  ],
+  ['path', { d: 'M6 8h12' }],
+  ['path', { d: 'M18.3 17.7a2.5 2.5 0 0 1-3.16 3.83 2.53 2.53 0 0 1-1.14-2V12' }],
+  ['path', { d: 'M6.6 15.6A2 2 0 1 0 10 17v-5' }],
+];
+
 export const coffee: IconNode = [
   ['path', { d: 'M17 8h1a4 4 0 1 1 0 8h-1', key: 'jx4kbh' }],
   ['path', { d: 'M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z', key: '1bxrl0' }],


### PR DESCRIPTION
Closes #2199

## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description

Automatically assigns a key if no key is provided on the `iconNode`.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
