### PR TITLE
feat(ci): added npm package provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
     if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
     needs: pre-release
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -80,11 +82,15 @@ jobs:
 
       - name: Publish
         run: pnpm --filter ${{ matrix.package }} publish --access public --no-git-checks --ignore-scripts
+        env:
+          NPM_CONFIG_PROVENANCE: true
 
   lucide-static:
     if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
     needs: [pre-release, lucide-font]
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -111,6 +117,8 @@ jobs:
 
       - name: Publish
         run: pnpm --filter lucide-static publish --no-git-checks
+        env:
+          NPM_CONFIG_PROVENANCE: true
 
   lucide-font:
     if: github.repository == 'lucide-icons/lucide'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

> You can generate provenance statements for the packages you publish. This allows you to publicly establish where a package was built and who published a package, which can increase supply-chain security for your packages.

https://docs.npmjs.com/generating-provenance-statements

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
