### PR TITLE
feat(icons): added `fork-in-road` icon

### DIFF
--- a/icons/fork-in-road.json
+++ b/icons/fork-in-road.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "Sempijja"
+  ],
+  "tags": [
+    "fork",
+    "junction",
+    "intersection",
+    "split",
+    "diverge",
+    "road-fork",
+    "highway-split",
+    "route-choice",
+    "navigation",
+    "wayfinding",
+    "direction",
+    "road-division",
+    "path-split",
+    "decision-point"
+  ],
+  "categories": [
+    "navigation"
+  ]
+}

--- a/icons/fork-in-road.svg
+++ b/icons/fork-in-road.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 11.7a4 4 0 0 0-1.172-2.872L4 2" />
+  <path d="M12 22V11.7a4 4 0 0 1 1.172-2.872L20 2" />
+  <path d="M20.656 7.485V1.828h-5.657" />
+  <path d="M9.485 1.828H3.828v5.657" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon
![image](https://github.com/user-attachments/assets/b60b7532-0e8e-457d-a15e-2228751d77d9)

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
This pull request introduces a new "fork-in-road" icon to our map interface assets. The icon represents an upcoming split or division in the route where users must choose between two or more paths.

Purpose:
The primary purpose of this icon is to provide clear visual guidance for users navigating complex road networks, highways, or decision points in various transportation scenarios. It alerts users to upcoming route choices, enhancing navigation accuracy and user experience.

Categories:
1. Navigation
2. Route Guidance
3. Traffic Signs

Real-life use cases:

1. Highway navigation: Alerting drivers to an upcoming major highway split, such as I-95 dividing into I-95 and I-295.

2. Airport approach: Guiding travelers to choose between terminals or specific airline areas as they approach an airport complex.

3. National park trail systems: Indicating trail splits for hikers, where paths diverge to different natural attractions or campsites.

4. Urban transit networks: Showing passengers where a bus or tram route splits into multiple directions, each serving different city areas.

5. Bike path navigation: Alerting cyclists to upcoming path divisions in extensive urban or rural cycling networks.

6. Theme park navigation: Guiding visitors through large amusement parks where paths split to different themed areas or attractions.

7. Shopping mall wayfinding: Indicating where corridors split to different wings or levels of a large shopping complex.

8. University campus navigation: Showing students and visitors where campus paths diverge to different faculties or facilities.

9. Industrial complex routing: Guiding truck drivers or workers through large industrial areas where roads split to different loading docks or facilities.

10. Ski resort trail maps: Indicating where ski runs split into different difficulty levels or end points on the mountain.

11. Emergency evacuation routes: Showing critical decision points in evacuation plans for large buildings or urban areas.

12. Harbor navigation: Guiding boats to choose between different channels or docking areas as they approach a port.



### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] The icons are solely my own creation.
- [x] The icons were originally created in #<issueNumber> by @Sempijja
- [x] I've based them on the following Lucide icons: `fork-in-road`
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.