### PR TITLE
fix(icons): optimised some `move-` icons

### DIFF
--- a/icons/move-diagonal-2.svg
+++ b/icons/move-diagonal-2.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="5 11 5 5 11 5" />
-  <polyline points="19 13 19 19 13 19" />
-  <line x1="5" x2="19" y1="5" y2="19" />
+  <path d="M19 13v6h-6" />
+  <path d="M5 11V5h6" />
+  <path d="m5 5 14 14" />
 </svg>

--- a/icons/move-diagonal.svg
+++ b/icons/move-diagonal.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="13 5 19 5 19 11" />
-  <polyline points="11 19 5 19 5 13" />
-  <line x1="19" x2="5" y1="5" y2="19" />
+  <path d="M11 19H5v-6" />
+  <path d="M13 5h6v6" />
+  <path d="M19 5 5 19" />
 </svg>

--- a/icons/move-horizontal.svg
+++ b/icons/move-horizontal.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="18 8 22 12 18 16" />
-  <polyline points="6 8 2 12 6 16" />
-  <line x1="2" x2="22" y1="12" y2="12" />
+  <path d="m18 8 4 4-4 4" />
+  <path d="M2 12h20" />
+  <path d="m6 8-4 4 4 4" />
 </svg>

--- a/icons/move-vertical.svg
+++ b/icons/move-vertical.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="8 18 12 22 16 18" />
-  <polyline points="8 6 12 2 16 6" />
-  <line x1="12" x2="12" y1="2" y2="22" />
+  <path d="M12 2v20" />
+  <path d="m8 18 4 4 4-4" />
+  <path d="m8 6 4-4 4 4" />
 </svg>

--- a/icons/move.svg
+++ b/icons/move.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="5 9 2 12 5 15" />
-  <polyline points="9 5 12 2 15 5" />
-  <polyline points="15 19 12 22 9 19" />
-  <polyline points="19 9 22 12 19 15" />
-  <line x1="2" x2="22" y1="12" y2="12" />
-  <line x1="12" x2="12" y1="2" y2="22" />
+  <path d="M12 2v20" />
+  <path d="m15 19-3 3-3-3" />
+  <path d="m19 9 3 3-3 3" />
+  <path d="M2 12h20" />
+  <path d="m5 9-3 3 3 3" />
+  <path d="m9 5 3-3 3 3" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Other: icon update

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Replace `<polyline/>`s and `<line/>`s with equivalent `<path/>`s using Lucide Studio's 'tidy' function

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
