### PR TITLE
fix(site): Correct GitHub link in the footer

### DIFF
--- a/docs/.vitepress/theme/components/overrides/VPFooter.vue
+++ b/docs/.vitepress/theme/components/overrides/VPFooter.vue
@@ -24,7 +24,7 @@ const links = computed(() => [
   },
   {
     text: 'Github',
-    href: `${githubLink.value}/issues`
+    href: `${githubLink.value}`
   },
   {
     text: 'Issues',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
This pull request addresses an issue with the footer links on website. Previously, both the `Github` and `Issues` links were pointing to the issue page (`/lucide/issues`). Now, the GitHub link directs to the correct repository.

Thanks!

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
