### PR TITLE
refactor(icons): optimised some `align`-, `indent`- and `list`-icons

### DIFF
--- a/icons/align-center.svg
+++ b/icons/align-center.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="21" x2="3" y1="6" y2="6" />
-  <line x1="17" x2="7" y1="12" y2="12" />
-  <line x1="19" x2="5" y1="18" y2="18" />
+  <path d="M17 12H7" />
+  <path d="M19 18H5" />
+  <path d="M21 6H3" />
 </svg>

--- a/icons/align-justify.svg
+++ b/icons/align-justify.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="3" x2="21" y1="6" y2="6" />
-  <line x1="3" x2="21" y1="12" y2="12" />
-  <line x1="3" x2="21" y1="18" y2="18" />
+  <path d="M3 12h18" />
+  <path d="M3 18h18" />
+  <path d="M3 6h18" />
 </svg>

--- a/icons/align-left.svg
+++ b/icons/align-left.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="21" x2="3" y1="6" y2="6" />
-  <line x1="15" x2="3" y1="12" y2="12" />
-  <line x1="17" x2="3" y1="18" y2="18" />
+  <path d="M15 12H3" />
+  <path d="M17 18H3" />
+  <path d="M21 6H3" />
 </svg>

--- a/icons/align-right.svg
+++ b/icons/align-right.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="21" x2="3" y1="6" y2="6" />
-  <line x1="21" x2="9" y1="12" y2="12" />
-  <line x1="21" x2="7" y1="18" y2="18" />
+  <path d="M21 12H9" />
+  <path d="M21 18H7" />
+  <path d="M21 6H3" />
 </svg>

--- a/icons/indent-decrease.svg
+++ b/icons/indent-decrease.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="7 8 3 12 7 16" />
-  <line x1="21" x2="11" y1="12" y2="12" />
-  <line x1="21" x2="11" y1="6" y2="6" />
-  <line x1="21" x2="11" y1="18" y2="18" />
+  <path d="M21 12H11" />
+  <path d="M21 18H11" />
+  <path d="M21 6H11" />
+  <path d="m7 8-4 4 4 4" />
 </svg>

--- a/icons/indent-increase.svg
+++ b/icons/indent-increase.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="3 8 7 12 3 16" />
-  <line x1="21" x2="11" y1="12" y2="12" />
-  <line x1="21" x2="11" y1="6" y2="6" />
-  <line x1="21" x2="11" y1="18" y2="18" />
+  <path d="M21 12H11" />
+  <path d="M21 18H11" />
+  <path d="M21 6H11" />
+  <path d="m3 8 4 4-4 4" />
 </svg>

--- a/icons/list-ordered.svg
+++ b/icons/list-ordered.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="10" x2="21" y1="6" y2="6" />
-  <line x1="10" x2="21" y1="12" y2="12" />
-  <line x1="10" x2="21" y1="18" y2="18" />
-  <path d="M4 6h1v4" />
+  <path d="M10 12h11" />
+  <path d="M10 18h11" />
+  <path d="M10 6h11" />
   <path d="M4 10h2" />
+  <path d="M4 6h1v4" />
   <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" />
 </svg>

--- a/icons/list.svg
+++ b/icons/list.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="8" x2="21" y1="6" y2="6" />
-  <line x1="8" x2="21" y1="12" y2="12" />
-  <line x1="8" x2="21" y1="18" y2="18" />
-  <line x1="3" x2="3.01" y1="6" y2="6" />
-  <line x1="3" x2="3.01" y1="12" y2="12" />
-  <line x1="3" x2="3.01" y1="18" y2="18" />
+  <path d="M3 12h.01" />
+  <path d="M3 18h.01" />
+  <path d="M3 6h.01" />
+  <path d="M8 12h13" />
+  <path d="M8 18h13" />
+  <path d="M8 6h13" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Other: icon optimisation

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Replaced `<line/>` and `<polyline/>` elements with equivalent `<path/>`s using Lucide Studio's 'tidy' function

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
