### PR TITLE
fix(icons): changed `cloud-upload` icon

### DIFF
--- a/icons/cloud-upload.json
+++ b/icons/cloud-upload.json
@@ -4,7 +4,8 @@
     "colebemis",
     "csandman",
     "ericfennis",
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "file"

--- a/icons/cloud-upload.svg
+++ b/icons/cloud-upload.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M12 13v8" />
   <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
-  <path d="M12 12v9" />
-  <path d="m16 16-4-4-4 4" />
+  <path d="m8 17 4-4 4 4" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Use same arrow as everywhere else.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.