### PR TITLE
feat(icons): added `picnic` icon

### DIFF
--- a/icons/picnic.json
+++ b/icons/picnic.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "skajosborn"
+  ],
+  "tags": [
+    "picnic",
+    "outdoor",
+    "rest",
+    "table",
+    "bench",
+    "park"
+  ],
+  "categories": [
+    "ui",
+    "interface",
+    "location",
+    "activity"
+  ]
+}

--- a/icons/picnic.svg
+++ b/icons/picnic.svg
@@ -1,0 +1,22 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 14h8" />
+  <path d="m13 19 1-4.5" />
+  <path d="M14 17h4.5" />
+  <path d="m17.693 14 1.415 5" />
+  <path d="M21.006 20.653 3 20.613" />
+  <path d="M3 17h4" />
+  <path d="M5.005 19.5v-2" />
+  <path d="M5.89 17s-.953-.48-1.4-.994c-1.505-1.734.934-5.966.934-5.966S6.003 9.145 6.5 9c.556-.162.889.068 1.257.543A53 53 0 0 1 9.5 12l2-1" />
+  <path d="M7 12.5v2.214s1.003.114 1.5.429c.869.55 1 1.857 1 1.857a49 49 0 0 0 .5 2" />
+  <circle cx="9" cy="6" r="1.25" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `picnic` icon.

### Icon use case
This icon represents a person sitting at a picnic table, making it suitable for:

- Outdoor recreation apps or websites  
- Park locator maps  
- Rest area markers  
- Campground booking platforms  
- Event planning tools for outdoor venues  
- Travel or tourism UI elements that indicate public seating or amenities  

It visually conveys concepts like *rest*, *outdoor seating*, or *public tables*, making it a versatile UI asset for nature- or leisure-oriented applications.

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

---

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have not added any brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
- [x] The icons are solely my own creation.
<!-- If based on another icon or design, use the correct line instead -->

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/picnic.json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

---

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.