### PR TITLE
fix(icons): changed `languages` icon

### DIFF
--- a/icons/languages.json
+++ b/icons/languages.json
@@ -3,7 +3,8 @@
   "contributors": [
     "ericfennis",
     "mittalyashu",
-    "johnletey"
+    "johnletey",
+    "jamiemlaw"
   ],
   "tags": [
     "translate"

--- a/icons/languages.svg
+++ b/icons/languages.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m5 8 6 6" />
-  <path d="m4 14 6-6 2-3" />
-  <path d="M2 5h12" />
-  <path d="M7 2h1" />
-  <path d="m22 22-5-10-5 10" />
-  <path d="M14 18h6" />
+  <path d="M12 18h8" />
+  <path d="M12 4A10 10 0 0 1 2 14" />
+  <path d="M2 4h12" />
+  <path d="m22 22-6-12-6 12" />
+  <path d="M4 4a10 10 0 0 0 10 10" />
+  <path d="M8 2v2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Fixes a 2px-gap violation and otherwise improves the look of the 文 glyph.

### Alternative Designs

![image](https://github.com/user-attachments/assets/a010e9b8-6ea4-4397-8caa-b5288018a02b)

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.