### PR TITLE
fix(icons): changed `chevrons-left-right-ellipsis` icon

### DIFF
--- a/icons/chevrons-left-right-ellipsis.json
+++ b/icons/chevrons-left-right-ellipsis.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "internet",

--- a/icons/chevrons-left-right-ellipsis.json
+++ b/icons/chevrons-left-right-ellipsis.json
@@ -2,7 +2,8 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "ericfennis",
-    "jguddas"
+    "jguddas",
+    "karsa-mistmere"
   ],
   "tags": [
     "internet",

--- a/icons/chevrons-left-right-ellipsis.svg
+++ b/icons/chevrons-left-right-ellipsis.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m18 8 4 4-4 4" />
-  <path d="m6 8-4 4 4 4" />
-  <path d="M8 12h.01" />
   <path d="M12 12h.01" />
   <path d="M16 12h.01" />
+  <path d="m17 7 5 5-5 5" />
+  <path d="m7 7-5 5 5 5" />
+  <path d="M8 12h.01" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Make the chevrons bigger to match `chevrons-left-right`.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.