### PR TITLE
Add `hd` icon

### DIFF
--- a/icons/hd.json
+++ b/icons/hd.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "ahtohbi4",
+    "jamiemlaw"
+  ],
+  "tags": [
+    "tv",
+    "resolution",
+    "video",
+    "high definition",
+    "720p",
+    "1080p"
+  ],
+  "categories": [
+    "devices",
+    "multimedia"
+  ]
+}

--- a/icons/hd.svg
+++ b/icons/hd.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 12H6" />
+  <path d="M10 15V9" />
+  <path d="M14 15V9h2a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2z" />
+  <path d="M6 15V9" />
+  <rect width="20" height="14" x="2" y="5" rx="2" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

Goes part-way to closing #119 

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Adds an `hd` icon

### Icon use case <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->

* In a media scrubber bar, shows that the item currently playing is in HD
* On a list of videos, shows that a video is available in HD

### Alternative icon designs <!-- ONLY for new icons, remove this part if not icon PR -->

<a title="Open lucide studio" target="_blank" href="https://lucide-studio.vercel.app/edit?value=%3Cpath+d=%22M11+8v8%22+/%3E%3Cpath+d=%22M15+8h2a4+4+0+0+1+0+8h-2z%22+/%3E%3Cpath+d=%22M2+6a2+2+0+0+1+2-2h16a2+2+0+0+1+2+2%22+/%3E%3Cpath+d=%22M22+18a2+2+0+0+1-2+2H4a2+2+0+0+1-2-2%22+/%3E%3Cpath+d=%22M5+12h6%22+/%3E%3Cpath+d=%22M5+8v8%22+/%3E&name=copyright"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTEgOHY4IiAvPgogIDxwYXRoIGQ9Ik0xNSA4aDJhNCA0IDAgMCAxIDAgOGgtMnoiIC8+CiAgPHBhdGggZD0iTTIgNmEyIDIgMCAwIDEgMi0yaDE2YTIgMiAwIDAgMSAyIDIiIC8+CiAgPHBhdGggZD0iTTIyIDE4YTIgMiAwIDAgMS0yIDJINGEyIDIgMCAwIDEtMi0yIiAvPgogIDxwYXRoIGQ9Ik01IDEyaDYiIC8+CiAgPHBhdGggZD0iTTUgOHY4IiAvPgo8L3N2Zz4=.svg"/><br/>Open lucide studio</a>

<a title="Open lucide studio" target="_blank" href="https://lucide-studio.vercel.app/edit?value=%3Cpath+d=%22M10+12H6%22+/%3E%3Cpath+d=%22M10+16V8%22+/%3E%3Cpath+d=%22M14+16V8h2a2+2+0+0+1+2+2v4a2+2+0+0+1-2+2z%22+/%3E%3Cpath+d=%22M6+16V8%22+/%3E%3Crect+x=%222%22+y=%224%22+width=%2220%22+height=%2216%22+rx=%222%22+/%3E&name=copyright"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTAgMTJINiIgLz4KICA8cGF0aCBkPSJNMTAgMTZWOCIgLz4KICA8cGF0aCBkPSJNMTQgMTZWOGgyYTIgMiAwIDAgMSAyIDJ2NGEyIDIgMCAwIDEtMiAyeiIgLz4KICA8cGF0aCBkPSJNNiAxNlY4IiAvPgogIDxyZWN0IHg9IjIiIHk9IjQiIHdpZHRoPSIyMCIgaGVpZ2h0PSIxNiIgcng9IjIiIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

My main submission follows the same visual format at the [currently-proposed closed captions icon](https://github.com/lucide-icons/lucide/pull/2910). However, if we were in future to add an SD counterpart to this icon, there would not be enough space for the 'S'. For that reason, it might be worth choosing one of these two alternatives as a way to future-proof tings. If that ends up being the case, would the closed caption icon need to be revised?

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [x] The icons were originally created in [feathericons/#557](https://github.com/feathericons/feather/issues/557) by @ahtohbi4
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
