### PR TITLE
chore(metadata): added tag to `bandage` icon

### DIFF
--- a/icons/bandage.json
+++ b/icons/bandage.json
@@ -18,7 +18,8 @@
     "protection",
     "emergency",
     "aid",
-    "safety"
+    "safety",
+    "patch"
   ],
   "categories": [
     "medical"


### PR DESCRIPTION
Added `patch` as a tag to `bandage` icon

Seen on an A/B testing app where tests can be applied as patches. Seemed like an appropriate keyword to add.

![image](https://github.com/user-attachments/assets/e326861f-c242-4ccc-8060-49dad8e1d3cd)