### PR TITLE
fix(icons): changed `circle-stop` icon

### DIFF
--- a/icons/circle-stop.svg
+++ b/icons/circle-stop.svg
@@ -10,5 +10,5 @@
   stroke-linejoin="round"
 >
   <circle cx="12" cy="12" r="10" />
-  <rect width="6" height="6" x="9" y="9" />
+  <rect x="9" y="9" width="6" height="6" rx="1" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Clicked arcify button.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.