### PR TITLE
fix(dev): point urls on packages page to correct page

### DIFF
--- a/docs/.vitepress/theme/components/packages/PackageList.data.ts
+++ b/docs/.vitepress/theme/components/packages/PackageList.data.ts
@@ -14,8 +14,8 @@ export default {
           return {
             ...pJson,
             ...packageData,
-            documentation: `/guide/packages/${packageData.docsAlias ?? packageData.name}`,
-            source: `https://github.com/lucide-icons/lucide/tree/main/packages/${packageData.packageDirname ?? packageData.name}`,
+            documentation: `/guide/packages/${packageData.docsAlias ?? pJson.name}`,
+            source: `https://github.com/lucide-icons/lucide/tree/main/packages/${packageData.packageDirname ?? pJson.name}`,
             icon: `/framework-logos/${packageData.icon}.svg`,
             iconDark: Boolean(packageData.iconDark)
               ? `/framework-logos/${packageData.iconDark}.svg`


### PR DESCRIPTION
Resolves #2980

<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [x] Bug fix x
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

I changed packageData.name to pJson.name in PackageList.Data.ts as it was causing an error on the website in which users where being redirected to a 404 page.



## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md). 
- [x] I've checked if there was an existing PR that solves the same issue.
