### PR TITLE
fix(icons): update `anchor` icon

### DIFF
--- a/icons/anchor.json
+++ b/icons/anchor.json
@@ -3,7 +3,8 @@
   "contributors": [
     "colebemis",
     "csandman",
-    "ericfennis"
+    "ericfennis",
+    "jamiemlaw"
   ],
   "tags": [
     "ship"

--- a/icons/anchor.svg
+++ b/icons/anchor.svg
@@ -9,7 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 22V8" />
-  <path d="M5 12H2a10 10 0 0 0 20 0h-3" />
-  <circle cx="12" cy="5" r="3" />
+  <path d="M12 22V6" />
+  <path d="M15 10H9" />
+  <path d="m22 14-2-2-2 2" />
+  <path d="M4 12v2a8 8 0 0 0 16 0v-2" />
+  <path d="m6 14-2-2-2 2" />
+  <circle cx="12" cy="4" r="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Other: icon update

### Description

Brings Lucide's anchor icon more inline with designs seen elsewhere.

![image](https://github.com/user-attachments/assets/13ab7ff7-3f03-41c2-92a6-5bed3901ac0b)


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
