### PR TITLE
Combined line into path to fix transparency bug

### DIFF
--- a/icons/mic.svg
+++ b/icons/mic.svg
@@ -10,6 +10,5 @@
   stroke-linejoin="round"
 >
   <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
-  <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-  <line x1="12" x2="12" y1="19" y2="22" />
+  <path d="M19 10v2a7 7 0 0 1-14 0v-2 M12 19 L12 22" />
 </svg>


### PR DESCRIPTION
Closes #2853 

## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
This change fixes the overlapping issue with the Microphone SVG. I fixed the issue by combining the line element with one of the path elements.

## Before Submitting <!-- For every PR! -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
