### PR TITLE
feat(icons): added `credit-card-x` icon

### DIFF
--- a/icons/credit-card-x.json
+++ b/icons/credit-card-x.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "maxgeor"
+  ],
+  "tags": [
+    "account",
+    "finance"
+  ],
+  "categories": [
+    "bank",
+    "purchase",
+    "payment",
+    "cc",
+    "failure",
+    "declined"
+  ]
+}

--- a/icons/credit-card-x.svg
+++ b/icons/credit-card-x.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13 19H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5" />
+  <path d="m17 16 4 4" />
+  <path d="m17 20 4-4" />
+  <path d="M2 10h20" />
+</svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `credit-card-x` icon.

### Icon use case
Used to show an expired/unusable card, an unconnected payment card or payment account (like Stripe or a bank account), inability to accept card payments, failed/declined card transaction.

### Alternative icon designs
—

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
- [ ] The icons are solely my own creation.
- [x] The icons were originally created in #<issueNumber> by @maxgeor
- [x] I've based them on the following Lucide icons: `credit-card`, `mail-x`
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [ ] I've made sure that the icons look sharp on low DPI displays.
- [ ] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [ ] I've made sure that the icons are visually centered.
- [ ] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.