### PR TITLE
fix: only spread rest-props to top-level SVG element

### DIFF
--- a/packages/lucide-react-native/src/createLucideIcon.ts
+++ b/packages/lucide-react-native/src/createLucideIcon.ts
@@ -26,7 +26,6 @@ const createLucideIcon = (iconName: string, iconNode: IconNode): LucideIcon => {
       const customAttrs = {
         stroke: color,
         strokeWidth: absoluteStrokeWidth ? (Number(strokeWidth) * 24) / Number(size) : strokeWidth,
-        ...rest,
       };
 
       return createElement(
@@ -38,6 +37,7 @@ const createLucideIcon = (iconName: string, iconNode: IconNode): LucideIcon => {
           height: size,
           'data-testid': dataTestId,
           ...customAttrs,
+          ...rest,
         },
         [
           ...iconNode.map(([tag, attrs]) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
We were noticing rendering issues on react-native-web when using the lucide-react-native package.

It turns out that the `createLucideIcon` function used for generating SVG elements for react-native passes all `rest` props to all child elements of the SVG.
This can cause problems, if sizing-related properties are passed (i.e. width and/or height).
This is the case with gluestack-ui, for example, which passes width/height classes to the icon, thereby breaking certain SVGs.

This PR fixes this, by only inserting the `rest` props at the top-level SVG.


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
