### PR TITLE
fix(icons): changed `scale-3d` icon

### DIFF
--- a/icons/scale-3d.svg
+++ b/icons/scale-3d.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M5 7v11a1 1 0 0 0 1 1h11" />
+  <path d="M5.293 18.707 11 13" />
   <circle cx="19" cy="19" r="2" />
   <circle cx="5" cy="5" r="2" />
-  <path d="M5 7v12h12" />
-  <path d="m5 19 6-6" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Arcified corner.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.