### PR TITLE
fix(icons): rebase non-binary on square-asterisk

### DIFF
--- a/icons/non-binary.svg
+++ b/icons/non-binary.svg
@@ -10,7 +10,7 @@
   stroke-linejoin="round"
 >
   <path d="M12 2v10" />
-  <path d="m9 4 6 4" />
-  <path d="m9 8 6-4" />
+  <path d="m8.5 4 7 4" />
+  <path d="m8.5 8 7-4" />
   <circle cx="12" cy="17" r="5" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Other: icon review fix

### Description

I never saw #2607 got merged, I'm not super thrilled about the balance between the three icons (female and non-binary especially), but nonetheless, the asterisk as used by non-binary definitely should have been the same on we already use in `square-asterisk`.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
