### PR TITLE
fix(icons): changed `settings-2` icon

### DIFF
--- a/icons/settings-2.json
+++ b/icons/settings-2.json
@@ -2,13 +2,15 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "mittalyashu",
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "cog",
     "edit",
     "gear",
-    "preferences"
+    "preferences",
+    "slider"
   ],
   "categories": [
     "account"

--- a/icons/settings-2.svg
+++ b/icons/settings-2.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M20 7h-9" />
   <path d="M14 17H5" />
+  <path d="M19 7h-9" />
   <circle cx="17" cy="17" r="3" />
   <circle cx="7" cy="7" r="3" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Fixed path location by moving it to the right by 2px.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.