### PR TITLE
fix(icons): changed `touchpad-off` icon

### DIFF
--- a/icons/touchpad-off.json
+++ b/icons/touchpad-off.json
@@ -2,7 +2,8 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "karsa-mistmere",
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "trackpad",

--- a/icons/touchpad-off.svg
+++ b/icons/touchpad-off.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M4 4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16" />
-  <path d="M2 14h12" />
-  <path d="M22 14h-2" />
   <path d="M12 20v-6" />
+  <path d="M19.656 14H22" />
+  <path d="M2 14h12" />
   <path d="m2 2 20 20" />
-  <path d="M22 16V6a2 2 0 0 0-2-2H10" />
+  <path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2" />
+  <path d="M9.656 4H20a2 2 0 0 1 2 2v10.344" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Closed gaps.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.