### PR TITLE
fix(icons): redoing the `accessibility` icon

### DIFF
--- a/icons/accessibility.json
+++ b/icons/accessibility.json
@@ -1,7 +1,6 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere",
     "jguddas"
   ],
   "tags": [

--- a/icons/accessibility.svg
+++ b/icons/accessibility.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M14 13h4.5a9 9 0 0 1 0 6" />
+  <path d="M14 13h3.653a1 1 0 0 1 .986.836 9 9 0 0 1-.21 5.198" />
   <path d="M6.065 7.913A9 9 0 0 1 14 8l-1.9 3.5" />
   <circle cx="10" cy="16" r="5" />
   <circle cx="16.6" cy="3.7" r="1" />

--- a/icons/accessibility.svg
+++ b/icons/accessibility.svg
@@ -9,9 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="16" cy="4" r="1" />
-  <path d="m18 19 1-7-6 1" />
-  <path d="m5 8 3-3 5.5 3-2.36 3.5" />
-  <path d="M4.24 14.5a5 5 0 0 0 6.88 6" />
-  <path d="M13.76 17.5a5 5 0 0 0-6.88-6" />
+  <path d="M14 13h4.5a9 9 0 0 1 0 6" />
+  <path d="M6.065 7.913A9 9 0 0 1 14 8l-1.9 3.5" />
+  <circle cx="10" cy="16" r="5" />
+  <circle cx="16.6" cy="3.7" r="1" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Redoing the accessibility icon with less sharpness and without basing it on the accessibleicon project icon.

> The Accessible Icon is owned by Triangle, Inc. and was created by Sara Hendren & Brian Glenney. The Accessible Icon is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.