### PR TITLE
fix(icons): changed `palette` icon

### DIFF
--- a/icons/palette.json
+++ b/icons/palette.json
@@ -3,7 +3,8 @@
   "contributors": [
     "ericfennis",
     "csandman",
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jamiemlaw"
   ],
   "tags": [
     "colors",

--- a/icons/palette.svg
+++ b/icons/palette.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z" />
   <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
   <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
-  <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
   <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
-  <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+  <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Optimised some paths and pixel-aligned others

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.