### PR TITLE
Fix(icons): Fix typo in some horizontal icon variation json file

### DIFF
--- a/icons/between-horizontal-end.json
+++ b/icons/between-horizontal-end.json
@@ -33,7 +33,7 @@
   ],
   "aliases": [
     {
-      "name": "between-horizonal-end",
+      "name": "between-horizontal-end",
       "deprecated": true,
       "deprecationReason": "alias.typo",
       "toBeRemovedInVersion": "v1.0"

--- a/icons/between-horizontal-start.json
+++ b/icons/between-horizontal-start.json
@@ -33,7 +33,7 @@
   ],
   "aliases": [
     {
-      "name": "between-horizonal-start",
+      "name": "between-horizontal-start",
       "deprecated": true,
       "deprecationReason": "alias.typo",
       "toBeRemovedInVersion": "v1.0"

--- a/icons/send-horizontal.json
+++ b/icons/send-horizontal.json
@@ -19,7 +19,7 @@
   ],
   "aliases": [
     {
-      "name": "send-horizonal",
+      "name": "send-horizontal",
       "deprecated": true,
       "deprecationReason": "alias.typo",
       "toBeRemovedInVersion": "v1.0"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: json file update

### Description
This PR fixes minor typos in the following json files:
- between-horizontal-end.json
- between-horizontal-start.json
- send-horizontal.json

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
