### PR TITLE
feat(docs): add standalone example for angular

### DIFF
--- a/docs/guide/packages/lucide-angular.md
+++ b/docs/guide/packages/lucide-angular.md
@@ -37,6 +37,20 @@ import { LucideAngularModule, File, Home, Menu, UserCheck } from 'lucide-angular
 export class AppModule { }
 ```
 
+or using standalone version:
+
+```js
+import { LucideAngularModule, FileIcon } from 'lucide-angular';
+
+@NgModule({
+  imports: [
+    LucideAngularModule
+  ]
+})
+export class AppModule {
+  readonly FileIcon = FileIcon;
+}
+```
 ### Step 2: Use the icons in templates
 
 Within your templates you may now use one of the following component tags to insert an icon:
@@ -46,6 +60,13 @@ Within your templates you may now use one of the following component tags to ins
 <lucide-icon name="home" class="my-icon"></lucide-icon>
 <i-lucide name="menu" class="my-icon"></i-lucide>
 <span-lucide name="user-check" class="my-icon"></span-lucide>
+```
+for standalone
+```html
+<lucide-angular [img]="FileIcon" class="my-icon"></lucide-angular>
+<lucide-icon [img]="FileIcon" class="my-icon"></lucide-icon>
+<i-lucide [img]="FileIcon" class="my-icon"></i-lucide>
+<span-lucide [img]="FileIcon" class="my-icon"></span-lucide>
 ```
 
 ### Props


### PR DESCRIPTION
add standalone example for angular since it different with current behavior

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description
I'm using Lucide with Angular and really love it. I'm using Angular 18 and this update should help standalone user understand how to use it for new standard

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
