### PR TITLE
fix(icons): changed `file-music` icon

### DIFF
--- a/icons/file-music.json
+++ b/icons/file-music.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "audio",

--- a/icons/file-music.svg
+++ b/icons/file-music.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M10.5 22H18a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v8.4" />
+  <path d="M8 18v-7.7L16 9v7" />
   <circle cx="14" cy="16" r="2" />
   <circle cx="6" cy="18" r="2" />
-  <path d="M4 12.4V4a2 2 0 0 1 2-2h8.5L20 7.5V20a2 2 0 0 1-2 2h-7.5" />
-  <path d="M8 18v-7.7L16 9v7" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Moved corner line path to be more consistent with other file icons.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.