### PR TITLE
fix(icons): remove edit-2 alias from pen-off

### DIFF
--- a/icons/pen-off.json
+++ b/icons/pen-off.json
@@ -33,13 +33,5 @@
     "text",
     "design",
     "tools"
-  ],
-  "aliases": [
-    {
-      "name": "edit-2",
-      "deprecated": true,
-      "deprecationReason": "alias.name",
-      "toBeRemovedInVersion": "v1.0"
-    }
   ]
 }


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Bug fix

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
