### PR TITLE
fix(icons): changed `contact-*` icon

### DIFF
--- a/icons/contact-round.json
+++ b/icons/contact-round.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "user",

--- a/icons/contact-round.svg
+++ b/icons/contact-round.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M16 18a4 4 0 0 0-8 0" />
-  <circle cx="12" cy="11" r="3" />
-  <rect width="18" height="18" x="3" y="4" rx="2" />
-  <line x1="8" x2="8" y1="2" y2="4" />
-  <line x1="16" x2="16" y1="2" y2="4" />
+  <path d="M16 2v2" />
+  <path d="M17.915 22a6 6 0 0 0-12 0" />
+  <path d="M8 2v2" />
+  <circle cx="12" cy="12" r="4" />
+  <rect x="3" y="4" width="18" height="18" rx="2" />
 </svg>

--- a/icons/contact.json
+++ b/icons/contact.json
@@ -4,7 +4,8 @@
     "lscheibel",
     "karsa-mistmere",
     "FPDK",
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "user",

--- a/icons/contact.svg
+++ b/icons/contact.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M17 18a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2" />
-  <rect width="18" height="18" x="3" y="4" rx="2" />
-  <circle cx="12" cy="10" r="2" />
-  <line x1="8" x2="8" y1="2" y2="4" />
-  <line x1="16" x2="16" y1="2" y2="4" />
+  <path d="M16 2v2" />
+  <path d="M7 22v-2a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v2" />
+  <path d="M8 2v2" />
+  <circle cx="12" cy="11" r="3" />
+  <rect x="3" y="4" width="18" height="18" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Changed icon to be consistent with `square-user`.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.