### PR TITLE
fix(icons): changed `message-square-dashed` icon

### DIFF
--- a/icons/message-square-dashed.json
+++ b/icons/message-square-dashed.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "comment",

--- a/icons/message-square-dashed.svg
+++ b/icons/message-square-dashed.svg
@@ -9,12 +9,13 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M3 6V5c0-1.1.9-2 2-2h2" />
-  <path d="M11 3h3" />
-  <path d="M18 3h1c1.1 0 2 .9 2 2" />
-  <path d="M21 9v2" />
-  <path d="M21 15c0 1.1-.9 2-2 2h-1" />
-  <path d="M14 17h-3" />
-  <path d="m7 17-4 4v-5" />
-  <path d="M3 12v-2" />
+  <path d="M10 17H7l-4 4v-7" />
+  <path d="M14 17h1" />
+  <path d="M14 3h1" />
+  <path d="M19 3a2 2 0 0 1 2 2" />
+  <path d="M21 14v1a2 2 0 0 1-2 2" />
+  <path d="M21 9v1" />
+  <path d="M3 9v1" />
+  <path d="M5 3a2 2 0 0 0-2 2" />
+  <path d="M9 3h1" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Use same dashes as `square-dashed`.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.