### PR TITLE
ci(pr-comment): Fix icon preview comment on PRs

### DIFF
--- a/.github/workflows/comment-icon-preview.yml
+++ b/.github/workflows/comment-icon-preview.yml
@@ -2,7 +2,7 @@ name: Icon preview comment
 
 on:
   workflow_run:
-    workflows: ["Pull request icon preview"]
+    workflows: ['Pull request icon preview']
     types:
       - completed
 
@@ -44,7 +44,7 @@ jobs:
         uses: peter-evans/find-comment@v2
         id: pr-comment
         with:
-          issue-number:  ${{ steps.pr-number.outputs.stdout }}
+          issue-number: ${{ steps.pr-number.outputs.stdout }}
           comment-author: 'github-actions[bot]'
           body-includes: Added or changed icons
 

--- a/.github/workflows/comment-icon-preview.yml
+++ b/.github/workflows/comment-icon-preview.yml
@@ -1,0 +1,57 @@
+name: Icon preview comment
+
+on:
+  workflow_run:
+    workflows: ["Pull request icon preview"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+
+      - run: unzip pr.zip
+
+      - name: 'Get PR number'
+        run: cat pr/NR
+        id: pr-number
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: pr-comment
+        with:
+          issue-number:  ${{ steps.pr-number.outputs.stdout }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Added or changed icons
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.pr-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr-number.outputs.stdout }}
+          body-path: ./pr/comment-markup.md
+          edit-mode: replace

--- a/.github/workflows/pull-request-icon-preview.yml
+++ b/.github/workflows/pull-request-icon-preview.yml
@@ -41,5 +41,3 @@ jobs:
         with:
           name: pr
           path: pr/
-
-

--- a/.github/workflows/pull-request-icon-preview.yml
+++ b/.github/workflows/pull-request-icon-preview.yml
@@ -1,4 +1,4 @@
-name: Pull request icon previews
+name: Pull request icon preview
 
 on:
   pull_request:
@@ -22,28 +22,24 @@ jobs:
         with:
           files: icons/*.svg
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        id: pr-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Added or changed icons
-
       - uses: actions/setup-node@v4
       - name: Install svgson for code preview (safer and faster than installing all deps)
         run: npm install svgson
 
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
       - name: Generate comment markup
-        run: node ./scripts/generateChangedIconsCommentMarkup.mjs >> comment-markup.md
+        run: node ./scripts/generateChangedIconsCommentMarkup.mjs >> ./pr/comment-markup.md
         id: comment-markup
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v3
+      - uses: actions/upload-artifact@v4
         with:
-          comment-id: ${{ steps.pr-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: ./comment-markup.md
-          edit-mode: replace
+          name: pr
+          path: pr/
+
+


### PR DESCRIPTION
After closing #2764
Icon PR comment is not working anymore, since it needs write access. The `GITHUB_TOKEN` with `on:  pull_request:` has only read access. With `workflow_run:` we also get write access to PRs and make sure it is secure.

This solution is based on a blog article form GH. https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/