### PR TITLE
fix(icons): icon with misspelling

### DIFF
--- a/icons/between-horizontal-end.json
+++ b/icons/between-horizontal-end.json
@@ -34,7 +34,7 @@
   ],
   "aliases": [
     {
-      "name": "between-horizonal-end",
+      "name": "between-horizontal-end",
       "deprecated": true,
       "deprecationReason": "alias.typo",
       "toBeRemovedInVersion": "v1.0"

--- a/icons/between-horizontal-start.json
+++ b/icons/between-horizontal-start.json
@@ -34,7 +34,7 @@
   ],
   "aliases": [
     {
-      "name": "between-horizonal-start",
+      "name": "between-horizontal-start",
       "deprecated": true,
       "deprecationReason": "alias.typo",
       "toBeRemovedInVersion": "v1.0"

--- a/icons/send-horizontal.json
+++ b/icons/send-horizontal.json
@@ -18,7 +18,7 @@
   ],
   "aliases": [
     {
-      "name": "send-horizonal",
+      "name": "send-horizontal",
       "deprecated": true,
       "deprecationReason": "alias.typo",
       "toBeRemovedInVersion": "v1.0"


### PR DESCRIPTION
closes #2296

## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description

changes the names of icons with incorrect spelling of `horizontal`.

## Before Submitting <!-- For every PR! -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
