### PR TITLE
fix(icons): changed `square-equal` and `circle-equal` icon

### DIFF
--- a/icons/circle-equal.json
+++ b/icons/circle-equal.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "calculate",

--- a/icons/circle-equal.svg
+++ b/icons/circle-equal.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M7 10h10" />
-  <path d="M7 14h10" />
+  <path d="M9 10h6" />
+  <path d="M9 14h6" />
   <circle cx="12" cy="12" r="10" />
 </svg>

--- a/icons/square-equal.json
+++ b/icons/square-equal.json
@@ -2,7 +2,8 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "danielbayley",
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "calculate",

--- a/icons/square-equal.svg
+++ b/icons/square-equal.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="18" height="18" x="3" y="3" rx="2" />
-  <path d="M7 10h10" />
-  <path d="M7 14h10" />
+  <path d="M9 10h6" />
+  <path d="M9 14h6" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Made equal symbol smaller.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.