### PR TITLE
fix(site): Aliases redirect

### DIFF
--- a/scripts/writeVercelOutput.mjs
+++ b/scripts/writeVercelOutput.mjs
@@ -12,9 +12,7 @@ const iconMetaData = await getIconMetaData(path.resolve(scriptDir, '../icons'));
 const iconAliasesRedirectRoutes = Object.entries(iconMetaData)
   .filter(([, { aliases }]) => aliases?.length)
   .map(([iconName, { aliases }]) => {
-    if (aliases.some((alias) => typeof alias === 'object')) {
-      aliases = aliases.map((alias) => alias.name);
-    }
+    aliases = aliases.map((alias) => (typeof alias === 'object' ? alias.name : alias));
 
     const aliasRouteMatches = aliases.join('|');
 

--- a/scripts/writeVercelOutput.mjs
+++ b/scripts/writeVercelOutput.mjs
@@ -12,6 +12,10 @@ const iconMetaData = await getIconMetaData(path.resolve(scriptDir, '../icons'));
 const iconAliasesRedirectRoutes = Object.entries(iconMetaData)
   .filter(([, { aliases }]) => aliases?.length)
   .map(([iconName, { aliases }]) => {
+    if(aliases.some(alias => typeof alias === 'object')) {
+      aliases = aliases.map(alias => alias.name)
+    }
+
     const aliasRouteMatches = aliases.join('|');
 
     return {

--- a/scripts/writeVercelOutput.mjs
+++ b/scripts/writeVercelOutput.mjs
@@ -12,8 +12,8 @@ const iconMetaData = await getIconMetaData(path.resolve(scriptDir, '../icons'));
 const iconAliasesRedirectRoutes = Object.entries(iconMetaData)
   .filter(([, { aliases }]) => aliases?.length)
   .map(([iconName, { aliases }]) => {
-    if(aliases.some(alias => typeof alias === 'object')) {
-      aliases = aliases.map(alias => alias.name)
+    if (aliases.some((alias) => typeof alias === 'object')) {
+      aliases = aliases.map((alias) => alias.name);
     }
 
     const aliasRouteMatches = aliases.join('|');


### PR DESCRIPTION
Aliases redirect was not working correctly when we changed to object definition for aliases.