### PR TITLE
fix(site): remove studio link from navbar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -153,7 +153,6 @@ export default defineConfig({
       { text: 'Icons', link: '/icons/' },
       { text: 'Guide', link: '/guide/' },
       { text: 'Packages', link: '/packages' },
-      { text: 'Studio', link: 'https://studio.lucide.dev' },
       { text: 'Showcase', link: '/showcase' },
       { text: 'License', link: '/license' },
     ],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Common types: feat, fix, docs, style, refactor, test, chore
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] New Icon
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: Site

### Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

We are getting a lot of people creating icons who have not read the guidelines, we need to fix this somehow.

For now I say we are not ready for having Lucide Studio in the nav bar.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
