### PR TITLE
feat(icons): added `house-plus` icon

### DIFF
--- a/icons/house-plus.json
+++ b/icons/house-plus.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "karsa-mistmere"
+  ],
+  "tags": [
+    "home",
+    "living",
+    "medical",
+    "new",
+    "addition",
+    "building",
+    "residence",
+    "architecture"
+  ],
+  "categories": [
+    "account",
+    "medical"
+  ]
+}

--- a/icons/house-plus.json
+++ b/icons/house-plus.json
@@ -14,6 +14,7 @@
     "architecture"
   ],
   "categories": [
+    "buildings",
     "account",
     "medical"
   ]

--- a/icons/house-plus.json
+++ b/icons/house-plus.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "home",

--- a/icons/house-plus.svg
+++ b/icons/house-plus.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13.22 2.416a2 2 0 0 0-2.511.057l-7 5.999A2 2 0 0 0 3 10v9a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7.354" />
+  <path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" />
+  <path d="M15 6h6" />
+  <path d="M18 3v6" />
+</svg>


### PR DESCRIPTION
closes #2098

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Icon

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] The icons are solely my own creation.
- [x] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [x] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
