### PR TITLE
fix(bolt-icon): correct "contruction" typo in tags to "construction"

### DIFF
--- a/icons/bolt.json
+++ b/icons/bolt.json
@@ -14,7 +14,7 @@
     "diy",
     "fixed",
     "build",
-    "contruction",
+    "construction",
     "parts"
   ],
   "categories": [


### PR DESCRIPTION

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
This PR fixes a typo in the `tags` for the `bolt` icon. The tag `"contruction"` was corrected to `"construction"`.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
