### PR TITLE
fix(icons): ensure shaft overlaps arrowhead in `circle-arrow-left` and `circle-arrow-right`

### DIFF
--- a/icons/circle-arrow-left.svg
+++ b/icons/circle-arrow-left.svg
@@ -10,6 +10,6 @@
   stroke-linejoin="round"
 >
   <circle cx="12" cy="12" r="10" />
-  <path d="M16 12H8" />
   <path d="m12 8-4 4 4 4" />
+  <path d="M16 12H8" />
 </svg>

--- a/icons/circle-arrow-right.svg
+++ b/icons/circle-arrow-right.svg
@@ -10,6 +10,6 @@
   stroke-linejoin="round"
 >
   <circle cx="12" cy="12" r="10" />
-  <path d="M8 12h8" />
   <path d="m12 16 4-4-4-4" />
+  <path d="M8 12h8" />
 </svg>


### PR DESCRIPTION
## Description
This PR fixes a subtle rendering issue in the circle-arrow-left and circle-arrow-right Lucide icons.

Previously, the arrow shaft rendered before the arrowhead, leading to a visual gap at the junction when using `fill="green" stroke="white"` 

### Fix Implemented
* The shaft `<path>` is now rendered after the arrowhead, allowing it to overlap and hide any anti-aliasing or stroke gap.
* No visual regressions expected; only layering order changed.

### 📸 Visual Comparison

#### `circle-arrow-left`

**Before**

<img width="423" alt="circle-arrow-left (Before)" src="https://github.com/user-attachments/assets/f5aa5acb-db07-4ace-97a8-840bfdaab722" />

**After (Fixed)**

<img width="449" alt="circle-arrow-left (After)" src="https://github.com/user-attachments/assets/967aca29-893c-4705-9c8a-d53a364e3590" />

---

#### `circle-arrow-right`

**Before**

<img width="504" alt="circle-arrow-right (Before)" src="https://github.com/user-attachments/assets/ec9093af-5d91-46b0-b789-caeb1ea3bb0f" />



**After (Fixed)**

<img width="487" alt="circle-arrow-right (After)" src="https://github.com/user-attachments/assets/9325810f-b1af-44aa-a0ac-dd07268b7952" />

---


## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
