### PR TITLE
fix(site): use the same camel/pascal same conversion as when releasing packages

### DIFF
--- a/docs/.vitepress/theme/components/icons/CopyCodeButton.vue
+++ b/docs/.vitepress/theme/components/icons/CopyCodeButton.vue
@@ -1,98 +1,98 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { startCase, camelCase } from 'lodash-es'
-import ButtonMenu from '../base/ButtonMenu.vue'
+import { toPascalCase } from '@lucide/shared';
+import ButtonMenu from '../base/ButtonMenu.vue';
 import { useIconStyleContext } from '../../composables/useIconStyle';
 import useConfetti from '../../composables/useConfetti';
 
 const props = defineProps<{
-  name: string
-  popoverPosition?: 'top' | 'bottom'
-}>()
-const { size, color, strokeWidth, absoluteStrokeWidth } = useIconStyleContext()
-const { animate, confetti } = useConfetti()
+  name: string;
+  popoverPosition?: 'top' | 'bottom';
+}>();
+const { size, color, strokeWidth, absoluteStrokeWidth } = useIconStyleContext();
+const { animate, confetti } = useConfetti();
 const componentName = computed(() => {
-  return startCase(camelCase(props.name)).replace(/\s/g, '')
-})
+  return (toPascalCase(props.name) as string).replace(/\s/g, '');
+});
 
 function copyJSX() {
-  let attrs = ['']
+  let attrs = [''];
 
   if (size.value && size.value !== 24) {
-    attrs.push(`size={${size.value}}`)
+    attrs.push(`size={${size.value}}`);
   }
 
   if (color.value && color.value !== 'currentColor') {
-    attrs.push(`color="${color.value}"`)
+    attrs.push(`color="${color.value}"`);
   }
 
   if (strokeWidth.value && strokeWidth.value !== 2) {
-    attrs.push(`strokeWidth={${strokeWidth.value}}`)
+    attrs.push(`strokeWidth={${strokeWidth.value}}`);
   }
 
   if (absoluteStrokeWidth.value) {
-    attrs.push(`absoluteStrokeWidth`)
+    attrs.push(`absoluteStrokeWidth`);
   }
 
-  const code = `<${componentName.value}${attrs.join(' ')} />`
+  const code = `<${componentName.value}${attrs.join(' ')} />`;
 
-  navigator.clipboard.writeText(code)
+  navigator.clipboard.writeText(code);
 }
 
 function copyComponentName() {
-  const code = componentName.value
+  const code = componentName.value;
 
-  navigator.clipboard.writeText(code)
+  navigator.clipboard.writeText(code);
 }
 
 function copyVue() {
-  let attrs = ['']
+  let attrs = [''];
 
   if (size.value && size.value !== 24) {
-    attrs.push(`:size="${size.value}"`)
+    attrs.push(`:size="${size.value}"`);
   }
 
   if (color.value && color.value !== 'currentColor') {
-    attrs.push(`color="${color.value}"`)
+    attrs.push(`color="${color.value}"`);
   }
 
   if (strokeWidth.value && strokeWidth.value !== 2) {
-    attrs.push(`:stroke-width="${strokeWidth.value}"`)
+    attrs.push(`:stroke-width="${strokeWidth.value}"`);
   }
 
   if (absoluteStrokeWidth.value) {
-    attrs.push(`absoluteStrokeWidth`)
+    attrs.push(`absoluteStrokeWidth`);
   }
 
-  const code = `<${componentName.value}${attrs.join(' ')} />`
+  const code = `<${componentName.value}${attrs.join(' ')} />`;
 
-  navigator.clipboard.writeText(code)
+  navigator.clipboard.writeText(code);
 }
 
 function copyAngular() {
-  let attrs = ['']
+  let attrs = [''];
 
-  attrs.push(`name="${props.name}"`)
+  attrs.push(`name="${props.name}"`);
 
   if (size.value && size.value !== 24) {
-    attrs.push(`[size]="${size.value}"`)
+    attrs.push(`[size]="${size.value}"`);
   }
 
   if (color.value && color.value !== 'currentColor') {
-    attrs.push(`color="${color.value}"`)
+    attrs.push(`color="${color.value}"`);
   }
 
   if (strokeWidth.value && strokeWidth.value !== 2) {
-    attrs.push(`[strokeWidth]="${strokeWidth.value}"`)
+    attrs.push(`[strokeWidth]="${strokeWidth.value}"`);
   }
 
   if (absoluteStrokeWidth.value) {
-    attrs.push(`[absoluteStrokeWidth]="true"`)
+    attrs.push(`[absoluteStrokeWidth]="true"`);
   }
 
-  const code = `<lucide-icon${attrs.join(' ')}></lucide-icon>`
+  const code = `<lucide-icon${attrs.join(' ')}></lucide-icon>`;
 
-  navigator.clipboard.writeText(code)
+  navigator.clipboard.writeText(code);
 }
 </script>
 
@@ -106,11 +106,11 @@ function copyAngular() {
     data-confetti-text="Copied!"
     :popoverPosition="popoverPosition"
     :options="[
-      { text: 'Copy JSX' , onClick: copyJSX },
-      { text: 'Copy Component Name' , onClick: copyComponentName },
-      { text: 'Copy Vue' , onClick: copyVue },
-      { text: 'Copy Svelte' , onClick: copyJSX },
-      { text: 'Copy Angular' , onClick: copyAngular },
+      { text: 'Copy JSX', onClick: copyJSX },
+      { text: 'Copy Component Name', onClick: copyComponentName },
+      { text: 'Copy Vue', onClick: copyVue },
+      { text: 'Copy Svelte', onClick: copyJSX },
+      { text: 'Copy Angular', onClick: copyAngular },
     ]"
   />
 </template>

--- a/docs/icons/[name].md
+++ b/docs/icons/[name].md
@@ -18,9 +18,8 @@ import RelatedIcons from '~/.vitepress/theme/components/icons/RelatedIcons.vue'
 import CodeGroup from '~/.vitepress/theme/components/base/CodeGroup.vue'
 import Badge from '~/.vitepress/theme/components/base/Badge.vue'
 import Label from '~/.vitepress/theme/components/base/Label.vue'
-import VPButton from 'vitepress/dist/client/theme-default/components/VPButton.vue';
 import { data } from './codeExamples.data'
-import { camelCase, startCase } from 'lodash-es'
+import { toCamelCase, toPascalCase } from '@lucide/shared'
 import { satisfies } from 'semver'
 
 const { params } = useData()
@@ -31,8 +30,8 @@ const tabs = computed(() => data.codeExamples?.map(
 
 const codeExample = computed(() => data.codeExamples?.map(
     (codeExample) => {
-      const pascalCaseName = startCase(camelCase( params.value.name)).replace(/\s/g, '')
-      const camelCaseName = camelCase(params.value.name)
+      const pascalCaseName = toPascalCase( params.value.name)
+      const camelCaseName = toCamelCase(params.value.name)
 
       return codeExample.code
         .replace(/\$(?:<[^>]+>)*PascalCase/g, pascalCaseName)

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -10,15 +10,24 @@ export const toKebabCase = (string: string) =>
   string.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 
 /**
+ * Converts string to camel case
+ *
+ * @param {string} string
+ * @returns {string} A camelized string
+ */
+export const toCamelCase = <T extends string>(string: T) =>
+  string.replace(/^([A-Z])|[\s-_]+(\w)/g, (match, p1, p2) =>
+    p2 ? p2.toUpperCase() : p1.toLowerCase(),
+  );
+
+/**
  * Converts string to pascal case
  *
  * @param {string} string
  * @returns {string} A pascalized string
  */
 export const toPascalCase = <T extends string>(string: T): CamelToPascal<T> => {
-  const camelCase = string.replace(/^([A-Z])|[\s-_]+(\w)/g, (match, p1, p2) =>
-    p2 ? p2.toUpperCase() : p1.toLowerCase(),
-  );
+  const camelCase = toCamelCase(string);
 
   return (camelCase.charAt(0).toUpperCase() + camelCase.slice(1)) as CamelToPascal<T>;
 };


### PR DESCRIPTION
closes #2507 


## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Bug fix

## Description

The site uses `camelCase` and `startCase` from `lodash-es`, our packages don't. Let's fix this.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
