### PR TITLE
Change mentions of Icon to LucideIcon

### DIFF
--- a/docs/guide/packages/lucide-react.md
+++ b/docs/guide/packages/lucide-react.md
@@ -65,19 +65,19 @@ const App = () => {
 
 [Lucide lab](https://github.com/lucide-icons/lucide-lab) is a collection of icons that are not part of the Lucide main library.
 
-They can be used by using the `Icon` component.
+They can be used by using the `LucideIcon` component.
 All props like regular lucide icons can be passed to adjust the icon appearance.
 
-### Using the `Icon` component
+### Using the `LucideIcon` component
 
 This creates a single icon based on the iconNode passed and renders a Lucide icon component.
 
 ```jsx
-import { Icon } from 'lucide-react';
+import { LucideIcon } from 'lucide-react';
 import { burger } from '@lucide/lab';
 
 const App = () => (
-  <Icon iconNode={burger} />
+  <LucideIcon iconNode={burger} />
 );
 ```
 


### PR DESCRIPTION
There's no Icon component exported from lucide-react. It is called LucideIcon.

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other:

### Description

There's no Icon component exported from lucide-react. It is called LucideIcon.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
