### PR TITLE
docs(lucide-static): replace nonexistent icon references

### DIFF
--- a/docs/guide/packages/lucide-static.md
+++ b/docs/guide/packages/lucide-static.md
@@ -43,7 +43,7 @@ bun add lucide-static
 
 ```html
 <!-- SVG file for a single icon -->
-<img src="https://unpkg.com/lucide-static@latest/icons/home.svg" />
+<img src="https://unpkg.com/lucide-static@latest/icons/house.svg" />
 
 <!-- Icon font -->
 <style>
@@ -66,12 +66,12 @@ To use it in for example html:
 
 ```html
 <!-- SVG file for a single icon -->
-<img src="~lucide-static/icons/home.svg" />
+<img src="~lucide-static/icons/house.svg" />
 ```
 
 ```css
-.home-icon {
-  background-image: url(~lucide-static/icons/home.svg);
+.house-icon {
+  background-image: url(~lucide-static/icons/house.svg);
 }
 ```
 
@@ -94,7 +94,7 @@ You may need additional loader for this.
 
 ```html
 <!-- Icon Sprite, not recommended for production! -->
-<img src="lucide-static/sprite.svg#home" />
+<img src="lucide-static/sprite.svg#house" />
 
 <!-- or -->
 <svg
@@ -151,7 +151,7 @@ and update the SVG as follows
 ```
 
 ```html
-<div class="icon-home"></div>
+<div class="icon-house"></div>
 ```
 
 ### Node.js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
this pr updates the docs to use valid icons in the static installation guide. the guide uses a `home` icon as demonstration, but such icon doesn't exist. i've replaced all references to `home` with `house`

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
