### PR TITLE
Add 49 new themed icons across various categories

### DIFF
--- a/icons/avatar-gear.svg
+++ b/icons/avatar-gear.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="8" r="3"/>
+  <path d="M12.67 11.33a8 8 0 0 0-10.34 6.34C2.33 20 4.67 22 8 22h8c3.33 0 5.67-2 5.67-4.33a8 8 0 0 0-10.34-6.34Z"/>
+  <path d="M19.13 14.64a3.5 3.5 0 1 0 0-5.28"/>
+  <path d="M19.13 14.64a3.5 3.5 0 1 1 0-5.28"/>
+  <circle cx="19" cy="12" r="1"/>
+</svg>

--- a/icons/battery-low.svg
+++ b/icons/battery-low.svg
@@ -1,15 +1,7 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="currentColor"
-  stroke-width="2"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path d="M22 14v-4" />
-  <path d="M6 14v-4" />
-  <rect x="2" y="6" width="16" height="12" rx="2" />
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="16" y="7" width="6" height="10" rx="1" ry="1"/>
+  <line x1="20" y1="10" x2="20" y2="14"/>
+  <line x1="2" y1="12" x2="12" y2="12"/>
+  <line x1="4" y1="7" x2="4" y2="17"/>
+  <line x1="8" y1="7" x2="8" y2="17"/>
 </svg>

--- a/icons/book-open.svg
+++ b/icons/book-open.svg
@@ -1,14 +1,11 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="currentColor"
-  stroke-width="2"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path d="M12 7v14" />
-  <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 6.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/>
+  <path d="M20 6.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/>
+  <path d="M4 6.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/>
+  <path d="M12 22.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/>
+  <path d="M20 22.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/>
+  <path d="M4 22.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/>
+  <path d="M5 4v16"/>
+  <path d="M19 4v16"/>
+  <path d="M5 12h14"/>
 </svg>

--- a/icons/brush-stroke.svg
+++ b/icons/brush-stroke.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/>
+  <path d="M15 5l4 4"/>
 </svg>

--- a/icons/bug-magnify.svg
+++ b/icons/bug-magnify.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m15 15-3.5 3.5"/>
+  <path d="M18.5 11.5a7 7 0 1 1-10 5.196"/>
+  <path d="M10.153 10.153A3.5 3.5 0 1 1 15 15"/>
+  <path d="M13 18h.01"/>
+  <path d="M16 15h.01"/>
+  <path d="M19 12h.01"/>
+  <path d="M16 9h.01"/>
+  <path d="M13 6h.01"/>
+  <path d="M10 9h.01"/>
+  <path d="M10 15h.01"/>
+</svg>

--- a/icons/canvas-frame.svg
+++ b/icons/canvas-frame.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <rect x="7" y="7" width="10" height="10" rx="1" ry="1" stroke-dasharray="2 2"/>
 </svg>

--- a/icons/cart-checkout.svg
+++ b/icons/cart-checkout.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="9" cy="21" r="1"/>
+  <circle cx="20" cy="21" r="1"/>
+  <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/>
+  <polyline points="16 10 20 14 16 18"/>
+  <line x1="20" y1="14" x2="10" y2="14"/>
+</svg>

--- a/icons/chat-bubble-heart.svg
+++ b/icons/chat-bubble-heart.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/>
+  <path d="M15.5 7.5c.3-.6.9-1 1.5-1a2.12 2.12 0 0 1 1.4 2.4A2.12 2.12 0 0 1 17 10a2.12 2.12 0 0 1-2.4-1.4 2.12 2.12 0 0 1 1-2.5z"/>
+</svg>

--- a/icons/compass-rose.svg
+++ b/icons/compass-rose.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2L14.5 9.5L22 12L14.5 14.5L12 22L9.5 14.5L2 12L9.5 9.5L12 2Z"/>
+  <circle cx="12" cy="12" r="2"/>
+  <line x1="12" y1="2" x2="12" y2="5"/>
+  <line x1="12" y1="19" x2="12" y2="22"/>
+  <line x1="2" y1="12" x2="5" y2="12"/>
+  <line x1="19" y1="12" x2="22" y2="12"/>
+  <line x1="4.93" y1="4.93" x2="7.05" y2="7.05"/>
+  <line x1="16.95" y1="16.95" x2="19.07" y2="19.07"/>
+  <line x1="4.93" y1="19.07" x2="7.05" y2="16.95"/>
+  <line x1="16.95" y1="7.05" x2="19.07" y2="4.93"/>
+</svg>

--- a/icons/credit-card-scan.svg
+++ b/icons/credit-card-scan.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
+  <line x1="1" y1="10" x2="23" y2="10"/>
+  <path d="M7 15h.01"/>
+  <path d="M3 15h2"/>
+  <path d="M12 15h2"/>
+  <path d="M17 15h2"/>
+  <line x1="5" y1="12" x2="19" y2="12" stroke-dasharray="2 4"/>
+</svg>

--- a/icons/design-grid.svg
+++ b/icons/design-grid.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <line x1="3" y1="9" x2="21" y2="9"/>
+  <line x1="3" y1="15" x2="21" y2="15"/>
+  <line x1="9" y1="3" x2="9" y2="21"/>
+  <line x1="15" y1="3" x2="15" y2="21"/>
+</svg>

--- a/icons/envelope-open.svg
+++ b/icons/envelope-open.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M22 10V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h12"/>
+  <path d="m22 10-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 10"/>
+  <path d="M2 10l7.53 4.82a2 2 0 0 0 2.94 0L22 10"/>
 </svg>

--- a/icons/eye-slash.svg
+++ b/icons/eye-slash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/>
+  <line x1="1" y1="1" x2="23" y2="23"/>
+</svg>

--- a/icons/file-upload.svg
+++ b/icons/file-upload.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+  <polyline points="14 2 14 8 20 8"/>
+  <line x1="12" y1="18" x2="12" y2="12"/>
+  <polyline points="9 15 12 12 15 15"/>
+</svg>

--- a/icons/fingerprint-scan.svg
+++ b/icons/fingerprint-scan.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 12a3 3 0 0 0-3 3"/>
+  <path d="M12 12a3 3 0 0 1 3 3"/>
+  <path d="M12 5a7 7 0 0 0-7 7"/>
+  <path d="M12 5a7 7 0 0 1 7 7"/>
+  <path d="M2 12C2 6.5 6.5 2 12 2s10 4.5 10 10-4.5 10-10 10S2 17.5 2 12"/>
+  <path d="M5 12h.01"/>
+  <path d="M19 12h.01"/>
+  <path d="M12 19v-2"/>
+  <path d="M12 7V5"/>
+</svg>

--- a/icons/folder-download.svg
+++ b/icons/folder-download.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 12.58V6.5C20 5.39543 19.1046 4.5 18 4.5H8.5C7.39543 4.5 6.5 5.39543 6.5 6.5V17.5C6.5 18.6046 7.39543 19.5 8.5 19.5H12.5"/>
+  <path d="M2 9.5h12.5"/>
+  <path d="M16 17l3 3 3-3"/>
+  <path d="M19 14v6"/>
+</svg>

--- a/icons/gear-lock.svg
+++ b/icons/gear-lock.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20a8 8 0 1 0-16 0 8 8 0 0 0 16 0z"/>
+  <path d="M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"/>
+  <path d="M12 2v2"/>
+  <path d="M12 22v-2"/>
+  <path d="m17 20.66-1-1.73"/>
+  <path d="m11 10.27 1 1.73"/>
+  <path d="m7 20.66 1-1.73"/>
+  <path d="m13 10.27-1 1.73"/>
+  <path d="M4 12H2"/>
+  <path d="M22 12h-2"/>
+  <path d="m17 3.34 1 1.73"/>
+  <path d="m11 13.73-1-1.73"/>
+  <path d="m7 3.34-1 1.73"/>
+  <path d="m13 13.73 1-1.73"/>
+  <rect x="18" y="11" width="4" height="6" rx="1"/>
+  <path d="M20 11V9a2 2 0 0 0-2-2h0a2 2 0 0 0-2 2v2"/>
+</svg>

--- a/icons/group-minus.svg
+++ b/icons/group-minus.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 13a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v2"/>
+  <path d="M17 13a4 4 0 0 0-4-4h-1"/>
+  <circle cx="7.5" cy="7.5" r="2.5"/>
+  <circle cx="16.5" cy="7.5" r="2.5"/>
+  <path d="M21 15h-6"/>
+</svg>

--- a/icons/hammer-screwdriver.svg
+++ b/icons/hammer-screwdriver.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M15 2l-2.5 2.5L6 11l-4 4 1.5 1.5L7 13l6.5-6.5L16 5l4-4-1-1z"/>
+  <path d="M16 12.5L11.5 17L8 13.5l-1.5 1.5L10 18.5 14.5 14l1.5-1.5z"/>
+  <path d="M22 6l-4.5 4.5"/>
+  <path d="M2 16l4.5-4.5"/>
+</svg>

--- a/icons/headphones-microphone.svg
+++ b/icons/headphones-microphone.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 18v-6a9 9 0 0 1 18 0v6"/>
+  <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/>
+  <path d="M12 12a3 3 0 0 0-3 3v6"/>
+  <path d="M12 12a3 3 0 0 1 3 3v6"/>
+  <rect x="9" y="5" width="6" height="8" rx="2"/>
+  <line x1="12" y1="13" x2="12" y2="17"/>
+</svg>

--- a/icons/image-frame.svg
+++ b/icons/image-frame.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <circle cx="8.5" cy="8.5" r="1.5"/>
+  <polyline points="21 15 16 10 5 21"/>
 </svg>

--- a/icons/invoice-paper.svg
+++ b/icons/invoice-paper.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+  <polyline points="14 2 14 8 20 8"/>
+  <line x1="16" y1="13" x2="8" y2="13"/>
+  <line x1="16" y1="17" x2="8" y2="17"/>
+  <polyline points="10 9 9 9 8 9"/>
+</svg>

--- a/icons/keyhole-heart.svg
+++ b/icons/keyhole-heart.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20.784C12 20.784 4 15.784 4 10.784C4 5.78396 7.58172 2.78396 12 2.78396C16.4183 2.78396 20 5.78396 20 10.784C20 15.784 12 20.784 12 20.784Z"/>
+  <path d="M12 12.784a2 2 0 0 0-2 2v0a2 2 0 0 0 4 0v0a2 2 0 0 0-2-2Z"/>
+</svg>

--- a/icons/lamp-idea.svg
+++ b/icons/lamp-idea.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="M9 18h6"/>
   <path d="M10 22h4"/>
-  <path d="M12.352 14.648A5 5 0 0 1 12 14a5 5 0 0 1-5-5 5 5 0 0 1 .648-.352M12 2a5 5 0 0 0-5 5c0 1.61.764 3.064 2 4M17 9a5 5 0 0 0-2.352-4.352"/>
-  <line x1="2" y1="2" x2="22" y2="22"/>
+  <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5A4.61 4.61 0 0 1 8.91 14"/>
+  <path d="M7 6a7.5 7.5 0 1 0 10 0"/>
+  <path d="M12 6V2"/>
 </svg>

--- a/icons/laptop-open.svg
+++ b/icons/laptop-open.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M20 16V7a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v9m16 0H4m16 0 1.28-2.55A1 1 0 0 0 20.7 12H3.3a1 1 0 0 0-.58 1.45L4 16"/>
+  <rect x="2" y="17" width="20" height="3" rx="1"/>
 </svg>

--- a/icons/location-pin-drop.svg
+++ b/icons/location-pin-drop.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M12 22s-8-6-8-12a8 8 0 0 1 16 0c0 6-8 12-8 12z"/>
+  <circle cx="12" cy="10" r="3"/>
+  <path d="M12 10v10"/>
+  <ellipse cx="12" cy="22" rx="3" ry="1"/>
 </svg>

--- a/icons/lock-open.svg
+++ b/icons/lock-open.svg
@@ -1,14 +1,4 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="currentColor"
-  stroke-width="2"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
-  <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+  <path d="M7 11V7a5 5 0 0 1 9.9-1"/>
 </svg>

--- a/icons/map-folded-corner.svg
+++ b/icons/map-folded-corner.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M2 6l8 3 8-3v12l-8 3-8-3V6z"/>
+  <path d="M14 6v12"/>
+  <path d="M18 4l-4 2v12l4-2V4z"/>
 </svg>

--- a/icons/map-marker-plus.svg
+++ b/icons/map-marker-plus.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/>
+  <circle cx="12" cy="10" r="3"/>
+  <line x1="12" y1="7" x2="12" y2="13"/>
+  <line x1="9" y1="10" x2="15" y2="10"/>
 </svg>

--- a/icons/message-quote.svg
+++ b/icons/message-quote.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+  <polyline points="9 8 11 10 9 12"/>
+  <polyline points="13 8 15 10 13 12"/>
 </svg>

--- a/icons/music-note-circle.svg
+++ b/icons/music-note-circle.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M10 17V8l5-2v7"/>
+  <circle cx="8" cy="17" r="2"/>
+  <circle cx="13" cy="15" r="2"/>
 </svg>

--- a/icons/palette-paint.svg
+++ b/icons/palette-paint.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"/>
+  <path d="m15 5 3 3"/>
+  <path d="M10.41 11.59c.2-.2.2-.51 0-.71L6.12 6.59a1.5 1.5 0 0 0-2.12 0L2.59 8.01a1.5 1.5 0 0 0 0 2.12l4.29 4.29c.2.2.51.2.71 0Z"/>
+  <circle cx="6.5" cy="17.5" r="1.5"/>
+  <circle cx="9.5" cy="14.5" r="1.5"/>
+  <circle cx="12.5" cy="11.5" r="1.5"/>
+  <circle cx="15.5" cy="8.5" r="1.5"/>
+</svg>

--- a/icons/phone-call-missed.svg
+++ b/icons/phone-call-missed.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+  <line x1="20" y1="4" x2="14" y2="10"/>
+  <line x1="14" y1="4" x2="20" y2="10"/>
+</svg>

--- a/icons/printer-wireless.svg
+++ b/icons/printer-wireless.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 9V2h12v7"/>
+  <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/>
+  <path d="M6 14h12v8H6z"/>
+  <path d="M12 10.5c1.66 0 3-1.34 3-3"/>
+  <path d="M12 7.5c2.76 0 5-2.24 5-5"/>
+  <path d="M12 4.5c3.87 0 7-3.13 7-7"/>
+</svg>

--- a/icons/profile-picture.svg
+++ b/icons/profile-picture.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <circle cx="12" cy="10" r="3"/>
+  <path d="M7 18v-1a5 5 0 0 1 10 0v1"/>
 </svg>

--- a/icons/rocket-launch.svg
+++ b/icons/rocket-launch.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
+  <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
+  <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
+  <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
+</svg>

--- a/icons/route-arrow.svg
+++ b/icons/route-arrow.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M18 3.5L14 7.5L18 11.5"/>
+  <path d="M12 3.5L8 7.5L12 11.5"/>
+  <path d="M6 3.5L2 7.5L6 11.5"/>
+  <path d="M2 7.5h11c2.2 0 4 1.8 4 4v0c0 2.2-1.8 4-4 4H6"/>
 </svg>

--- a/icons/ruler-pencil.svg
+++ b/icons/ruler-pencil.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21.174 6.826a1 1 0 0 0-1.414-1.414L12 13.172l-2.121-2.121-5.657 5.657a1 1 0 0 0 0 1.414l1.414 1.414a1 1 0 0 0 1.414 0l5.657-5.657L19.76 6.826Z"/>
+  <path d="M16 4l4 4"/>
+  <path d="M2 12h2"/>
+  <path d="M6 12h2"/>
+  <path d="M10 12h2"/>
+  <path d="M14 12h2"/>
+  <path d="M18 12h2"/>
+  <path d="M12 2v2"/>
+  <path d="M12 6v2"/>
+  <path d="M12 10v2"/>
+  <path d="M12 14v2"/>
+  <path d="M12 18v2"/>
+</svg>

--- a/icons/smartphone-lock.svg
+++ b/icons/smartphone-lock.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="7" y="2" width="10" height="20" rx="2" ry="2"/>
+  <path d="M12 18h.01"/>
+  <rect x="10" y="10" width="4" height="5" rx="1"/>
+  <path d="M12 10V8a2 2 0 0 0-2-2H0a0 0 0 0 0 0 0v0a2 2 0 0 0 2 2v0" transform="translate(12 8) rotate(180) translate(-12 -8)"/>
+</svg>

--- a/icons/storefront-sign.svg
+++ b/icons/storefront-sign.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 21V10.5A2.5 2.5 0 0 1 6.5 8H17.5a2.5 2.5 0 0 1 2.5 2.5V21"/>
+  <path d="M2 21h20"/>
+  <path d="M12 11v-2a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v2"/>
+  <path d="M12 11h7a1 1 0 0 0 1-1V8a1 1 0 0 0-1-1h-7"/>
+  <path d="M12 11V7"/>
+  <path d="M7 11V7"/>
+</svg>

--- a/icons/tablet-stand.svg
+++ b/icons/tablet-stand.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <rect x="4" y="2" width="16" height="20" rx="2" ry="2"/>
+  <path d="M12 18h.01"/>
+  <path d="M8 22h8"/>
+  <path d="M7 18.5l-3 3.5"/>
+  <path d="M17 18.5l3 3.5"/>
 </svg>

--- a/icons/user-circle.svg
+++ b/icons/user-circle.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <circle cx="12" cy="12" r="10"/>
+  <circle cx="12" cy="10" r="3"/>
+  <path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662"/>
 </svg>

--- a/icons/user-plus.svg
+++ b/icons/user-plus.svg
@@ -1,16 +1,6 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="currentColor"
-  stroke-width="2"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-  <circle cx="9" cy="7" r="4" />
-  <line x1="19" x2="19" y1="8" y2="14" />
-  <line x1="22" x2="16" y1="11" y2="11" />
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+  <circle cx="8.5" cy="7" r="4"/>
+  <line x1="20" y1="8" x2="20" y2="14"/>
+  <line x1="17" y1="11" x2="23" y2="11"/>
 </svg>

--- a/icons/video-call-off.svg
+++ b/icons/video-call-off.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M16 16v-3.277L20.414 16H22V8h-1.586L16 11.277V8H2v8h14z"/>
+  <line x1="2" y1="22" x2="22" y2="2"/>
 </svg>

--- a/icons/video-playlist.svg
+++ b/icons/video-playlist.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-  <polyline points="9 12 11 14 15 10"/>
+  <path d="M10 16.5l6-4.5-6-4.5v9z"/>
+  <path d="M20 12H4"/>
+  <path d="M20 8H4"/>
+  <path d="M20 16H4"/>
+  <rect x="2" y="5" width="20" height="14" rx="2"/>
 </svg>

--- a/icons/wallet-open.svg
+++ b/icons/wallet-open.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 12V7H4v10h16M2 12h20"/>
+  <path d="M18 12.5a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1z"/>
+  <path d="M12 12V7H4v5"/>
+  <path d="M20 17a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v0a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v0z"/>
+</svg>

--- a/icons/wrench-crossed.svg
+++ b/icons/wrench-crossed.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.4 1.4a1 1 0 0 0 1.4 0l3.5-3.5a1 1 0 0 0 0-1.4l-1.4-1.4a1 1 0 0 0-1.4 0L14.7 6.3z"/>
+  <path d="M9.3 17.7a1 1 0 0 0 0-1.4l-1.4-1.4a1 1 0 0 0-1.4 0L2.9 18.5a1 1 0 0 0 0 1.4l1.4 1.4a1 1 0 0 0 1.4 0L9.3 17.7z"/>
+  <path d="M16.5 3.5c-3.9 3.9-9.2 9.2-13 13"/>
+  <path d="m20.5 7.5-13 13"/>
+</svg>


### PR DESCRIPTION
This PR adds 49 new icons organized into 10 thematic categories:

- Communication & UI
- Tools & Utilities
- Files & Media
- Devices & Hardware
- Security & Privacy
- Navigation & Maps
- Social & Avatars
- Commerce & Business
- Creativity & Design
- Miscellaneous / Fun

All icons follow the Lucide style guidelines with 2px stroke width, 24x24 viewport, and clean minimalist design.