### PR TITLE
fix(icons): changed `*-user-round` icons

### DIFF
--- a/icons/circle-user-round.json
+++ b/icons/circle-user-round.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "person",

--- a/icons/circle-user-round.svg
+++ b/icons/circle-user-round.svg
@@ -10,6 +10,6 @@
   stroke-linejoin="round"
 >
   <path d="M18 20a6 6 0 0 0-12 0" />
-  <circle cx="12" cy="10" r="4" />
+  <circle cx="12" cy="11" r="3" />
   <circle cx="12" cy="12" r="10" />
 </svg>

--- a/icons/square-user-round.json
+++ b/icons/square-user-round.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "person",

--- a/icons/square-user-round.svg
+++ b/icons/square-user-round.svg
@@ -10,6 +10,6 @@
   stroke-linejoin="round"
 >
   <path d="M18 21a6 6 0 0 0-12 0" />
-  <circle cx="12" cy="11" r="4" />
-  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <circle cx="12" cy="12" r="3" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Changed head size to be the same as in circle-user and square-user.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.