### PR TITLE
feat(icons): added `video-plus` icon

### DIFF
--- a/icons/video-plus.json
+++ b/icons/video-plus.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "abraimi"
+  ],
+  "tags": [
+    "add",
+    "video",
+    "files",
+    "upload",
+    "new",
+    "new video",
+    "add new video"
+  ],
+  "categories": [
+    "devices",
+    "communication",
+    "connectivity",
+    "multimedia",
+    "files",
+    "photography"
+  ]
+}

--- a/icons/video-plus.svg
+++ b/icons/video-plus.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m15 16 6 4V10l-6 3.5" />
+  <path d="M16 5.5h5" />
+  <path d="M18.5 3v5" />
+  <path d="M3 11a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5.001a2 2 0 0 1-2-2.066" />
+  <path d="M3 19v-7.934" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `video-plus` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
In a recent gallery webapp that I was working on I got to this point where I added 2 categories one for images and one for videos, well there is an image-plus icon for the user to add images but not a video-plus to add a video so I had to use an editor to add a plus and then I have to create a component than will return the plain svg, this goes for the first use case that I personally got into, as for the second I guess it goes for any place that requires the consumer to add or upload a video like in a mobile app where a chef  adds videos of the making process of certain dishes which he has to do manually by clicking on a file upload form with the video-plus icon to serve his purpose. And am sure there are plenty of other use cases out there to be made with a video-plus icon. And sorry for the first PR it was a rush from my behalf.

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [x] The icons were originally created in #<issueNumber> by @abraimi
- [x] I've based them on the following Lucide icons: `video`, `image-plus`
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [ ] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [ ] I've made sure that the icons look sharp on low DPI displays.
- [ ] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [ ] I've made sure that the icons are visually centered.
- [ ] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.