### PR TITLE
fix: #2566 expand card beyond max-width limit by adjusting CSS

### DIFF
--- a/docs/.vitepress/theme/components/home/HomeIconCustomizer.vue
+++ b/docs/.vitepress/theme/components/home/HomeIconCustomizer.vue
@@ -171,16 +171,14 @@ watch(absoluteStrokeWidth, (enabled) => {
   margin-top: 32px;
   padding: 0;
   background: none;
-  max-width: 280px;
 }
 
 @media (min-width: 640px) {
-
   .card {
     display: grid;
     grid-template-columns: 8fr 10fr;
   }
-/*
+  /*
   .card-column {
     flex: 1;
   } */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
This pull request addresses issue https://github.com/lucide-icons/lucide/issues/2566, which concerns the max-width property limiting the expansion of the card component. By adjusting the CSS, this update allows the card to expand fully without layout constraints, enhancing the display and usability of icons and related content.

#### Changes Made:
CSS Adjustments for Card Expansion: Remove the max-width property on the card component to allow it to expand beyond previous limits.

#### Testing:
Manually tested across different screen sizes to confirm that the card expands without layout issues.
Verified compatibility with other existing components

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
