### PR TITLE
fix(lucide-react) Adds type module in package.json

### DIFF
--- a/packages/lucide-react/package.json
+++ b/packages/lucide-react/package.json
@@ -24,9 +24,9 @@
   "author": "Eric Fennis",
   "amdName": "lucide-react",
   "source": "src/lucide-react.ts",
-  "main": "dist/cjs/lucide-react.js",
-  "module": "dist/esm/lucide-react.js",
+  "main": "dist/ems/lucide-react.js",
   "types": "dist/lucide-react.d.ts",
+  "type": "module",
   "files": [
     "dist"
   ],

--- a/packages/lucide-react/package.json
+++ b/packages/lucide-react/package.json
@@ -24,7 +24,7 @@
   "author": "Eric Fennis",
   "amdName": "lucide-react",
   "source": "src/lucide-react.ts",
-  "main": "dist/ems/lucide-react.js",
+  "main": "dist/esm/lucide-react.js",
   "types": "dist/lucide-react.d.ts",
   "type": "module",
   "files": [


### PR DESCRIPTION
fixes: #2730 
Probably fixes: #2729 

## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
Adds `"type": "module"` in package json, so bundeler knows which export property it should use.