### PR TITLE
fix(icons): changed `axis-3d` icon

### DIFF
--- a/icons/axis-3d.json
+++ b/icons/axis-3d.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "lscheibel"
+    "lscheibel",
+    "jguddas"
   ],
   "tags": [
     "gizmo",

--- a/icons/axis-3d.svg
+++ b/icons/axis-3d.svg
@@ -9,6 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M4 4v16h16" />
-  <path d="m4 20 7-7" />
+  <path d="M13.5 10.5 15 9" />
+  <path d="M4 4v15a1 1 0 0 0 1 1h15" />
+  <path d="M4.293 19.707 6 18" />
+  <path d="m9 15 1.5-1.5" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Added rounding and made 3rd axis dashed.

### Alternative

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Cpath+d=%22m16+8.5-10+6%22+/%3E%3Cpath+d=%22M5.5+2v11.5a2+2+0+0+0+1+1.73l9+5.27%22+/%3E&name=box&dialog=false"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMTYgOC41LTEwIDYiIC8+CiAgPHBhdGggZD0iTTUuNSAydjExLjVhMiAyIDAgMCAwIDEgMS43M2w5IDUuMjciIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.