### PR TITLE
feat(docs): Add deprecated badge for icons with deprecation status

### DIFF
--- a/docs/.vitepress/theme/components/icons/IconInfo.vue
+++ b/docs/.vitepress/theme/components/icons/IconInfo.vue
@@ -117,8 +117,9 @@ const deprecatedTitle = computed(() => {
 }
 
 .deprecated-badge {
-  background-color: var(--vp-c-brand);
+  background-color: var(--vp-c-brand-5);
   margin-left: 40px;
+  opacity: .8;
 }
 
 .deprecated-badge:hover {

--- a/docs/.vitepress/theme/components/icons/IconInfo.vue
+++ b/docs/.vitepress/theme/components/icons/IconInfo.vue
@@ -9,6 +9,8 @@ import {useData, useRouter} from 'vitepress';
 import { computed } from 'vue';
 import createLucideIcon from 'lucide-vue-next/src/createLucideIcon';
 import { diamond }  from '../../../data/iconNodes'
+import deprecationReasonTemplate from '../../../../../tools/build-icons/utils/deprecationReasonTemplate.mjs';
+
 
 const props = defineProps<{
   icon: IconEntity
@@ -24,6 +26,15 @@ const tags = computed(() => {
 })
 
 const DiamondIcon = createLucideIcon('Diamond', diamond)
+
+const deprecatedTitle = computed(() => {
+  if (!props.icon.deprecationReason) return '';
+  return deprecationReasonTemplate(props.icon.deprecationReason, {
+    componentName: props.icon.name,
+    iconName: props.icon.name,
+    toBeRemovedInVersion: props.icon.toBeRemovedInVersion,
+  });
+});
 </script>
 
 <template>
@@ -36,6 +47,13 @@ const DiamondIcon = createLucideIcon('Diamond', diamond)
         <DiamondIcon fill="currentColor" :size="12"/>
         {{ icon.externalLibrary }}
       </div>
+      <Badge
+        v-if="icon.deprecated"
+        class="deprecated-badge"
+        :title="deprecatedTitle"
+      >
+        Deprecated
+      </Badge>
     </div>
     <div class="tags-scroller" v-if="tags.length">
       <p class="icon-tags horizontal-scroller">
@@ -96,6 +114,15 @@ const DiamondIcon = createLucideIcon('Diamond', diamond)
   display: flex;
   gap: 8px;
   align-items: center;
+}
+
+.deprecated-badge {
+  background-color: var(--vp-c-brand);
+  margin-left: 40px;
+}
+
+.deprecated-badge:hover {
+  background-color: var(--vp-c-brand-2);
 }
 
 .icon-tags {

--- a/docs/.vitepress/theme/types.ts
+++ b/docs/.vitepress/theme/types.ts
@@ -6,6 +6,9 @@ export interface IconMetaData {
   categories: string[];
   contributors: string[];
   aliases?: string[];
+  deprecated?: boolean;
+  deprecationReason?: string;  
+  toBeRemovedInVersion?: string;
 }
 
 export type ExternalLibs = 'lab';

--- a/docs/.vitepress/theme/types.ts
+++ b/docs/.vitepress/theme/types.ts
@@ -7,7 +7,7 @@ export interface IconMetaData {
   contributors: string[];
   aliases?: string[];
   deprecated?: boolean;
-  deprecationReason?: string;  
+  deprecationReason?: string;
   toBeRemovedInVersion?: string;
 }
 

--- a/docs/scripts/writeIconDetails.mjs
+++ b/docs/scripts/writeIconDetails.mjs
@@ -27,7 +27,7 @@ import iconNode from '../iconNodes/${iconName}.node.json'
 import metaData from '../../../../icons/${iconName}.json'
 import releaseData from '../releaseMetadata/${iconName}.json'
 
-const { tags, categories, contributors, aliases } = metaData
+const { tags, categories, contributors, aliases, deprecated, deprecationReason, toBeRemovedInVersion } = metaData
 
 const iconDetails = {
   name: '${iconName}',
@@ -36,6 +36,9 @@ const iconDetails = {
   tags,
   categories,
   aliases,
+  deprecated,
+  deprecationReason,
+  toBeRemovedInVersion,
   ...releaseData,
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other:

### Description
This pull request introduces a "Deprecated" badge that appears for icons flagged as deprecated in the `IconInfo.vue` component. This update improves the user interface by clearly indicating which icons are deprecated, helping users avoid using outdated assets.

#### Changes Made:

- **Badge Component**: Added a `Badge` component to display the "Deprecated" label next to icons flagged as deprecated.
- **Conditional Badge Display**: Updated `IconInfo.vue` to conditionally show the deprecated badge if the icon has the` deprecated` property set to `true`.
- **Tooltip with Deprecation Details**: Included a tooltip that provides additional context on hover, displaying the reason for deprecation and the version in which the icon will be removed.

#### Testing:

Manually tested the badge display on various icons, ensuring the tooltip shows the correct deprecation reason and version.
Verified the badge does not appear for icons without the deprecated property.

Screenshots:
Before:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/e77592ee-5485-42ae-a921-971f9c633508">

After:
<img width="756" alt="image" src="https://github.com/user-attachments/assets/8f18973a-9d18-4d22-b546-850e70394764">


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
