### PR TITLE
feat(website): propose new color picker component

### DIFF
--- a/docs/.vitepress/theme/components/base/ColorPicker.vue
+++ b/docs/.vitepress/theme/components/base/ColorPicker.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import { Chrome } from '@ckpack/vue-color'
 
 const props = defineProps<{
   modelValue: string
@@ -10,22 +11,143 @@ const emit = defineEmits(['update:modelValue'])
 
 const value = computed({
   get: () => props.modelValue,
-  set: (val) => emit('update:modelValue', val)
+  set: val => emit('update:modelValue', val),
+})
+
+const pickerColor = ref(props.modelValue === 'currentColor' ? '#000000' : props.modelValue || '#000000')
+const showPicker = ref(false)
+const pickerPosition = ref({ top: '0px', left: '0px' })
+const colorWrapperRef = ref<HTMLElement | null>(null)
+let scrollableParents: Element[] = []
+
+watch(
+  () => props.modelValue,
+  newVal => {
+    pickerColor.value = newVal === 'currentColor' ? '#000000' : newVal || '#000000'
+  }
+)
+
+function handleColorChange(color: { hex: string }) {
+  value.value = color.hex
+}
+
+function updatePosition() {
+  const rect = colorWrapperRef.value?.getBoundingClientRect()
+  if (!rect) return
+  
+  pickerPosition.value = {
+    top: `${rect.bottom + 8}px`,
+    left: `${rect.left}px`,
+  }
+}
+
+function togglePicker(e: MouseEvent) {
+  e.stopPropagation()
+  if (showPicker.value) {
+    showPicker.value = false
+    return
+  }
+  updatePosition()
+  showPicker.value = true
+}
+
+function handleDocumentClick(e: MouseEvent) {
+  if (!showPicker.value) return
+  const pickerEl = document.querySelector('.color-picker-popup')
+  const swatch = colorWrapperRef.value
+  if (
+    pickerEl && !pickerEl.contains(e.target as Node) &&
+    swatch && !swatch.contains(e.target as Node)
+  ) {
+    showPicker.value = false
+  }
+}
+
+function setupScrollListeners() {
+  if (!colorWrapperRef.value) return
+  
+  let element = colorWrapperRef.value
+  const newScrollableParents: Element[] = []
+  
+  while (element.parentElement) {
+    element = element.parentElement
+    
+    const style = window.getComputedStyle(element)
+    const overflowY = style.getPropertyValue('overflow-y')
+    const overflowX = style.getPropertyValue('overflow-x')
+    
+    if (
+      overflowY === 'auto' || 
+      overflowY === 'scroll' ||
+      overflowX === 'auto' || 
+      overflowX === 'scroll'
+    ) {
+      newScrollableParents.push(element)
+      element.addEventListener('scroll', handleScroll, { passive: true })
+    }
+  }
+  
+  return newScrollableParents
+}
+
+function removeScrollListeners(scrollableParents: Element[]) {
+  scrollableParents.forEach(element => {
+    element.removeEventListener('scroll', handleScroll)
+  })
+}
+
+function handleScroll() {
+  if (showPicker.value) {
+    showPicker.value = false
+  }
+}
+
+function attachGlobalListeners() {
+  document.addEventListener('click', handleDocumentClick, true)
+  window.addEventListener('scroll', handleScroll, { passive: true })
+  window.addEventListener('resize', updatePosition, { passive: true })
+}
+
+function detachGlobalListeners() {
+  document.removeEventListener('click', handleDocumentClick, true)
+  window.removeEventListener('scroll', handleScroll)
+  window.removeEventListener('resize', updatePosition)
+  
+  if (scrollableParents.length) {
+    removeScrollListeners(scrollableParents)
+    scrollableParents = []
+  }
+}
+
+onMounted(attachGlobalListeners)
+onBeforeUnmount(detachGlobalListeners)
+
+watch(showPicker, (opened) => {
+  if (opened) {
+    scrollableParents = setupScrollListeners() || []
+  } else {
+    if (scrollableParents.length) {
+      removeScrollListeners(scrollableParents)
+      scrollableParents = []
+    }
+  }
 })
 </script>
 
 <template>
   <div class="color-picker">
-    <div class="color-input-wrapper">
-      <!-- TODO: Add currentColor div if value is currentColor -->
-      <input
-        type="color"
-        :id="id"
-        :name="id"
-        class="color-input"
-        v-model="value"
-      />
+    <div
+      ref="colorWrapperRef"
+      class="color-input-wrapper"
+      @click="togglePicker"
+    >
+      <div
+        class="color-swatch"
+        :style="{ backgroundColor: value === 'currentColor' ? '#000000' : (value || '#000000') }"
+      >
+      </div>
     </div>
+
     <input
       type="text"
       :id="`${id}-input`"
@@ -34,60 +156,106 @@ const value = computed({
       aria-label="Color picker input"
       v-model="value"
     />
+
+    <Teleport to="body">
+      <div
+        v-if="showPicker"
+        class="color-picker-popup"
+        :style="pickerPosition"
+        @click.stop
+      >
+        <Chrome
+          :model-value="pickerColor"
+          @update:modelValue="handleColorChange"
+          :disable-alpha="true"
+        />
+      </div>
+    </Teleport>
   </div>
 </template>
 
 <style scoped>
-.color-input {
-  width: 34px;
-  height: 34px;
-  position: absolute;
-  top: -5px;
-  left: -5px;
-}
 .color-input-wrapper {
-  height: 24px;
+  height: 24px; 
   width: 24px;
-  overflow: hidden;
+  overflow: hidden; 
   position: relative;
   border-radius: 12px;
-  flex-shrink: 0;
+  flex-shrink: 0; 
+  cursor: pointer;
 }
+
+.color-swatch { 
+  width: 100%; 
+  height: 100%; 
+  border-radius: 12px; 
+}
+
 .color-picker {
   background: var(--color-picker-bg, var(--vp-c-bg-alt));
   border-radius: 8px;
   color: var(--vp-c-text-2);
   padding: 4px 8px;
-  height: auto;
-  font-size: 14px;
-  text-align: left;
-  border: 1px solid transparent;
-  cursor: text;
-  display: flex;
-  align-items: center;
+  display: flex; 
+  align-items: center; 
   gap: 2px;
+  border: 1px solid transparent;
+  cursor: text; 
+  font-size: 14px;
 }
 
 .color-input-text {
-  width: 100%;
-  height: 100%;
-  padding: 0 0 0 8px;
-  border: none;
+  width: 100%; 
+  border: none; 
   background: transparent;
-  color: var(--vp-c-text-1);
+  padding-left: 8px; 
   font-size: 14px;
-  text-align: left;
-  border-radius: 8px;
-  cursor: text;
-  transition: border-color 0.25s, background 0.4s ease;
+  color: var(--vp-c-text-1);
 }
 
-.color-picker:hover, .color-picker:focus {
-  border-color: var(--vp-c-brand);
-  background: var(--vp-c-bg-alt);
+.color-picker:hover,
+.color-picker:focus { 
+  border-color: var(--vp-c-brand); 
 }
 
-.color-input[value="currentColor"] {
+.color-picker-popup {
+  position: fixed;
+  z-index: 9999;
+}
 
+.vc-chrome {
+  box-shadow: var(--vp-shadow-3);
+  border-radius: 12px;
+  border: 1px solid var(--vp-c-brand) !important;
+  padding: 8px;
+}
+</style>
+
+<!-- Non-scoped styles for color picker -->
+<style>
+.vc-chrome-body { 
+  padding-bottom: 2px; 
+}
+
+.vc-chrome-sliders,
+.vc-chrome-fields-wrap { 
+  padding-top: 0 !important; 
+}
+
+.vc-chrome-field { 
+  width: 100% !important; 
+}
+
+.vc-chrome-saturation-wrap { 
+  border-radius: 0 !important; 
+}
+
+.vc-chrome-fields .vc-input__input { 
+  box-shadow: none;
+  font-size: 13px; 
+}
+
+.vc-chrome-toggle-icon-highlight { 
+  left: 0; 
 }
 </style>

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,6 +36,7 @@
     "vitepress": "^1.3.1"
   },
   "dependencies": {
+    "@ckpack/vue-color": "^1.6.0",
     "@floating-ui/vue": "^1.0.3",
     "@headlessui/vue": "^1.7.17",
     "@resvg/resvg-wasm": "^2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
 
   docs:
     dependencies:
+      '@ckpack/vue-color':
+        specifier: ^1.6.0
+        version: 1.6.0(vue@3.5.13(typescript@5.8.3))
       '@floating-ui/vue':
         specifier: ^1.0.3
         version: 1.0.6(vue@3.5.13(typescript@5.8.3))
@@ -2496,6 +2499,12 @@ packages:
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
+  '@ckpack/vue-color@1.6.0':
+    resolution: {integrity: sha512-b9kFTKhYbNArfgP1lmnaVm0VNsWdZjqIbyHUYry7mZ+E7JeTQclbjq1+2xWn0SE3wzqRYlXmAVjECPOgteWmMQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      vue: ^3.2.0
+
   '@cloudflare/kv-asset-handler@0.3.4':
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
     engines: {node: '>=16.13'}
@@ -2635,6 +2644,10 @@ packages:
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss-selector-parser: ^6.0.10
+
+  '@ctrl/tinycolor@3.6.1':
+    resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
+    engines: {node: '>=10'}
 
   '@discoveryjs/json-ext@0.5.6':
     resolution: {integrity: sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==}
@@ -9538,6 +9551,9 @@ packages:
   marky@1.2.5:
     resolution: {integrity: sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==}
 
+  material-colors@1.2.6:
+    resolution: {integrity: sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -10055,6 +10071,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
@@ -14228,7 +14245,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.24.8':
     dependencies:
       '@babel/traverse': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/types': 7.27.0
     transitivePeerDependencies:
       - supports-color
 
@@ -14310,7 +14327,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
-      '@babel/types': 7.26.5
+      '@babel/types': 7.27.0
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
@@ -16129,6 +16146,12 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@ckpack/vue-color@1.6.0(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@ctrl/tinycolor': 3.6.1
+      material-colors: 1.2.6
+      vue: 3.5.13(typescript@5.8.3)
+
   '@cloudflare/kv-asset-handler@0.3.4':
     dependencies:
       mime: 3.0.0
@@ -16303,6 +16326,8 @@ snapshots:
   '@csstools/selector-specificity@2.2.0(postcss-selector-parser@6.1.2)':
     dependencies:
       postcss-selector-parser: 6.1.2
+
+  '@ctrl/tinycolor@3.6.1': {}
 
   '@discoveryjs/json-ext@0.5.6': {}
 
@@ -24041,6 +24066,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marky@1.2.5: {}
+
+  material-colors@1.2.6: {}
 
   math-intrinsics@1.1.0: {}
 


### PR DESCRIPTION
## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] Other: A nicer looking color picker for the Lucide website

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

I typically use Safari, which doesn’t have a very nice color picker popup, so I decided to design one (based on an existing Vue component) that fits better with Lucide. The proposed color picker is built on a modified version of the Chrome one from the `@ckpack/vue-color` package. 

Proposed design on icons page:
<img width="250px" src="https://github.com/user-attachments/assets/4bc24026-5a32-47da-817e-5db07268b999">


Proposed design on home page:
<img width="250px" src="https://github.com/user-attachments/assets/1daa9f60-9741-4868-aa0a-f3c69eca3bdf">


Default in Safari:
<img width="250px" src="https://github.com/user-attachments/assets/f933c212-8cef-4104-aa8b-87503799b7de">


Default in Chrome:
<img width="250px" src="https://github.com/user-attachments/assets/e5b24749-7b92-4821-b057-fc10d8cb3d0e">



## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
