### PR TITLE
fix(packages/lucide-angular): restore exporting prefixed and suffixed icon names

### DIFF
--- a/packages/lucide-angular/package.json
+++ b/packages/lucide-angular/package.json
@@ -29,7 +29,7 @@
     "build": "pnpm clean && pnpm copy:license && pnpm build:icons && pnpm build:ng",
     "copy:license": "cp ../../LICENSE ./LICENSE",
     "clean": "rm -rf dist && rm -rf ./src/icons/*.ts",
-    "build:icons": "build-icons --output=./src --templateSrc=./scripts/exportTemplate.mjs --renderUniqueKey --withAliases --aliasNamesOnly --aliasesFileExtension=.ts --iconFileExtension=.ts --exportFileName=lucide-icons.ts",
+    "build:icons": "build-icons --output=./src --templateSrc=./scripts/exportTemplate.mjs --renderUniqueKey --withAliases --aliasesFileExtension=.ts --iconFileExtension=.ts --exportFileName=lucide-icons.ts",
     "build:ng": "ng build --configuration production",
     "test": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "test:watch": "ng test",

--- a/packages/lucide-angular/src/aliases/index.ts
+++ b/packages/lucide-angular/src/aliases/index.ts
@@ -1,1 +1,3 @@
 export * from './aliases';
+export * from './prefixed';
+export * from './suffixed';


### PR DESCRIPTION
closes #2870

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Bug fix

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
