### PR TITLE
fix(scripts): Fix auto formatting script

### DIFF
--- a/icons/grid-2x2-check.json
+++ b/icons/grid-2x2-check.json
@@ -26,5 +26,8 @@
     "text",
     "layout",
     "math"
+  ],
+  "aliases": [
+    "grid-2-x-2-check"
   ]
 }

--- a/icons/grid-2x2-x.json
+++ b/icons/grid-2x2-x.json
@@ -26,5 +26,8 @@
     "text",
     "layout",
     "math"
+  ],
+  "aliases": [
+    "grid-2-x-2-x"
   ]
 }

--- a/scripts/generateChangedIconsCommentMarkup.mjs
+++ b/scripts/generateChangedIconsCommentMarkup.mjs
@@ -22,7 +22,7 @@ if (changedFilesPathString == null) {
 
 const changedFiles = changedFilesPathString
   .split(' ')
-  .map((file) => file.replace('.json', '.svg'))
+  .filter((file) => file.includes('.svg'))
   .filter((file, idx, arr) => arr.indexOf(file) === idx);
 
 if (changedFiles.length === 0) {

--- a/scripts/generateNextJSAliases.mjs
+++ b/scripts/generateNextJSAliases.mjs
@@ -41,7 +41,8 @@ Promise.all(
         aliases.push(iconNameKebabCaseNextjsFlavour);
       }
 
-      const output = JSON.stringify({ ...iconMetaData, aliases }, null, 2);
+      let output = JSON.stringify({ ...iconMetaData, aliases }, null, 2);
+      output = `${output}\n`;
       fs.writeFile(path.resolve(ICONS_DIR, `${iconName}.json`), output, 'utf-8');
     }
   }),


### PR DESCRIPTION
Fixes auto-formatting scripts.
Currently, the script [generateNextJSAliases.mjs](https://github.com/lucide-icons/lucide/pull/2712/commits/a79ac376e3350679c56c2cbbb9b50393c794edf8) is not matching the output the prettier and lining configuration. Which results in annoying changed files when running the pre-commit hook.