### PR TITLE
fix(metadata): added window related tags to `grid-2x2` icon metadata file

### DIFF
--- a/icons/grid-2x2.json
+++ b/icons/grid-2x2.json
@@ -18,7 +18,9 @@
     "distance",
     "surface area",
     "square meter",
-    "acre"
+    "acre",
+    "window",
+    "skylight"
   ],
   "categories": [
     "text",

--- a/icons/grid-2x2.svg
+++ b/icons/grid-2x2.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="18" height="18" x="3" y="3" rx="2" />
-  <path d="M3 12h18" />
   <path d="M12 3v18" />
+  <path d="M3 12h18" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Added metadata.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.