### PR TITLE
feat(icons): add `search-error` icon

### DIFF
--- a/icons/search-error.json
+++ b/icons/search-error.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "../icon.schema.json",
+    "contributors": [
+      "Veatec22"
+    ],
+    "tags": [
+      "find",
+      "scan",
+      "magnifier",
+      "magnifying glass",
+      "stop",
+      "warning",
+      "error",
+      "anomaly",
+      "lens"
+    ],
+    "categories": [
+      "text",
+      "social"
+    ]
+  }

--- a/icons/search-error.svg
+++ b/icons/search-error.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="11" cy="11" r="8" />
+  <path d="M21 21l-4.3-4.3" />
+  <path d="M11 7v4" />
+  <path d="M11 15h.01" />
+</svg>


### PR DESCRIPTION
feat(icons): add `search-error` icon

## Description

Added a new icon named `search-error`, representing a magnifying glass with an alert indicator. This icon combines search functionality with a visual warning to indicate an error state or failed search result.

### Icon use case

- Used in search interfaces to signal an error in query processing (e.g., invalid syntax or server error).
- Helpful in admin dashboards or developer tools to indicate that a search did not return expected results due to an internal issue.
- In support/ticketing platforms to show when a search failed to match any known issues or produced an error.

### Alternative icon designs

Alternative considered: using an “X” mark instead of exclamation point, but the exclamation mark provides clearer association with an error state.

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license

- [x] The icons are solely my own creation.
- [x]  I've based them on the following Lucide icons: search-code

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/search-error.json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
