### PR TITLE
fix(icons): changed `shopping-cart` icon

### DIFF
--- a/icons/shopping-cart.json
+++ b/icons/shopping-cart.json
@@ -4,7 +4,8 @@
     "colebemis",
     "csandman",
     "ericfennis",
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jamiemlaw"
   ],
   "tags": [
     "trolley",

--- a/icons/shopping-cart.svg
+++ b/icons/shopping-cart.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="8" cy="21" r="1" />
+  <path d="M2 2h2l2.66 12.42A2 2 0 0 0 8.62 16h9.78a2 2 0 0 0 1.95-1.57L22 7H5.07" />
   <circle cx="19" cy="21" r="1" />
-  <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12" />
+  <circle cx="8" cy="21" r="1" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Pixel-aligned some paths on the `shopping-cart` icon

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.