### PR TITLE
chore(docs): fixed footer typo

### DIFF
--- a/docs/.vitepress/theme/components/overrides/VPFooter.vue
+++ b/docs/.vitepress/theme/components/overrides/VPFooter.vue
@@ -23,7 +23,7 @@ const links = computed(() => [
     href: `${githubLink.value}/releases`
   },
   {
-    text: 'Github',
+    text: 'GitHub',
     href: `${githubLink.value}`
   },
   {


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description
Fixes a footer link typo.
Renamed "Github" to "GitHub".

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
