### PR TITLE
feat(icon): add `egg-cracked` icon

### DIFF
--- a/icons/egg-cracked.json
+++ b/icons/egg-cracked.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "kriparajp1"
+  ],
+  "tags": [
+   "bird",
+    "chicken",
+    "egg ",
+    "cracked ",
+    "break ",
+    "shell "
+  ],
+  "categories": [
+   "food-beverage",
+    "animals"
+  ]
+}

--- a/icons/egg-cracked.svg
+++ b/icons/egg-cracked.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" 
+     width="24" height="24" 
+     viewBox="0 0 24 24" 
+     fill="none" 
+     stroke="currentColor" 
+     stroke-width="2" 
+     stroke-linecap="round" 
+     stroke-linejoin="round" 
+     class="lucide lucide-egg-cracked">
+
+  
+  <path d="M12 22
+           c6.23-.05 7.87-5.57 7.5-10
+           -.36-4.34-3.95-9.96-7.5-10
+           -3.55.04-7.14 5.66-7.5 10
+           -.37 4.43 1.27 9.95 7.5 10z
+
+           M7 13
+           Q9 12.5 10 13.5
+           Q11 14.5 12 13
+           Q13 11.5 14 13
+           Q15 14.5 17 13"/>
+</svg>


### PR DESCRIPTION
## PR Title
feat(icons): added egg-cracked icon

### Description
This PR adds a new egg-cracked icon to the Lucide icon set for use in the Lucide React library. The icon depicts a cracked egg, designed to align with Lucide’s minimalist style, and is optimized for clarity and consistency with the existing icon set.

### Icon use case
Cooking interfaces: To indicate actions like cracking an egg in recipe apps or kitchen tools.
Fragility or error states: To represent broken or delicate items, such as in e-commerce for fragile goods or UI error messages.
Alternative icon designs
No alternative designs provided. The submitted design uses a simple egg shape with a jagged crack to ensure clarity and alignment with Lucide’s aesthetic.

Icon Design Checklist

### Concept

-  I have provided valid use cases for each icon.
-  I have not added any brand or logo icon.
-  I have not used any hate symbols.
-  I have not included any religious or political imagery.

Author, credits & license

-  I've based them on the following Lucide icons: egg

### Naming

-  I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions).
-  I've named icons by what they are rather than their use case (egg-cracked).
-  I've provided meta JSON files in icons/egg-cracked.json.
-  I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide).
-  I've made sure that the icons look sharp on low DPI displays.
-  I've made sure that the icons look consistent with the icon set in size, optical volume, and density.
-  I've made sure that the icons are visually centered.
-  I've correctly optimized all icons to three points of precision.

### Before Submitting

-  I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
-  I've checked if there was an existing PR that solves the same issue.