### PR TITLE
fix(icons): changed `square-code` icon

### DIFF
--- a/icons/square-code.json
+++ b/icons/square-code.json
@@ -1,7 +1,10 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas",
+    "karsa-mistmere",
+    "ericfennis"
   ],
   "tags": [
     "gist",

--- a/icons/square-code.svg
+++ b/icons/square-code.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M10 9.5 8 12l2 2.5" />
-  <path d="m14 9.5 2 2.5-2 2.5" />
-  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="m10 9-3 3 3 3" />
+  <path d="m14 15 3-3-3-3" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Used `code` from `file-code-2`.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.