### PR TITLE
ci: Improve build speeds

### DIFF
--- a/docs/scripts/writeCategoriesMetadata.mjs
+++ b/docs/scripts/writeCategoriesMetadata.mjs
@@ -1,16 +1,17 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 const currentDir = process.cwd();
 const dataDirectory = path.resolve(currentDir, '.vitepress/data');
 const directory = path.join(process.cwd(), '../categories');
 
-function getAllCategoryFiles() {
-  const fileNames = fs.readdirSync(directory).filter((file) => path.extname(file) === '.json');
+async function getAllCategoryFiles() {
+  const categoryDirectoryContents = await fs.readdir(directory)
+  const fileNames = categoryDirectoryContents.filter((file) => path.extname(file) === '.json');
 
-  return fileNames.map((fileName) => {
+  const categoryJSONReadPromises = fileNames.map(async (fileName) => {
     const name = path.basename(fileName, '.json');
-    const fileContent = fs.readFileSync(path.join(directory, fileName), 'utf8');
+    const fileContent = await fs.readFile(path.join(directory, fileName), 'utf8');
 
     const parsedFileContent = JSON.parse(fileContent);
 
@@ -19,13 +20,15 @@ function getAllCategoryFiles() {
       title: parsedFileContent.title,
     };
   });
+
+  return Promise.all(categoryJSONReadPromises)
 }
 
 const categoriesFile = path.resolve(dataDirectory, `categoriesData.json`);
 
-const categoriesData = getAllCategoryFiles();
+const categoriesData = await getAllCategoryFiles();
 
-fs.promises
+fs
   .writeFile(categoriesFile, JSON.stringify(categoriesData, null, 2), 'utf-8')
   .then(() => {
     console.log('Successfully written categoriesData.json file');

--- a/docs/scripts/writeCategoriesMetadata.mjs
+++ b/docs/scripts/writeCategoriesMetadata.mjs
@@ -6,7 +6,7 @@ const dataDirectory = path.resolve(currentDir, '.vitepress/data');
 const directory = path.join(process.cwd(), '../categories');
 
 async function getAllCategoryFiles() {
-  const categoryDirectoryContents = await fs.readdir(directory)
+  const categoryDirectoryContents = await fs.readdir(directory);
   const fileNames = categoryDirectoryContents.filter((file) => path.extname(file) === '.json');
 
   const categoryJSONReadPromises = fileNames.map(async (fileName) => {
@@ -21,15 +21,14 @@ async function getAllCategoryFiles() {
     };
   });
 
-  return Promise.all(categoryJSONReadPromises)
+  return Promise.all(categoryJSONReadPromises);
 }
 
 const categoriesFile = path.resolve(dataDirectory, `categoriesData.json`);
 
 const categoriesData = await getAllCategoryFiles();
 
-fs
-  .writeFile(categoriesFile, JSON.stringify(categoriesData, null, 2), 'utf-8')
+fs.writeFile(categoriesFile, JSON.stringify(categoriesData, null, 2), 'utf-8')
   .then(() => {
     console.log('Successfully written categoriesData.json file');
   })

--- a/docs/scripts/writeIconDetails.mjs
+++ b/docs/scripts/writeIconDetails.mjs
@@ -4,7 +4,7 @@ import { readSvgDirectory, toCamelCase } from '@lucide/helpers';
 
 const currentDir = process.cwd();
 const ICONS_DIR = path.resolve(currentDir, '../icons');
-const icons = readSvgDirectory(ICONS_DIR, '.json');
+const icons = await readSvgDirectory(ICONS_DIR, '.json');
 
 const iconDetailsDirectory = path.resolve(currentDir, '.vitepress/data', 'iconDetails');
 

--- a/docs/scripts/writeIconMetaIndex.mjs
+++ b/docs/scripts/writeIconMetaIndex.mjs
@@ -4,7 +4,7 @@ import { readSvgDirectory, toCamelCase } from '@lucide/helpers';
 
 const currentDir = process.cwd();
 const ICONS_DIR = path.resolve(currentDir, '../icons');
-const iconJsonFiles = readSvgDirectory(ICONS_DIR, '.json');
+const iconJsonFiles = await readSvgDirectory(ICONS_DIR, '.json');
 
 const location = path.resolve(currentDir, '.vitepress/data', 'iconMetaData.ts');
 

--- a/docs/scripts/writeIconNodes.mjs
+++ b/docs/scripts/writeIconNodes.mjs
@@ -32,7 +32,7 @@ const writeIconFiles = Object.entries(icons).map(async ([iconName, { children }]
   await fs.promises.writeFile(location, output, 'utf-8');
 
   iconIndexFileImports.push(
-    `import ${toCamelCase(iconName)}Node from './${iconName}.node.json' assert { type: "json" };`,
+    `import ${toCamelCase(iconName)}Node from './${iconName}.node.json' with { type: "json" };`,
   );
   iconIndexFileExports.push(`  ${toCamelCase(iconName)}Node as ${toCamelCase(iconName)},`);
   iconIndexFileDefaultExports.push(`  '${iconName}': ${toCamelCase(iconName)}Node,`);

--- a/docs/scripts/writeIconNodes.mjs
+++ b/docs/scripts/writeIconNodes.mjs
@@ -5,8 +5,8 @@ import { readSvgDirectory, toCamelCase } from '@lucide/helpers';
 
 const currentDir = process.cwd();
 const ICONS_DIR = path.resolve(currentDir, '../icons');
-const svgFiles = readSvgDirectory(ICONS_DIR);
-const icons = renderIconsObject(svgFiles, ICONS_DIR, true);
+const svgFiles = await readSvgDirectory(ICONS_DIR);
+const icons = await renderIconsObject(svgFiles, ICONS_DIR, true);
 
 const iconNodesDirectory = path.resolve(currentDir, '.vitepress/data', 'iconNodes');
 

--- a/docs/scripts/writeIconRelatedIcons.mjs
+++ b/docs/scripts/writeIconRelatedIcons.mjs
@@ -4,7 +4,7 @@ import { readSvgDirectory } from '@lucide/helpers';
 
 const currentDir = process.cwd();
 const ICONS_DIR = path.resolve(currentDir, '../icons');
-const svgFiles = readSvgDirectory(ICONS_DIR, '.json');
+const svgFiles = await readSvgDirectory(ICONS_DIR, '.json');
 
 const location = path.resolve(currentDir, '.vitepress/data', 'relatedIcons.json');
 
@@ -18,9 +18,7 @@ const categoryWeight = 3;
 
 const MAX_RELATED_ICONS = 4 * 17; // grid of 4x17 icons, = 68 icons
 
-const arrayMatches = (a, b) => {
-  return a.filter((item) => b.includes(item)).length;
-};
+const arrayMatches = (a, b) => a.filter((item) => b.includes(item)).length;
 
 const nameParts = (icon) =>
   [

--- a/docs/scripts/writeIconRelatedIcons.mjs
+++ b/docs/scripts/writeIconRelatedIcons.mjs
@@ -34,6 +34,7 @@ const getRelatedIcons = (currentIcon, icons) => {
     nameWeight * arrayMatches(nameParts(item), nameParts(currentIcon)) +
     categoryWeight * arrayMatches(item.categories ?? [], currentIcon.categories ?? []) +
     tagWeight * arrayMatches(item.tags ?? [], currentIcon.tags ?? []);
+
   return icons
     .filter((i) => i.name !== currentIcon.name)
     .map((icon) => ({ icon, similarity: iconSimilarity(icon) }))
@@ -44,7 +45,8 @@ const getRelatedIcons = (currentIcon, icons) => {
 };
 
 const iconsMetaDataPromises = svgFiles.map(async (iconName) => {
-  const metaData = JSON.parse(fs.readFileSync(`../icons/${iconName}`));
+  const metaDataFileContent = await fs.promises.readFile(`../icons/${iconName}`)
+  const metaData = JSON.parse(metaDataFileContent);
 
   const name = iconName.replace('.json', '');
 

--- a/docs/scripts/writeIconRelatedIcons.mjs
+++ b/docs/scripts/writeIconRelatedIcons.mjs
@@ -45,7 +45,7 @@ const getRelatedIcons = (currentIcon, icons) => {
 };
 
 const iconsMetaDataPromises = svgFiles.map(async (iconName) => {
-  const metaDataFileContent = await fs.promises.readFile(`../icons/${iconName}`)
+  const metaDataFileContent = await fs.promises.readFile(`../icons/${iconName}`);
   const metaData = JSON.parse(metaDataFileContent);
 
   const name = iconName.replace('.json', '');

--- a/docs/scripts/writeReleaseMetadata.mjs
+++ b/docs/scripts/writeReleaseMetadata.mjs
@@ -11,7 +11,7 @@ const git = simpleGit();
 
 const currentDir = process.cwd();
 const ICONS_DIR = path.resolve(currentDir, '../icons');
-const iconJsonFiles = readSvgDirectory(ICONS_DIR, '.json');
+const iconJsonFiles = await readSvgDirectory(ICONS_DIR, '.json');
 const location = path.resolve(currentDir, '.vitepress/data', 'releaseMetaData.json');
 const releaseMetaDataDirectory = path.resolve(currentDir, '.vitepress/data', 'releaseMetadata');
 

--- a/docs/scripts/writeVercelOutput.mjs
+++ b/docs/scripts/writeVercelOutput.mjs
@@ -44,4 +44,4 @@ const output = JSON.stringify(vercelRouteConfig, null, 2);
 
 const vercelOutputJSON = path.resolve(currentDir, '.vercel/output/config.json');
 
-fs.writeFileSync(vercelOutputJSON, output, 'utf-8');
+await fs.promises.writeFile(vercelOutputJSON, output, 'utf-8');

--- a/packages/lucide-angular/scripts/exportTemplate.mjs
+++ b/packages/lucide-angular/scripts/exportTemplate.mjs
@@ -1,7 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  componentName,
+  iconName,
+  children,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/packages/lucide-angular/scripts/exportTemplate.mjs
+++ b/packages/lucide-angular/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `\

--- a/packages/lucide-preact/rollup.config.mjs
+++ b/packages/lucide-preact/rollup.config.mjs
@@ -1,6 +1,6 @@
 import plugins from '@lucide/rollup-plugins';
 import dts from 'rollup-plugin-dts';
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 const packageName = 'LucidePreact';
 const outputFileName = 'lucide-preact';

--- a/packages/lucide-preact/scripts/exportTemplate.mjs
+++ b/packages/lucide-preact/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `

--- a/packages/lucide-preact/scripts/exportTemplate.mjs
+++ b/packages/lucide-preact/scripts/exportTemplate.mjs
@@ -1,7 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  componentName,
+  iconName,
+  children,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/packages/lucide-react-native/scripts/exportTemplate.mjs
+++ b/packages/lucide-react-native/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `

--- a/packages/lucide-react-native/scripts/exportTemplate.mjs
+++ b/packages/lucide-react-native/scripts/exportTemplate.mjs
@@ -1,7 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  componentName,
+  iconName,
+  children,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/packages/lucide-react/scripts/exportTemplate.mjs
+++ b/packages/lucide-react/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `

--- a/packages/lucide-react/scripts/exportTemplate.mjs
+++ b/packages/lucide-react/scripts/exportTemplate.mjs
@@ -1,7 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  componentName,
+  iconName,
+  children,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/packages/lucide-solid/scripts/exportTemplate.mjs
+++ b/packages/lucide-solid/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `

--- a/packages/lucide-solid/scripts/exportTemplate.mjs
+++ b/packages/lucide-solid/scripts/exportTemplate.mjs
@@ -1,7 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  componentName,
+  iconName,
+  children,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/packages/lucide-static/scripts/buildLib.mjs
+++ b/packages/lucide-static/scripts/buildLib.mjs
@@ -43,4 +43,4 @@ await Promise.all([
   generateSprite(parsedSvgs, PACKAGE_DIR, license),
   generateIconNodes(parsedSvgs, PACKAGE_DIR),
   copyIcons(parsedSvgs, PACKAGE_DIR, license),
-])
+]);

--- a/packages/lucide-static/scripts/buildLib.mjs
+++ b/packages/lucide-static/scripts/buildLib.mjs
@@ -31,7 +31,7 @@ createDirectory(LIB_DIR);
 createDirectory(ICON_MODULE_DIR);
 
 const svgFiles = await readSvgDirectory(ICONS_DIR);
-const svgs = readSvgs(svgFiles, ICONS_DIR);
+const svgs = await readSvgs(svgFiles, ICONS_DIR);
 
 const parsedSvgs = svgs.map(({ name, contents }) => ({
   name,
@@ -39,6 +39,8 @@ const parsedSvgs = svgs.map(({ name, contents }) => ({
   parsedSvg: parseSync(contents),
 }));
 
-generateSprite(parsedSvgs, PACKAGE_DIR, license);
-generateIconNodes(parsedSvgs, PACKAGE_DIR);
-copyIcons(parsedSvgs, PACKAGE_DIR, license);
+await Promise.all([
+  generateSprite(parsedSvgs, PACKAGE_DIR, license),
+  generateIconNodes(parsedSvgs, PACKAGE_DIR),
+  copyIcons(parsedSvgs, PACKAGE_DIR, license),
+])

--- a/packages/lucide-static/scripts/buildLib.mjs
+++ b/packages/lucide-static/scripts/buildLib.mjs
@@ -30,7 +30,7 @@ const license = `@license ${pkg.name} v${pkg.version} - ${pkg.license}`;
 createDirectory(LIB_DIR);
 createDirectory(ICON_MODULE_DIR);
 
-const svgFiles = readSvgDirectory(ICONS_DIR);
+const svgFiles = await readSvgDirectory(ICONS_DIR);
 const svgs = readSvgs(svgFiles, ICONS_DIR);
 
 const parsedSvgs = svgs.map(({ name, contents }) => ({

--- a/packages/lucide-static/scripts/exportTemplate.mjs
+++ b/packages/lucide-static/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  let svgContents = getSvg();
+export default async ({ componentName, iconName, getSvg, deprecated, deprecationReason }) => {
+  let svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   svgContents = svgContents.replace(

--- a/packages/lucide-static/scripts/generateIconNodes.mjs
+++ b/packages/lucide-static/scripts/generateIconNodes.mjs
@@ -1,6 +1,6 @@
 import { writeFile } from '@lucide/helpers';
 
-export default function generateIconNodes(parsedSvgs, packageDir) {
+export default async function generateIconNodes(parsedSvgs, packageDir) {
   const iconNodes = parsedSvgs.reduce((acc, { name, parsedSvg }) => {
     acc[name] = parsedSvg.children.map(({ name, attributes }) => [name, attributes]);
 
@@ -9,5 +9,5 @@ export default function generateIconNodes(parsedSvgs, packageDir) {
 
   const iconNodesStringified = JSON.stringify(iconNodes, null, 2);
 
-  writeFile(iconNodesStringified, 'icon-nodes.json', packageDir);
+  await writeFile(iconNodesStringified, 'icon-nodes.json', packageDir);
 }

--- a/packages/lucide-static/scripts/generateSprite.mjs
+++ b/packages/lucide-static/scripts/generateSprite.mjs
@@ -3,7 +3,7 @@ import { stringify } from 'svgson';
 import { format } from 'prettier';
 import { appendFile } from '@lucide/helpers';
 
-export default function generateSprite(svgs, packageDir, license) {
+export default async function generateSprite(svgs, packageDir, license) {
   const symbols = svgs.map(({ name, parsedSvg }) => ({
     name: 'symbol',
     type: 'element',
@@ -34,6 +34,6 @@ export default function generateSprite(svgs, packageDir, license) {
 
   const xmlMeta = `<?xml version="1.0" encoding="utf-8"?>\n<!-- ${license} -->\n`;
 
-  appendFile(xmlMeta, `sprite.svg`, packageDir);
-  appendFile(prettifiedSprite, `sprite.svg`, packageDir);
+  await appendFile(xmlMeta, `sprite.svg`, packageDir);
+  await appendFile(prettifiedSprite, `sprite.svg`, packageDir);
 }

--- a/packages/lucide-static/scripts/readSvgs.mjs
+++ b/packages/lucide-static/scripts/readSvgs.mjs
@@ -9,10 +9,12 @@ import { readSvg } from '@lucide/helpers';
  * @returns {Object}
  */
 export default function readSVGs(svgFiles, iconsDirectory) {
-  return svgFiles.map((svgFile) => {
+  const SVGReadPromises = svgFiles.map(async (svgFile) => {
     const name = basename(svgFile, '.svg');
-    const contents = readSvg(svgFile, iconsDirectory);
+    const contents = await readSvg(svgFile, iconsDirectory);
 
     return { name, contents };
   });
+
+  return Promise.all(SVGReadPromises);
 }

--- a/packages/lucide-svelte/package.json
+++ b/packages/lucide-svelte/package.json
@@ -52,7 +52,7 @@
     "build:icons": "build-icons --output=./src --templateSrc=./scripts/exportTemplate.mjs --exportFileName=index.ts --iconFileExtension=.svelte --importImportFileExtension=.svelte --separateIconFileExport --separateIconFileExportExtension=.ts --withAliases --aliasesFileExtension=.ts --separateAliasesFile  --separateAliasesFileExtension=.ts --aliasImportFileExtension=.js --pretty=false",
     "build:package": "svelte-package --input ./src",
     "build:license": "node ./scripts/appendBlockComments.mjs",
-    "test": "pnpm build:icons && vitest run",
+    "test": "pnpm copy:license && pnpm build:icons && vitest run",
     "test:watch": "vitest watch",
     "version": "pnpm version --git-tag-version=false"
   },

--- a/packages/lucide-svelte/scripts/appendBlockComments.mjs
+++ b/packages/lucide-svelte/scripts/appendBlockComments.mjs
@@ -4,7 +4,7 @@ import path from 'path';
 import { getCurrentDirPath } from '@lucide/helpers';
 import { getJSBanner } from './license.mjs';
 
-const currentDir = getCurrentDirPath(import.meta.url);
+const currentDir = await getCurrentDirPath(import.meta.url);
 const targetDirectory = path.join(currentDir, '../dist');
 
 const files = await readdir(targetDirectory, {

--- a/packages/lucide-svelte/scripts/exportTemplate.mjs
+++ b/packages/lucide-svelte/scripts/exportTemplate.mjs
@@ -2,7 +2,14 @@
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 import { getJSBanner } from './license.mjs';
 
-export default async ({ iconName, children, componentName, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  iconName,
+  children,
+  componentName,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/packages/lucide-svelte/scripts/exportTemplate.mjs
+++ b/packages/lucide-svelte/scripts/exportTemplate.mjs
@@ -2,8 +2,8 @@
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 import { getJSBanner } from './license.mjs';
 
-export default ({ iconName, children, componentName, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ iconName, children, componentName, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `\

--- a/packages/lucide-vue-next/scripts/exportTemplate.mjs
+++ b/packages/lucide-vue-next/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `

--- a/packages/lucide-vue-next/scripts/exportTemplate.mjs
+++ b/packages/lucide-vue-next/scripts/exportTemplate.mjs
@@ -1,7 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  componentName,
+  iconName,
+  children,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/packages/lucide-vue/scripts/exportTemplate.mjs
+++ b/packages/lucide-vue/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `

--- a/packages/lucide-vue/scripts/exportTemplate.mjs
+++ b/packages/lucide-vue/scripts/exportTemplate.mjs
@@ -1,7 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  componentName,
+  iconName,
+  children,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/packages/lucide/scripts/exportTemplate.mjs
+++ b/packages/lucide/scripts/exportTemplate.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
-  const svgContents = getSvg();
+export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+  const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 
   return `

--- a/packages/lucide/scripts/exportTemplate.mjs
+++ b/packages/lucide/scripts/exportTemplate.mjs
@@ -1,7 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
 
-export default async ({ componentName, iconName, children, getSvg, deprecated, deprecationReason }) => {
+export default async ({
+  componentName,
+  iconName,
+  children,
+  getSvg,
+  deprecated,
+  deprecationReason,
+}) => {
   const svgContents = await getSvg();
   const svgBase64 = base64SVG(svgContents);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,9 +704,6 @@ importers:
 
   tools/build-icons:
     dependencies:
-      '@lucide/helpers':
-        specifier: ^1.0.0
-        version: 1.0.0
       minimist:
         specifier: ^1.2.7
         version: 1.2.8
@@ -722,6 +719,10 @@ importers:
       svgson:
         specifier: ^5.2.1
         version: 5.3.1
+    devDependencies:
+      '@lucide/helpers':
+        specifier: workspace:*
+        version: link:../build-helpers
 
   tools/outline-svg:
     dependencies:
@@ -3297,9 +3298,6 @@ packages:
 
   '@lezer/lr@1.3.10':
     resolution: {integrity: sha512-BZfVvf7Re5BIwJHlZXbJn9L8lus5EonxQghyn+ih8Wl36XMFBPTXC0KM0IdUtj9w/diPHsKlXVgL+AlX2jYJ0Q==}
-
-  '@lucide/helpers@1.0.0':
-    resolution: {integrity: sha512-9dfxrgLLaoCfr3R/eh6wwlUcY+ZPdEv6SDwFMUhYoO6HhGL8yN8hb5ZwI/OfzbK9mdJpa+jYfwP4nF4ZlZwZLA==}
 
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
@@ -15810,8 +15808,6 @@ snapshots:
     dependencies:
       '@lezer/common': 1.2.1
 
-  '@lucide/helpers@1.0.0': {}
-
   '@mapbox/node-pre-gyp@1.0.11(encoding@0.1.13)':
     dependencies:
       detect-libc: 2.0.2
@@ -17590,18 +17586,6 @@ snapshots:
       '@babel/parser': 7.26.1
       postcss: 8.4.49
       source-map: 0.6.1
-
-  '@vue/compiler-sfc@3.4.18':
-    dependencies:
-      '@babel/parser': 7.23.9
-      '@vue/compiler-core': 3.4.18
-      '@vue/compiler-dom': 3.4.18
-      '@vue/compiler-ssr': 3.4.18
-      '@vue/shared': 3.4.18
-      estree-walker: 2.0.2
-      magic-string: 0.30.11
-      postcss: 8.4.41
-      source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.4.21':
     dependencies:

--- a/scripts/migrateCategoriesToIcons.mjs
+++ b/scripts/migrateCategoriesToIcons.mjs
@@ -1,5 +1,5 @@
 import path from 'path';
-import categories from '../categories.json' assert { type: 'json' };
+import categories from '../categories.json' with { type: 'json' };
 import {
   mergeArrays,
   writeFile,

--- a/scripts/migrateIconsToTags.mjs
+++ b/scripts/migrateIconsToTags.mjs
@@ -3,7 +3,7 @@ import { writeFile, getCurrentDirPath, readAllMetadata } from '../tools/build-he
 
 const currentDir = getCurrentDirPath(import.meta.url);
 const ICONS_DIR = path.resolve(currentDir, '../icons');
-const icons = readAllMetadata(ICONS_DIR);
+const icons = await readAllMetadata(ICONS_DIR);
 
 const tags = Object.keys(icons)
   .sort()
@@ -14,4 +14,4 @@ const tags = Object.keys(icons)
 
 const tagsContent = JSON.stringify(tags, null, 2);
 
-writeFile(tagsContent, 'tags.json', path.resolve(process.cwd()));
+await writeFile(tagsContent, 'tags.json', path.resolve(process.cwd()));

--- a/tools/build-helpers/src/appendFile.mjs
+++ b/tools/build-helpers/src/appendFile.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 /**
@@ -10,4 +10,4 @@ import path from 'path';
  * @param {string} outputDirectory
  */
 export const appendFile = (content, fileName, outputDirectory) =>
-  fs.appendFileSync(path.join(outputDirectory, fileName), content, 'utf-8');
+  fs.appendFile(path.join(outputDirectory, fileName), content, 'utf-8');

--- a/tools/build-helpers/src/readAllMetadata.mjs
+++ b/tools/build-helpers/src/readAllMetadata.mjs
@@ -9,8 +9,8 @@ import { readMetadata } from './readMetadata.mjs';
  * @param {string} directory
  * @returns {object} A map of icon or category metadata
  */
-export const readAllMetadata = async (directory) =>{
-  const directoryContent = await fs.readdir(directory)
+export const readAllMetadata = async (directory) => {
+  const directoryContent = await fs.readdir(directory);
 
   return directoryContent
     .filter((file) => path.extname(file) === '.json')
@@ -18,4 +18,4 @@ export const readAllMetadata = async (directory) =>{
       acc[path.basename(fileName, '.json')] = readMetadata(fileName, directory);
       return acc;
     }, {});
-}
+};

--- a/tools/build-helpers/src/readAllMetadata.mjs
+++ b/tools/build-helpers/src/readAllMetadata.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 import { readMetadata } from './readMetadata.mjs';
 
@@ -9,11 +9,13 @@ import { readMetadata } from './readMetadata.mjs';
  * @param {string} directory
  * @returns {object} A map of icon or category metadata
  */
-export const readAllMetadata = (directory) =>
-  fs
-    .readdirSync(directory)
+export const readAllMetadata = async (directory) =>{
+  const directoryContent = await fs.readdir(directory)
+
+  return directoryContent
     .filter((file) => path.extname(file) === '.json')
     .reduce((acc, fileName) => {
       acc[path.basename(fileName, '.json')] = readMetadata(fileName, directory);
       return acc;
     }, {});
+}

--- a/tools/build-helpers/src/readFile.mjs
+++ b/tools/build-helpers/src/readFile.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 /**
@@ -8,4 +8,4 @@ import path from 'path';
  * @param {string} path
  * @returns {string} The contents of a file
  */
-export const readFile = (path) => fs.readFileSync(path.resolve(__dirname, '../', path), 'utf-8');
+export const readFile = (path) => fs.readFile(path.resolve(__dirname, '../', path), 'utf-8');

--- a/tools/build-helpers/src/readMetadata.mjs
+++ b/tools/build-helpers/src/readMetadata.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 /**

--- a/tools/build-helpers/src/readMetadata.mjs
+++ b/tools/build-helpers/src/readMetadata.mjs
@@ -9,5 +9,8 @@ import path from 'path';
  * @param {string} directory
  * @returns {object} The metadata for the icon or category
  */
-export const readMetadata = (fileName, directory) =>
-  JSON.parse(fs.readFileSync(path.join(directory, fileName), 'utf-8'));
+export const readMetadata = async (fileName, directory) =>{
+  const metadataFileContent = await fs.readFile(path.join(directory, fileName), 'utf-8')
+
+  return JSON.parse(metadataFileContent);
+}

--- a/tools/build-helpers/src/readMetadata.mjs
+++ b/tools/build-helpers/src/readMetadata.mjs
@@ -9,8 +9,8 @@ import path from 'path';
  * @param {string} directory
  * @returns {object} The metadata for the icon or category
  */
-export const readMetadata = async (fileName, directory) =>{
-  const metadataFileContent = await fs.readFile(path.join(directory, fileName), 'utf-8')
+export const readMetadata = async (fileName, directory) => {
+  const metadataFileContent = await fs.readFile(path.join(directory, fileName), 'utf-8');
 
   return JSON.parse(metadataFileContent);
-}
+};

--- a/tools/build-helpers/src/readSvg.mjs
+++ b/tools/build-helpers/src/readSvg.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 /**
@@ -9,4 +9,4 @@ import path from 'path';
  * @param {string} directory
  */
 export const readSvg = (fileName, directory) =>
-  fs.readFileSync(path.join(directory, fileName), 'utf-8');
+  fs.readFile(path.join(directory, fileName), 'utf-8');

--- a/tools/build-helpers/src/readSvgDirectory.mjs
+++ b/tools/build-helpers/src/readSvgDirectory.mjs
@@ -13,4 +13,4 @@ export const readSvgDirectory = async (directory, fileExtension = '.svg') => {
   const directoryContents = await fs.readdir(directory);
 
   return directoryContents.filter((file) => path.extname(file) === fileExtension);
-}
+};

--- a/tools/build-helpers/src/readSvgDirectory.mjs
+++ b/tools/build-helpers/src/readSvgDirectory.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 /**
@@ -9,5 +9,8 @@ import path from 'path';
  * @param {string} fileExtension
  * @returns {array} An array of file paths containing svgs
  */
-export const readSvgDirectory = (directory, fileExtension = '.svg') =>
-  fs.readdirSync(directory).filter((file) => path.extname(file) === fileExtension);
+export const readSvgDirectory = async (directory, fileExtension = '.svg') => {
+  const directoryContents = await fs.readdir(directory);
+
+  return directoryContents.filter((file) => path.extname(file) === fileExtension);
+}

--- a/tools/build-helpers/src/resetFile.mjs
+++ b/tools/build-helpers/src/resetFile.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 /**
@@ -9,4 +9,4 @@ import path from 'path';
  * @param {string} outputDirectory
  */
 export const resetFile = (fileName, outputDirectory) =>
-  fs.writeFileSync(path.join(outputDirectory, fileName), '', 'utf-8');
+  fs.writeFile(path.join(outputDirectory, fileName), '', 'utf-8');

--- a/tools/build-helpers/src/writeFile.mjs
+++ b/tools/build-helpers/src/writeFile.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 /**
@@ -10,4 +10,4 @@ import path from 'path';
  * @param {string} outputDirectory
  */
 export const writeFile = (content, fileName, outputDirectory) =>
-  fs.writeFileSync(path.join(outputDirectory, fileName), content, 'utf-8');
+  fs.writeFile(path.join(outputDirectory, fileName), content, 'utf-8');

--- a/tools/build-helpers/src/writeFileIfNotExists.mjs
+++ b/tools/build-helpers/src/writeFileIfNotExists.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 import { writeFile } from './writeFile.mjs';
 

--- a/tools/build-helpers/src/writeSvgFile.mjs
+++ b/tools/build-helpers/src/writeSvgFile.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
 /**
@@ -10,4 +10,4 @@ import path from 'path';
  * @param {string} content
  */
 export const writeSvgFile = (fileName, outputDirectory, content) =>
-  fs.writeFileSync(path.join(outputDirectory, fileName), content, 'utf-8');
+  fs.writeFile(path.join(outputDirectory, fileName), content, 'utf-8');

--- a/tools/build-icons/building/aliases/generateAliasesFiles.mjs
+++ b/tools/build-icons/building/aliases/generateAliasesFiles.mjs
@@ -31,11 +31,11 @@ export default async function generateAliasesFiles({
   }
 
   // Reset files
-  resetFile(aliasFileName, destinationDirectory);
+  await resetFile(aliasFileName, destinationDirectory);
 
   if (!aliasNamesOnly) {
-    resetFile(aliasPrefixesFileName, destinationDirectory);
-    resetFile(aliasSuffixFileName, destinationDirectory);
+    await resetFile(aliasPrefixesFileName, destinationDirectory);
+    await resetFile(aliasSuffixFileName, destinationDirectory);
   }
 
   // Generate Import for Icon VNodes
@@ -149,20 +149,20 @@ export default async function generateAliasesFiles({
         );
       }
 
-      appendFile(aliasFileContent, aliasFileName, destinationDirectory);
+      await appendFile(aliasFileContent, aliasFileName, destinationDirectory);
 
       if (!aliasNamesOnly) {
-        appendFile(aliasPrefixesFileContent, aliasPrefixesFileName, destinationDirectory);
-        appendFile(aliasSuffixFileContent, aliasSuffixFileName, destinationDirectory);
+        await appendFile(aliasPrefixesFileContent, aliasPrefixesFileName, destinationDirectory);
+        await appendFile(aliasSuffixFileContent, aliasSuffixFileName, destinationDirectory);
       }
     }),
   );
 
-  appendFile('\n', aliasFileName, destinationDirectory);
+  await appendFile('\n', aliasFileName, destinationDirectory);
 
   if (!aliasNamesOnly) {
-    appendFile('\n', aliasPrefixesFileName, destinationDirectory);
-    appendFile('\n', aliasSuffixFileName, destinationDirectory);
+    await appendFile('\n', aliasPrefixesFileName, destinationDirectory);
+    await appendFile('\n', aliasSuffixFileName, destinationDirectory);
   }
 
   if (showLog) {

--- a/tools/build-icons/building/generateDynamicImports.mjs
+++ b/tools/build-icons/building/generateDynamicImports.mjs
@@ -1,7 +1,7 @@
 import path from 'path';
 import { resetFile, appendFile } from '@lucide/helpers';
 
-export default function generateDynamicImports({
+export default async function generateDynamicImports({
   iconNodes,
   outputDirectory,
   fileExtension,
@@ -12,7 +12,7 @@ export default function generateDynamicImports({
   const icons = Object.keys(iconNodes);
 
   // Reset file
-  resetFile(fileName, outputDirectory);
+  await resetFile(fileName, outputDirectory);
 
   let importString = `const dynamicIconImports = {\n`;
 
@@ -40,7 +40,7 @@ export default function generateDynamicImports({
 
   importString += '};\nexport default dynamicIconImports;\n';
 
-  appendFile(importString, fileName, outputDirectory);
+  await appendFile(importString, fileName, outputDirectory);
 
   if (showLog) {
     console.log(`Successfully generated ${fileName} file`);

--- a/tools/build-icons/building/generateExportsFile.mjs
+++ b/tools/build-icons/building/generateExportsFile.mjs
@@ -35,4 +35,4 @@ export default async function generateExportFile(
   await appendFile('\n', fileName, outputDirectory);
 
   console.log(`Successfully generated ${fileName} file`);
-};
+}

--- a/tools/build-icons/building/generateExportsFile.mjs
+++ b/tools/build-icons/building/generateExportsFile.mjs
@@ -3,22 +3,22 @@ import path from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { toPascalCase, toCamelCase, resetFile, appendFile } from '@lucide/helpers';
 
-export default (
+export default async function generateExportFile(
   inputEntry,
   outputDirectory,
   iconNodes,
   exportModuleNameCasing,
   iconFileExtension = '',
-) => {
+) {
   const fileName = path.basename(inputEntry);
 
   // Reset file
-  resetFile(fileName, outputDirectory);
+  await resetFile(fileName, outputDirectory);
 
   const icons = Object.keys(iconNodes);
 
   // Generate Import for Icon VNodes
-  icons.forEach((iconName) => {
+  const iconImportNodesPromises = icons.map(async (iconName) => {
     let componentName;
 
     if (exportModuleNameCasing === 'camel') {
@@ -27,10 +27,12 @@ export default (
       componentName = toPascalCase(iconName);
     }
     const importString = `export { default as ${componentName} } from './${iconName}${iconFileExtension}';\n`;
-    appendFile(importString, fileName, outputDirectory);
+    return appendFile(importString, fileName, outputDirectory);
   });
 
-  appendFile('\n', fileName, outputDirectory);
+  await Promise.all(iconImportNodesPromises);
+
+  await appendFile('\n', fileName, outputDirectory);
 
   console.log(`Successfully generated ${fileName} file`);
 };

--- a/tools/build-icons/building/generateIconFiles.mjs
+++ b/tools/build-icons/building/generateIconFiles.mjs
@@ -80,6 +80,6 @@ function generateIconFiles({
     .catch((error) => {
       throw new Error(`Something went wrong generating icon files,\n ${error}`);
     });
-};
+}
 
-export default generateIconFiles
+export default generateIconFiles;

--- a/tools/build-icons/building/generateIconFiles.mjs
+++ b/tools/build-icons/building/generateIconFiles.mjs
@@ -4,7 +4,7 @@ import prettier from 'prettier';
 import { readSvg, toPascalCase } from '@lucide/helpers';
 import deprecationReasonTemplate from '../utils/deprecationReasonTemplate.mjs';
 
-export default ({
+function generateIconFiles({
   iconNodes,
   outputDirectory,
   template,
@@ -15,7 +15,7 @@ export default ({
   pretty = true,
   iconsDir,
   iconMetaData,
-}) => {
+}) {
   const icons = Object.keys(iconNodes);
   const iconsDistDirectory = path.join(outputDirectory, `icons`);
 
@@ -40,7 +40,7 @@ export default ({
         })
       : '';
 
-    const elementTemplate = template({
+    const elementTemplate = await template({
       componentName,
       iconName,
       children,
@@ -71,7 +71,7 @@ export default ({
     }
   });
 
-  Promise.all(writeIconFiles)
+  return Promise.all(writeIconFiles)
     .then(() => {
       if (showLog) {
         console.log('Successfully built', icons.length, 'icons.');
@@ -81,3 +81,5 @@ export default ({
       throw new Error(`Something went wrong generating icon files,\n ${error}`);
     });
 };
+
+export default generateIconFiles

--- a/tools/build-icons/cli.mjs
+++ b/tools/build-icons/cli.mjs
@@ -47,16 +47,16 @@ async function buildIcons() {
     throw new Error('No `templateSrc` argument given.');
   }
 
-  const svgFiles = readSvgDirectory(ICONS_DIR);
+  const svgFiles = await readSvgDirectory(ICONS_DIR);
 
-  const icons = renderIconsObject(svgFiles, ICONS_DIR, renderUniqueKey);
+  const icons = await renderIconsObject(svgFiles, ICONS_DIR, renderUniqueKey);
 
   const { default: iconFileTemplate } = await import(path.resolve(process.cwd(), templateSrc));
 
   const iconMetaData = await getIconMetaData(ICONS_DIR);
 
   // Generates iconsNodes files for each icon
-  generateIconFiles({
+  await generateIconFiles({
     iconNodes: icons,
     outputDirectory: OUTPUT_DIR,
     template: iconFileTemplate,
@@ -86,7 +86,7 @@ async function buildIcons() {
   }
 
   if (withDynamicImports) {
-    generateDynamicImports({
+    await generateDynamicImports({
       iconNodes: icons,
       outputDirectory: OUTPUT_DIR,
       fileExtension: aliasesFileExtension,
@@ -96,7 +96,7 @@ async function buildIcons() {
   }
 
   // Generates entry files for the compiler filled with icons exports
-  generateExportsFile(
+  await generateExportsFile(
     path.join(OUTPUT_DIR, 'icons', exportFileName),
     path.join(OUTPUT_DIR, 'icons'),
     icons,

--- a/tools/build-icons/package.json
+++ b/tools/build-icons/package.json
@@ -20,11 +20,13 @@
     "@lucide/helpers": "workspace:*"
   },
   "dependencies": {
-    "@lucide/helpers": "^1.0.0",
     "minimist": "^1.2.7",
     "node-fetch": "^3.2.10",
     "prettier": "2.7.1",
     "svgo": "^3.0.0",
     "svgson": "^5.2.1"
+  },
+  "peerDependencies": {
+    "@lucide/helpers": "*"
   }
 }

--- a/tools/build-icons/render/renderIconsObject.mjs
+++ b/tools/build-icons/render/renderIconsObject.mjs
@@ -11,7 +11,7 @@ import { generateHashedKey, readSvg, hasDuplicatedChildren } from '@lucide/helpe
 export default async function generateIconObject(
   svgFiles,
   iconsDirectory,
-  renderUniqueKey = false
+  renderUniqueKey = false,
 ) {
   const svgsContentPromises = svgFiles.map(async (svgFile) => {
     const name = basename(svgFile, '.svg');
@@ -35,7 +35,7 @@ export default async function generateIconObject(
     }
 
     return { name, contents };
-  })
+  });
 
   const svgsContents = await Promise.all(svgsContentPromises);
 

--- a/tools/build-icons/render/renderIconsObject.mjs
+++ b/tools/build-icons/render/renderIconsObject.mjs
@@ -8,32 +8,39 @@ import { generateHashedKey, readSvg, hasDuplicatedChildren } from '@lucide/helpe
  * @param {Function} getSvg - A function that returns the contents of an SVG file given a filename.
  * @returns {Object}
  */
-export default (svgFiles, iconsDirectory, renderUniqueKey = false) =>
-  svgFiles
-    .map((svgFile) => {
-      const name = basename(svgFile, '.svg');
-      const svg = readSvg(svgFile, iconsDirectory);
-      const contents = parseSync(svg);
+export default async function generateIconObject(
+  svgFiles,
+  iconsDirectory,
+  renderUniqueKey = false
+) {
+  const svgsContentPromises = svgFiles.map(async (svgFile) => {
+    const name = basename(svgFile, '.svg');
+    const svg = await readSvg(svgFile, iconsDirectory);
+    const contents = parseSync(svg);
 
-      if (!(contents.children && contents.children.length)) {
-        throw new Error(`${name}.svg has no children!`);
-      }
+    if (!(contents.children && contents.children.length)) {
+      throw new Error(`${name}.svg has no children!`);
+    }
 
-      if (hasDuplicatedChildren(contents.children)) {
-        throw new Error(`Duplicated children in ${name}.svg`);
-      }
+    if (hasDuplicatedChildren(contents.children)) {
+      throw new Error(`Duplicated children in ${name}.svg`);
+    }
 
-      if (renderUniqueKey) {
-        contents.children = contents.children.map((child) => {
-          child.attributes.key = generateHashedKey(child);
+    if (renderUniqueKey) {
+      contents.children = contents.children.map((child) => {
+        child.attributes.key = generateHashedKey(child);
 
-          return child;
-        });
-      }
+        return child;
+      });
+    }
 
-      return { name, contents };
-    })
-    .reduce((icons, icon) => {
-      icons[icon.name] = icon.contents;
-      return icons;
-    }, {});
+    return { name, contents };
+  })
+
+  const svgsContents = await Promise.all(svgsContentPromises);
+
+  return svgsContents.reduce((icons, icon) => {
+    icons[icon.name] = icon.contents;
+    return icons;
+  }, {});
+}

--- a/tools/build-icons/utils/getAliases.mjs
+++ b/tools/build-icons/utils/getAliases.mjs
@@ -2,7 +2,7 @@ import path from 'path';
 import { readSvgDirectory } from '@lucide/helpers';
 
 async function getAliases(iconDirectory) {
-  const iconJsons = readSvgDirectory(iconDirectory, '.json');
+  const iconJsons = await readSvgDirectory(iconDirectory, '.json');
   const aliasesEntries = await Promise.all(
     iconJsons.map(async (jsonFile) => {
       const file = await import(path.join(iconDirectory, jsonFile), { with: { type: 'json' } });

--- a/tools/build-icons/utils/getIconMetaData.mjs
+++ b/tools/build-icons/utils/getIconMetaData.mjs
@@ -2,7 +2,7 @@ import path from 'path';
 import { readSvgDirectory } from '@lucide/helpers';
 
 async function getIconMetaData(iconDirectory) {
-  const iconJsons = readSvgDirectory(iconDirectory, '.json');
+  const iconJsons = await readSvgDirectory(iconDirectory, '.json');
   const aliasesEntries = await Promise.all(
     iconJsons.map(async (jsonFile) => {
       /** eslint-disable */


### PR DESCRIPTION
I've replaced all sync `fs` functions used in loops. And made them async, which increases build speeds significantly.

Before (4 min)
<img width="424" alt="Screenshot 2025-02-07 at 14 29 59" src="https://github.com/user-attachments/assets/c9f82afc-4fa1-448a-823c-091d6508ebe2" />

After (1 min)
<img width="433" alt="Screenshot 2025-02-07 at 14 32 02" src="https://github.com/user-attachments/assets/e27f1c2e-2b23-4362-a969-ddef9a71bf80" />
