### PR TITLE
fix(app): #2412 Fix tooltip being cut off

### DIFF
--- a/docs/.vitepress/theme/components/base/Tooltip.vue
+++ b/docs/.vitepress/theme/components/base/Tooltip.vue
@@ -42,7 +42,7 @@ onMounted(() => {
   font-weight: 400;
   background: var(--vp-c-brand-dark);
   color: white;
-  z-index: 10;
+  z-index: 99;
   white-space: nowrap;
   padding: 2px 8px;
   border-radius: 4px;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Fixes the tooltips on icons being cutoff. Closes #2412 . Increases the z-index to higher value so that they arent covered anymore by any obstructing things present on the website

### Screenshot
![image](https://github.com/user-attachments/assets/0ceb07e4-7e78-44bf-8fbe-2b46b18546a0)

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
