### PR TITLE
fix(icons): changed `list-ordered` icon

### DIFF
--- a/icons/list-ordered.json
+++ b/icons/list-ordered.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
+    "mittalyashu",
+    "karsa-mistmere",
     "ericfennis",
-    "csandman",
+    "colebemis",
     "jguddas"
   ],
   "tags": [

--- a/icons/list-ordered.json
+++ b/icons/list-ordered.json
@@ -2,7 +2,8 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "ericfennis",
-    "csandman"
+    "csandman",
+    "jguddas"
   ],
   "tags": [
     "number",

--- a/icons/list-ordered.svg
+++ b/icons/list-ordered.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M10.5 12H21" />
-  <path d="M10.5 18H21" />
-  <path d="M10.5 6H21" />
-  <path d="M3 10h4" />
-  <path d="M3 4h2v6" />
-  <path d="M3.337 14.889a2 2 0 1 1 2.319 3l-2.421 1.187A.5.5 0 0 0 3.5 20H7" />
+  <path d="M12 12h9" />
+  <path d="M12 18h9" />
+  <path d="M12 6h9" />
+  <path d="M4 14h2v6" />
+  <path d="M4 20h4" />
+  <rect x="4" y="4" width="4" height="6" rx="2" />
 </svg>

--- a/icons/list-ordered.svg
+++ b/icons/list-ordered.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M10 12h11" />
-  <path d="M10 18h11" />
-  <path d="M10 6h11" />
-  <path d="M4 10h2" />
-  <path d="M4 6h1v4" />
-  <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" />
+  <path d="M10.5 12H21" />
+  <path d="M10.5 18H21" />
+  <path d="M10.5 6H21" />
+  <path d="M3 10h4" />
+  <path d="M3 4h2v6" />
+  <path d="M3.337 14.889a2 2 0 1 1 2.319 3l-2.421 1.187A.5.5 0 0 0 3.5 20H7" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Used numbers from binary icon.

### Alternative suggestions

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Cpath+d=%22M11.5+12H21%22+/%3E%3Cpath+d=%22M11.5+18H21%22+/%3E%3Cpath+d=%22M11.5+6H21%22+/%3E%3Cpath+d=%22M4+10h4%22+/%3E%3Cpath+d=%22M4+4h2v6%22+/%3E%3Cpath+d=%22M4.337+14.889a2+2+0+1+1+2.319+3l-2.421+1.187A.5.5+0+0+0+4.5+20H8%22+/%3E&name=list-ordered&dialog=false"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTEuNSAxMkgyMSIgLz4KICA8cGF0aCBkPSJNMTEuNSAxOEgyMSIgLz4KICA8cGF0aCBkPSJNMTEuNSA2SDIxIiAvPgogIDxwYXRoIGQ9Ik00IDEwaDQiIC8+CiAgPHBhdGggZD0iTTQgNGgydjYiIC8+CiAgPHBhdGggZD0iTTQuMzM3IDE0Ljg4OWEyIDIgMCAxIDEgMi4zMTkgM2wtMi40MjEgMS4xODdBLjUuNSAwIDAgMCA0LjUgMjBIOCIgLz4KPC9zdmc+.svg"/><br/>Open lucide studio</a>

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.