### PR TITLE
fix(icons): changed `circle-slash-2` icon

### DIFF
--- a/icons/circle-slash-2.json
+++ b/icons/circle-slash-2.json
@@ -6,7 +6,7 @@
   "tags": [
     "diameter",
     "zero",
-    "Ø",
+    "ø",
     "nothing",
     "null",
     "void",
@@ -16,7 +16,12 @@
     "division",
     "half",
     "split",
-    "/"
+    "/",
+    "average",
+    "avg",
+    "mean",
+    "median",
+    "normal"
   ],
   "categories": [
     "shapes",

--- a/icons/circle-slash-2.svg
+++ b/icons/circle-slash-2.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="12" cy="12" r="10" />
   <path d="M22 2 2 22" />
+  <circle cx="12" cy="12" r="10" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Add more tags.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.