### PR TITLE
fix(icons): update `cloud-download` icon and close gaps

### DIFF
--- a/icons/cloud-download.svg
+++ b/icons/cloud-download.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" />
-  <path d="M12 12v9" />
-  <path d="m8 17 4 4 4-4" />
+  <path d="M12 13v8l-4-4" />
+  <path d="m12 21 4-4" />
+  <path d="M4.393 15.269A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.436 8.284" />
 </svg>


### PR DESCRIPTION
Update `cloud-download` to match the changes made in #2352 

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
