### PR TITLE
fix(shared): consistent kebab case conversion

### DIFF
--- a/packages/lucide-preact/tests/__snapshots__/lucide-preact.spec.tsx.snap
+++ b/packages/lucide-preact/tests/__snapshots__/lucide-preact.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`Using lucide icon components > should adjust the size, stroke color and
      stroke-width="4"
      stroke-linecap="round"
      stroke-linejoin="round"
-     class="lucide lucide-grid3x3"
+     class="lucide lucide-grid-3x3"
 >
   <rect width="18"
         height="18"
@@ -40,7 +40,7 @@ exports[`Using lucide icon components > should not scale the strokeWidth when ab
      stroke-width="1"
      stroke-linecap="round"
      stroke-linejoin="round"
-     class="lucide lucide-grid3x3"
+     class="lucide lucide-grid-3x3"
 >
   <rect width="18"
         height="18"
@@ -70,7 +70,7 @@ exports[`Using lucide icon components > should render an component 1`] = `
      stroke-width="2"
      stroke-linecap="round"
      stroke-linejoin="round"
-     class="lucide lucide-grid3x3"
+     class="lucide lucide-grid-3x3"
 >
   <rect width="18"
         height="18"

--- a/packages/lucide-react/tests/__snapshots__/lucide-react.spec.tsx.snap
+++ b/packages/lucide-react/tests/__snapshots__/lucide-react.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`Using lucide icon components > should adjust the size, stroke color and
      stroke-width="4"
      stroke-linecap="round"
      stroke-linejoin="round"
-     class="lucide lucide-grid3x3"
+     class="lucide lucide-grid-3x3"
 >
   <rect width="18"
         height="18"
@@ -40,7 +40,7 @@ exports[`Using lucide icon components > should not scale the strokeWidth when ab
      stroke-width="1"
      stroke-linecap="round"
      stroke-linejoin="round"
-     class="lucide lucide-grid3x3"
+     class="lucide lucide-grid-3x3"
 >
   <rect width="18"
         height="18"
@@ -70,7 +70,7 @@ exports[`Using lucide icon components > should render an component 1`] = `
      stroke-width="2"
      stroke-linecap="round"
      stroke-linejoin="round"
-     class="lucide lucide-grid3x3"
+     class="lucide lucide-grid-3x3"
 >
   <rect width="18"
         height="18"

--- a/packages/lucide-solid/tests/__snapshots__/lucide-solid.spec.tsx.snap
+++ b/packages/lucide-solid/tests/__snapshots__/lucide-solid.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`Using lucide icon components > should adjust the size, stroke color and
      height="48"
      stroke="red"
      stroke-width="4"
-     class="lucide lucide-icon lucide-grid3x3"
+     class="lucide lucide-icon lucide-grid-3x3"
      data-testid="grid-icon"
 >
   <rect width="18"
@@ -50,7 +50,7 @@ exports[`Using lucide icon components > should not scale the strokeWidth when ab
      height="48"
      stroke="red"
      stroke-width="1"
-     class="lucide lucide-icon lucide-grid3x3"
+     class="lucide lucide-icon lucide-grid-3x3"
      data-testid="grid-icon"
 >
   <rect width="18"
@@ -90,7 +90,7 @@ exports[`Using lucide icon components > should render a component 1`] = `
      height="24"
      stroke="currentColor"
      stroke-width="2"
-     class="lucide lucide-icon lucide-grid3x3"
+     class="lucide lucide-icon lucide-grid-3x3"
 >
   <rect width="18"
         height="18"

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -7,7 +7,11 @@ import { CamelToPascal } from './utility-types';
  * @returns {string} A kebabized string
  */
 export const toKebabCase = (string: string) =>
-  string.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+  string
+    .replace(/([A-Z])([A-Z])/g, '$1-$2')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/([a-zA-Z])(\d)/g, '$1-$2')
+    .toLowerCase();
 
 /**
  * Converts string to camel case

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -9,8 +9,8 @@ import { CamelToPascal } from './utility-types';
 export const toKebabCase = (string: string) =>
   string
     .replace(/([A-Z])([A-Z])/g, '$1-$2')
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/([a-zA-Z])(\d)/g, '$1-$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/(?<!\d)([a-zA-Z])(\d)/g, '$1-$2')
     .toLowerCase();
 
 /**

--- a/packages/shared/tests/utils.spec.tsx
+++ b/packages/shared/tests/utils.spec.tsx
@@ -53,4 +53,9 @@ describe('toKebabCase', () => {
     const kebabCase = toKebabCase('Scale3d');
     expect(kebabCase).toBe('scale-3d');
   });
+
+  it('handles numbers already in words', async () => {
+    const kebabCase = toKebabCase('Grid3x3X');
+    expect(kebabCase).toBe('grid-3x3-x');
+  });
 });

--- a/packages/shared/tests/utils.spec.tsx
+++ b/packages/shared/tests/utils.spec.tsx
@@ -58,7 +58,7 @@ describe('toKebabCase', () => {
     expect(kebabCase).toBe('scale-3d');
   });
   it('handles numbers already in words', async () => {
-    const kebabCase = toKebabCase('Grid3x3X');
-    expect(kebabCase).toBe('grid-3x3-x');
+    const kebabCase = toKebabCase('Grid3x3');
+    expect(kebabCase).toBe('grid-3x3');
   });
 });

--- a/packages/shared/tests/utils.spec.tsx
+++ b/packages/shared/tests/utils.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeClasses } from '../src/utils';
+import { mergeClasses, toKebabCase } from '../src/utils';
 
 describe('mergeClasses', () => {
   it('merges classes', async () => {
@@ -25,5 +25,20 @@ describe('mergeClasses', () => {
   it('trims the sub strings', async () => {
     const classes = mergeClasses('lucide', ' ', 'lucide-circle');
     expect(classes).toBe('lucide lucide-circle');
+  });
+});
+
+describe('toKebabCase', () => {
+  it('converts to kebab case', async () => {
+    const kebabCase = toKebabCase('LoaderCircle');
+    expect(kebabCase).toBe('loader-circle');
+  });
+  it('handles consecutive uppercase letters', async () => {
+    const kebabCase = toKebabCase('AArrowDown');
+    expect(kebabCase).toBe('a-arrow-down');
+  });
+  it('handles numbers', async () => {
+    const kebabCase = toKebabCase('Loader2');
+    expect(kebabCase).toBe('loader-2');
   });
 });

--- a/packages/shared/tests/utils.spec.tsx
+++ b/packages/shared/tests/utils.spec.tsx
@@ -37,6 +37,10 @@ describe('toKebabCase', () => {
     const kebabCase = toKebabCase('Dot');
     expect(kebabCase).toBe('dot');
   });
+  it('handles many words', async () => {
+    const kebabCase = toKebabCase('PictureInPicture');
+    expect(kebabCase).toBe('picture-in-picture');
+  });
   it('handles consecutive uppercase letters', async () => {
     const kebabCase = toKebabCase('AArrowDown');
     expect(kebabCase).toBe('a-arrow-down');
@@ -53,7 +57,6 @@ describe('toKebabCase', () => {
     const kebabCase = toKebabCase('Scale3d');
     expect(kebabCase).toBe('scale-3d');
   });
-
   it('handles numbers already in words', async () => {
     const kebabCase = toKebabCase('Grid3x3X');
     expect(kebabCase).toBe('grid-3x3-x');

--- a/packages/shared/tests/utils.spec.tsx
+++ b/packages/shared/tests/utils.spec.tsx
@@ -33,6 +33,10 @@ describe('toKebabCase', () => {
     const kebabCase = toKebabCase('LoaderCircle');
     expect(kebabCase).toBe('loader-circle');
   });
+  it('handles single word', async () => {
+    const kebabCase = toKebabCase('Dot');
+    expect(kebabCase).toBe('dot');
+  });
   it('handles consecutive uppercase letters', async () => {
     const kebabCase = toKebabCase('AArrowDown');
     expect(kebabCase).toBe('a-arrow-down');
@@ -40,5 +44,13 @@ describe('toKebabCase', () => {
   it('handles numbers', async () => {
     const kebabCase = toKebabCase('Loader2');
     expect(kebabCase).toBe('loader-2');
+  });
+  it('handles consecutive numbers', async () => {
+    const kebabCase = toKebabCase('Clock10');
+    expect(kebabCase).toBe('clock-10');
+  });
+  it('handles numbers and letters', async () => {
+    const kebabCase = toKebabCase('Scale3d');
+    expect(kebabCase).toBe('scale-3d');
   });
 });

--- a/tools/build-helpers/src/toKebabCase.mjs
+++ b/tools/build-helpers/src/toKebabCase.mjs
@@ -5,4 +5,9 @@
  * @param {string} string
  * @returns {string} A kebabized string
  */
-export const toKebabCase = (string) => string.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+export const toKebabCase = (string) =>
+  string
+    .replace(/([A-Z])([A-Z])/g, '$1-$2')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/([a-zA-Z])(\d)/g, '$1-$2')
+    .toLowerCase();

--- a/tools/build-helpers/src/toKebabCase.mjs
+++ b/tools/build-helpers/src/toKebabCase.mjs
@@ -8,6 +8,6 @@
 export const toKebabCase = (string) =>
   string
     .replace(/([A-Z])([A-Z])/g, '$1-$2')
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/([a-zA-Z])(\d)/g, '$1-$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/(?<!\d)([a-zA-Z])(\d)/g, '$1-$2')
     .toLowerCase();


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
Closes #2858 

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
When rendering an icon with `lucide-react`, the kebab-cased class name is inconsistent with the corresponding entry in `iconNames`.

Example with `AArrowDown` icon:
- Class attribute: `class="lucide lucide-aarrow-down"`
- In `iconNames`: `a-arrow-down`

Example with `Loader2` icon:
- Class attribute: `class="lucide lucide-loader2"`
- In `iconNames`: `loader-2`

This PR fixes the ⁠toKebabCase function to properly handle these cases. I've also added relevant test cases.

Note: there are some inherent inconsistencies with icon naming like `ArrowUp10` → `arrow-up-1-0` and `Clock10` → `clock-10`, but there are already aliases for those (`arrow-up-10` → `arrow-up-1-0`).

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
