### PR TITLE
feat(script): add generate icon names script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ packages/**/dynamic.mjs
 packages/**/LICENSE
 categories.json
 tags.json
+icon-names.json
 .vercel
 
 # docs

--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ netlify.toml
 rollup.config.js
 rollup.plugins.js
 tags.json
+icon-names.json

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "icons2tags": "node scripts/migrateIconsToTags.mjs",
     "icons2categories": "node scripts/migrateIconsToCategories.mjs",
     "categories2icons": "node scripts/migrateCategoriesToIcons.mjs",
+    "generate:icon-names": "node ./scripts/generateIconNames.mjs",
     "generate:changelog": "node ./scripts/generateChangelog.mjs",
     "generate:contributors": "node ./scripts/updateContributors.mjs icons/*.svg",
     "generate:nextJSAliases": "node ./scripts/generateNextJSAliases.mjs",

--- a/scripts/generateIconNames.mjs
+++ b/scripts/generateIconNames.mjs
@@ -1,0 +1,17 @@
+import path from 'path';
+import { writeFile, getCurrentDirPath, readAllMetadata } from '../tools/build-helpers/helpers.mjs';
+
+const currentDir = getCurrentDirPath(import.meta.url);
+const ICONS_DIR = path.resolve(currentDir, '../icons');
+const icons = await readAllMetadata(ICONS_DIR);
+
+const iconNames = Object.keys(icons).sort();
+
+const output = {
+  created_at: new Date().toISOString(),
+  icon_names: iconNames,
+};
+
+const outputContent = JSON.stringify(output, null, 2);
+
+await writeFile(outputContent, 'icon-names.json', path.resolve(process.cwd()));


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
Related to https://github.com/lucide-icons/lucide/discussions/1778

I just wanted the list of icon names to use to show them in an icon picker for my app users but the `tags.json` and `icon-nodes.json` included tags or svg paths that I didn't need. And deleting the extra parts manually would take forever. So I figured we can add a `generate:icon-names` script which would generate `icon-names.json` that would look like this:

```json
{
  "created_at": "2025-02-19T13:11:15.475Z",
  "icon_names": [
    "a-arrow-down",
    "a-arrow-up",
    "a-large-small",
    "accessibility",
    "activity",
    "air-vent",
    "airplay",
    "alarm-clock",
     // the rest of the icons
```
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
