### PR TITLE
fix(site): Fix svelte code examples

### DIFF
--- a/docs/icons/[name].md
+++ b/docs/icons/[name].md
@@ -35,7 +35,7 @@ const codeExample = computed(() => data.codeExamples?.map(
       const camelCaseName = camelCase(params.value.name)
 
       return codeExample.code
-        .replace(/\$PascalCase/g, pascalCaseName)
+        .replace(/\$(?:<[^>]+>)*PascalCase/g, pascalCaseName)
         .replace(/\$CamelCase/g, camelCaseName)
         .replace(/\$Name/g, params.value.name)
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Fixes Svelte code examples that were showing `$PascalCase` instead of the Svelte component's tag

![image](https://github.com/lucide-icons/lucide/assets/569053/c8e6230a-1409-492f-bc5f-1c580bd7c780)


Issue stemmed from the fact that the `$` and `PascalCase` were not contiguous, and separated by HTML:
![image](https://github.com/lucide-icons/lucide/assets/569053/30ce7135-02de-4684-b151-ea33f32ca884)

> Proposed fix is to add a a non-capturing group that matches zero or more occurrences of any sequence starting with <, followed by any characters that are not >, and ending with >; basically skipping over any HTML tags that might occur right after the `$` and before the `Pascal`.


### Behavior after fix
![image](https://github.com/lucide-icons/lucide/assets/569053/c4453915-5d4c-41eb-a001-af50c07ba590)


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
