### PR TITLE
fix(metadata): name change reflected in contributions

### DIFF
--- a/icons/dam.json
+++ b/icons/dam.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "AndreasSas"
+    "AnnaSasDev"
   ],
   "tags": [
     "electricity",

--- a/icons/logs.json
+++ b/icons/logs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "AndreasSas"
+    "AnnaSasDev"
   ],
   "tags": [
     "options",

--- a/icons/save-off.json
+++ b/icons/save-off.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "AndreasSas"
+    "AnnaSasDev"
   ],
   "tags": [
     "floppy disk",

--- a/icons/signature.json
+++ b/icons/signature.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "AndreasSas",
+    "AnnaSasDev",
     "jguddas"
   ],
   "tags": [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: Github username change

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Last year I made some contributions to Lucide, but have since then changed by name and would like to see those changes reflected so the links on the lucide website go to my actual Github profile.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
