### PR TITLE
fix(icons): changed `clock-6` icon

### DIFF
--- a/icons/clock-6.svg
+++ b/icons/clock-6.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M12 16.5V6" />
   <circle cx="12" cy="12" r="10" />
-  <polyline points="12 6 12 12 12 16.5" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

### Description
Optimized icon.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.