### PR TITLE
fix(site): use lab icon name in vue and svelte examples

### DIFF
--- a/docs/.vitepress/lib/codeExamples/createLabCodeExamples.ts
+++ b/docs/.vitepress/lib/codeExamples/createLabCodeExamples.ts
@@ -49,7 +49,7 @@ import { $CamelCase } from '@lucide/lab';
 </script>
 
 <template>
-  <Icon :iconNode="burger" />
+  <Icon :iconNode="$CamelCase" />
 </template>
 `,
     },
@@ -61,7 +61,7 @@ import { Icon } from 'lucide-svelte';
 import { $CamelCase } from '@lucide/lab';
 </script>
 
-<Icon iconNode={burger} />
+<Icon iconNode={$CamelCase} />
 `,
     },
     {


### PR DESCRIPTION
## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Fixes lab code examples for Vue and Svelte. It was always using "burger" as the value for the `iconNode` prop, rather than the name of the icon being viewed.

Vue:
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/9213c825-1b22-407e-a87d-b2ce86657830" />

Svelte:
<img width="1153" alt="image" src="https://github.com/user-attachments/assets/cf8987da-bddb-48c6-9abe-8e142245ac5c" />


## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
