### PR TITLE
docs(icon-design-guide): point people to lucide studio instead of svgo

### DIFF
--- a/docs/guide/design/icon-design-guide.md
+++ b/docs/guide/design/icon-design-guide.md
@@ -142,7 +142,7 @@ For each icon these attributes are applied, corresponding to the above rules.
 ### Minify paths
 
 The code of paths can sometimes get quite large. To reduce file size we like to minify the code.
-We recommend to use [SVGOMG](https://jakearchibald.github.io/svgomg/) to minify paths to 2 points of precision.
+We recommend to use [Lucide Studio](https://studio.lucide.dev/) to tidy paths to 3 points of precision.
 
 ### Allowed elements
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Common types: feat, fix, docs, style, refactor, test, chore
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Resolve #3151

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.
