### PR TITLE
chore(metadata): add `lens` tag to icons with magnifying glass

### DIFF
--- a/icons/calendar-search.json
+++ b/icons/calendar-search.json
@@ -11,7 +11,8 @@
     "month",
     "year",
     "events",
-    "search"
+    "search",
+    "lens"
   ],
   "categories": [
     "time"

--- a/icons/file-search-2.json
+++ b/icons/file-search-2.json
@@ -8,7 +8,8 @@
     "lost",
     "document",
     "find",
-    "browser"
+    "browser",
+    "lens"
   ],
   "categories": [
     "files"

--- a/icons/file-search.json
+++ b/icons/file-search.json
@@ -10,7 +10,8 @@
     "lost",
     "document",
     "find",
-    "browser"
+    "browser",
+    "lens"
   ],
   "categories": [
     "files"

--- a/icons/folder-search-2.json
+++ b/icons/folder-search-2.json
@@ -8,7 +8,8 @@
     "search",
     "find",
     "lost",
-    "browser"
+    "browser",
+    "lens"
   ],
   "categories": [
     "files"

--- a/icons/folder-search.json
+++ b/icons/folder-search.json
@@ -9,7 +9,8 @@
     "search",
     "find",
     "lost",
-    "browser"
+    "browser",
+    "lens"
   ],
   "categories": [
     "files"

--- a/icons/mail-search.json
+++ b/icons/mail-search.json
@@ -7,7 +7,8 @@
     "email",
     "message",
     "letter",
-    "search"
+    "search",
+    "lens"
   ],
   "categories": [
     "mail"

--- a/icons/package-search.json
+++ b/icons/package-search.json
@@ -7,7 +7,8 @@
   ],
   "tags": [
     "find",
-    "product process"
+    "product process",
+    "lens"
   ],
   "categories": [
     "files",

--- a/icons/search-check.json
+++ b/icons/search-check.json
@@ -11,7 +11,8 @@
     "found",
     "correct",
     "complete",
-    "tick"
+    "tick",
+    "lens"
   ],
   "categories": [
     "text",

--- a/icons/search-code.json
+++ b/icons/search-code.json
@@ -11,7 +11,8 @@
     "magnifying glass",
     "grep",
     "chevrons",
-    "<>"
+    "<>",
+    "lens"
   ],
   "categories": [
     "text",

--- a/icons/search-slash.json
+++ b/icons/search-slash.json
@@ -12,7 +12,8 @@
     "clear",
     "cancel",
     "abort",
-    "/"
+    "/",
+    "lens"
   ],
   "categories": [
     "text",

--- a/icons/search-x.json
+++ b/icons/search-x.json
@@ -11,7 +11,8 @@
     "stop",
     "clear",
     "cancel",
-    "abort"
+    "abort",
+    "lens"
   ],
   "categories": [
     "text",

--- a/icons/search.json
+++ b/icons/search.json
@@ -9,7 +9,8 @@
     "find",
     "scan",
     "magnifier",
-    "magnifying glass"
+    "magnifying glass",
+    "lens"
   ],
   "categories": [
     "text",

--- a/icons/text-search.json
+++ b/icons/text-search.json
@@ -12,7 +12,8 @@
     "document",
     "scan",
     "magnifier",
-    "magnifying glass"
+    "magnifying glass",
+    "lens"
   ],
   "categories": [
     "text"

--- a/icons/user-round-search.json
+++ b/icons/user-round-search.json
@@ -11,7 +11,8 @@
     "find",
     "scan",
     "magnifier",
-    "magnifying glass"
+    "magnifying glass",
+    "lens"
   ],
   "categories": [
     "account",

--- a/icons/user-search.json
+++ b/icons/user-search.json
@@ -15,7 +15,8 @@
     "find",
     "scan",
     "magnifier",
-    "magnifying glass"
+    "magnifying glass",
+    "lens"
   ],
   "categories": [
     "account",


### PR DESCRIPTION
## Description
Added `lens` tag to icons with a magnifying glass.


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
