### PR TITLE
chore(icons): add tag to ellipsis icons

### DIFF
--- a/icons/circle-ellipsis.json
+++ b/icons/circle-ellipsis.json
@@ -19,7 +19,7 @@
     "code",
     "spread",
     "rest",
-	  "more",
+    "more",
     "further",
     "extra",
     "overflow",

--- a/icons/circle-ellipsis.json
+++ b/icons/circle-ellipsis.json
@@ -20,6 +20,10 @@
     "spread",
     "rest",
 	  "more",
+    "further",
+    "extra",
+    "overflow",
+    "dots",
     "…",
     "..."
   ],

--- a/icons/circle-ellipsis.json
+++ b/icons/circle-ellipsis.json
@@ -19,6 +19,7 @@
     "code",
     "spread",
     "rest",
+	  "more",
     "…",
     "..."
   ],

--- a/icons/ellipsis-vertical.json
+++ b/icons/ellipsis-vertical.json
@@ -7,7 +7,7 @@
     "menu",
     "options",
     "spread",
-	  "more",
+    "more",
     "further",
     "extra",
     "overflow",

--- a/icons/ellipsis-vertical.json
+++ b/icons/ellipsis-vertical.json
@@ -6,6 +6,7 @@
   "tags": [
     "menu",
     "options",
+	  "more",
     "..."
   ],
   "categories": [

--- a/icons/ellipsis-vertical.json
+++ b/icons/ellipsis-vertical.json
@@ -6,7 +6,13 @@
   "tags": [
     "menu",
     "options",
+    "spread",
 	  "more",
+    "further",
+    "extra",
+    "overflow",
+    "dots",
+    "…",
     "..."
   ],
   "categories": [

--- a/icons/ellipsis.json
+++ b/icons/ellipsis.json
@@ -19,6 +19,10 @@
     "spread",
     "rest",
 	  "more",
+    "further",
+    "extra",
+    "overflow",
+    "dots",
     "…",
     "..."
   ],

--- a/icons/ellipsis.json
+++ b/icons/ellipsis.json
@@ -18,7 +18,7 @@
     "coding",
     "spread",
     "rest",
-	  "more",
+    "more",
     "further",
     "extra",
     "overflow",

--- a/icons/ellipsis.json
+++ b/icons/ellipsis.json
@@ -18,6 +18,7 @@
     "coding",
     "spread",
     "rest",
+	  "more",
     "…",
     "..."
   ],

--- a/icons/rectangle-ellipsis.json
+++ b/icons/rectangle-ellipsis.json
@@ -25,7 +25,7 @@
     "code",
     "spread",
     "rest",
-	  "more",
+    "more",
     "further",
     "extra",
     "overflow",

--- a/icons/rectangle-ellipsis.json
+++ b/icons/rectangle-ellipsis.json
@@ -26,6 +26,10 @@
     "spread",
     "rest",
 	  "more",
+    "further",
+    "extra",
+    "overflow",
+    "dots",
     "…",
     "..."
   ],

--- a/icons/rectangle-ellipsis.json
+++ b/icons/rectangle-ellipsis.json
@@ -25,6 +25,7 @@
     "code",
     "spread",
     "rest",
+	  "more",
     "…",
     "..."
   ],


### PR DESCRIPTION
Closes #2309 

## What is the purpose of this pull request?
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other:
Adds new tag to icons.

### Description
This PR adds a new tag `"more"` to some of the ellipsis icons.
The icons are: `circle-ellipsis`, `ellipsis-vertical`, `ellipsis`, `rectangle-ellipsis`

## Before Submitting <!-- For every PR! -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
