### PR TITLE
fix(icons): flipped `coins` icon

### DIFF
--- a/icons/coins.json
+++ b/icons/coins.json
@@ -3,7 +3,8 @@
   "contributors": [
     "lscheibel",
     "ericfennis",
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "money",

--- a/icons/coins.svg
+++ b/icons/coins.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="8" cy="8" r="6" />
-  <path d="M18.09 10.37A6 6 0 1 1 10.34 18" />
-  <path d="M7 6h1v4" />
-  <path d="m16.71 13.88.7.71-2.82 2.82" />
+  <path d="M17 6h-1v4" />
+  <path d="M5.904 10.378a6 6 0 1 0 7.75 7.63" />
+  <path d="m7.44 14.232-.708.707 2.829 2.829" />
+  <circle cx="16" cy="8" r="6" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Flipped icon.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.