### PR TITLE
fix(icons): changed `heading-6` icon

### DIFF
--- a/icons/heading-6.json
+++ b/icons/heading-6.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "h6",

--- a/icons/heading-6.svg
+++ b/icons/heading-6.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M12 18V6" />
+  <path d="M17 16v-4a2 2 0 0 1 2-2h1" />
   <path d="M4 12h8" />
   <path d="M4 18V6" />
-  <path d="M12 18V6" />
   <circle cx="19" cy="16" r="2" />
-  <path d="M20 10c-2 2-3 3.5-3 6" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Made 6 more monospace looking

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.