### PR TITLE
Add the sustainability category to some existing icons

### DIFF
--- a/icons/leafy-green.json
+++ b/icons/leafy-green.json
@@ -13,6 +13,7 @@
   ],
   "categories": [
     "food-beverage",
-    "emoji"
+    "emoji",
+    "sustainability"
   ]
 }

--- a/icons/sprout.json
+++ b/icons/sprout.json
@@ -11,6 +11,7 @@
   ],
   "categories": [
     "nature",
-    "gaming"
+    "gaming",
+    "sustainability"
   ]
 }

--- a/icons/sun.json
+++ b/icons/sun.json
@@ -14,6 +14,7 @@
   "categories": [
     "accessibility",
     "weather",
-    "seasons"
+    "seasons",
+    "sustainability"
   ]
 }

--- a/icons/tree-deciduous.json
+++ b/icons/tree-deciduous.json
@@ -11,6 +11,7 @@
     "nature"
   ],
   "categories": [
-    "nature"
+    "nature",
+    "sustainability"
   ]
 }

--- a/icons/tree-palm.json
+++ b/icons/tree-palm.json
@@ -9,7 +9,8 @@
     "island"
   ],
   "categories": [
-    "nature"
+    "nature",
+    "sustainability"
   ],
   "aliases": [
     "palmtree"

--- a/icons/tree-pine.json
+++ b/icons/tree-pine.json
@@ -13,6 +13,7 @@
     "nature"
   ],
   "categories": [
-    "nature"
+    "nature",
+    "sustainability"
   ]
 }

--- a/icons/trees.json
+++ b/icons/trees.json
@@ -10,6 +10,7 @@
     "nature"
   ],
   "categories": [
-    "nature"
+    "nature",
+    "sustainability"
   ]
 }

--- a/icons/waves.json
+++ b/icons/waves.json
@@ -15,6 +15,7 @@
   "categories": [
     "weather",
     "maps",
-    "multimedia"
+    "multimedia",
+    "sustainability"
   ]
 }

--- a/icons/wind.json
+++ b/icons/wind.json
@@ -11,6 +11,7 @@
     "blow"
   ],
   "categories": [
-    "weather"
+    "weather",
+    "sustainability"
   ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Adds the sustainability category to some of the existing icons that are related to sustainability for easier discovery.


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
