### PR TITLE
chore(metadata): add more tags to `trophy` icon

### DIFF
--- a/icons/trophy.json
+++ b/icons/trophy.json
@@ -8,7 +8,10 @@
     "sports",
     "winner",
     "achievement",
-    "award"
+    "award",
+    "champion",
+    "celebration",
+    "victory"
   ],
   "categories": [
     "sports",

--- a/icons/trophy.json
+++ b/icons/trophy.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "realguse"
   ],
   "tags": [
     "prize",

--- a/icons/trophy.json
+++ b/icons/trophy.json
@@ -1,8 +1,7 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere",
-    "realguse"
+    "karsa-mistmere"
   ],
   "tags": [
     "prize",


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] Documentation update

### Description
Adds `award`, `champion`, `celebration` and `victory` tags to the `trophy` icon

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
