### PR TITLE
fix(icons): changed `loader-pinwheel` icon

### DIFF
--- a/icons/loader-pinwheel.json
+++ b/icons/loader-pinwheel.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "loading",

--- a/icons/loader-pinwheel.svg
+++ b/icons/loader-pinwheel.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M2 12c0-2.8 2.2-5 5-5s5 2.2 5 5 2.2 5 5 5 5-2.2 5-5" />
+  <path d="M22 12a1 1 0 0 1-10 0 1 1 0 0 0-10 0" />
   <path d="M7 20.7a1 1 0 1 1 5-8.7 1 1 0 1 0 5-8.6" />
   <path d="M7 3.3a1 1 0 1 1 5 8.6 1 1 0 1 0 5 8.6" />
   <circle cx="12" cy="12" r="10" />

--- a/icons/loader-pinwheel.svg
+++ b/icons/loader-pinwheel.svg
@@ -9,8 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M22 12a1 1 0 0 1-10 0 1 1 0 0 0-10 0" />
-  <path d="M7 20.7a1 1 0 1 1 5-8.7 1 1 0 1 0 5-8.6" />
-  <path d="M7 3.3a1 1 0 1 1 5 8.6 1 1 0 1 0 5 8.6" />
+  <path d="M17 20.66A5 5 0 1 1 12 12a5 5 0 0 0-10 0" />
+  <path d="M17 3.34A5 5 0 1 1 12 12" />
   <circle cx="12" cy="12" r="10" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Reduced density.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.