### PR TITLE
feat: Adding Context providers

### DIFF
--- a/packages/lucide-react/src/Icon.tsx
+++ b/packages/lucide-react/src/Icon.tsx
@@ -2,6 +2,7 @@ import { createElement, forwardRef } from 'react';
 import defaultAttributes from './defaultAttributes';
 import { IconNode, LucideProps } from './types';
 import { mergeClasses, hasA11yProp } from '@lucide/shared';
+import { useLucideContext } from './context';
 
 interface IconComponentProps extends LucideProps {
   iconNode: IconNode;
@@ -25,9 +26,9 @@ interface IconComponentProps extends LucideProps {
 const Icon = forwardRef<SVGSVGElement, IconComponentProps>(
   (
     {
-      color = 'currentColor',
-      size = 24,
-      strokeWidth = 2,
+      color,
+      size,
+      strokeWidth,
       absoluteStrokeWidth,
       className = '',
       children,
@@ -35,16 +36,29 @@ const Icon = forwardRef<SVGSVGElement, IconComponentProps>(
       ...rest
     },
     ref,
-  ) =>
-    createElement(
+  ) =>{
+    const lucideContext = useLucideContext() ?? {};
+
+    const {
+      size: contextSize = 24,
+      strokeWidth: contextStrokeWidth = 2,
+      absoluteStrokeWidth: contextAbsoluteStrokeWidth = false,
+      color: contextColor = 'currentColor',
+    } = lucideContext;
+
+    const calculatedStrokeWidth = (absoluteStrokeWidth ?? contextAbsoluteStrokeWidth)
+      ? (Number(strokeWidth ?? contextStrokeWidth) * 24) / Number(size ?? contextSize)
+      : strokeWidth ?? contextStrokeWidth
+
+    return createElement(
       'svg',
       {
         ref,
         ...defaultAttributes,
-        width: size,
-        height: size,
-        stroke: color,
-        strokeWidth: absoluteStrokeWidth ? (Number(strokeWidth) * 24) / Number(size) : strokeWidth,
+        width: size ?? contextSize ?? 24,
+        height: size ?? contextSize ?? 24,
+        stroke: color ?? contextColor,
+        strokeWidth: calculatedStrokeWidth,
         className: mergeClasses('lucide', className),
         ...(!children && !hasA11yProp(rest) && { 'aria-hidden': 'true' }),
         ...rest,
@@ -53,7 +67,8 @@ const Icon = forwardRef<SVGSVGElement, IconComponentProps>(
         ...iconNode.map(([tag, attrs]) => createElement(tag, attrs)),
         ...(Array.isArray(children) ? children : [children]),
       ],
-    ),
+    )
+  }
 );
 
 export default Icon;

--- a/packages/lucide-react/src/context.tsx
+++ b/packages/lucide-react/src/context.tsx
@@ -1,0 +1,39 @@
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+} from "react";
+
+const LucideContext = createContext<{
+  size?: number;
+  fill?: string;
+  color?: string;
+  strokeWidth?: number;
+}>({
+  size: 24,
+  fill: 'none',
+  color: 'currentColor',
+  strokeWidth: 2,
+});
+
+interface LucideProviderProps {
+  children: ReactNode;
+  size?: number
+  fill?: string;
+  color?: string;
+  strokeWidth?: number;
+  absoluteStrokeWidth?: boolean;
+}
+
+export function LucideProvider({ children, ...props }: LucideProviderProps) {
+  return (
+    <LucideContext.Provider value={props}>
+      {children}
+    </LucideContext.Provider>
+  );
+}
+
+export function useLucideContext() {
+
+  return useContext(LucideContext);;
+}

--- a/packages/lucide-react/src/lucide-react.ts
+++ b/packages/lucide-react/src/lucide-react.ts
@@ -2,6 +2,7 @@ export * from './icons';
 export * as icons from './icons';
 export * from './aliases';
 export * from './types';
+export * from './context';
 
 export { default as createLucideIcon } from './createLucideIcon';
 export { default as Icon } from './Icon';

--- a/packages/lucide-react/tests/__snapshots__/context.spec.tsx.snap
+++ b/packages/lucide-react/tests/__snapshots__/context.spec.tsx.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Using LucideProvider > should render the icon with LucideProvider 1`] = `
+<svg
+  aria-hidden="true"
+  class="lucide lucide-house"
+  fill="none"
+  height="48"
+  stroke="red"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  stroke-width="2"
+  viewBox="0 0 24 24"
+  width="48"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"
+  />
+  <path
+    d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+  />
+</svg>
+`;

--- a/packages/lucide-react/tests/context.spec.tsx
+++ b/packages/lucide-react/tests/context.spec.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { House, LucideProvider } from "../src/lucide-react";
+
+describe('Using LucideProvider', () => {
+  it('should render the icon with LucideProvider', () => {
+    const { container } = render(
+      <LucideProvider
+        size={48}
+        color="red"
+      >
+        <House/>
+      </LucideProvider>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should render the icon with LucideProvider and custom strokeWidth', () => {
+    const { container } = render(
+      <LucideProvider
+        size={48}
+        color="red"
+        strokeWidth={4}
+      >
+        <House/>
+      </LucideProvider>
+    );
+
+    const IconComponent = container.firstElementChild;
+
+    expect(IconComponent).toHaveAttribute('width', '48');
+    expect(IconComponent).toHaveAttribute('height', '48');
+    expect(IconComponent).toHaveAttribute('stroke', 'red');
+    expect(IconComponent).toHaveAttribute('stroke-width', '4');
+  });
+})

--- a/packages/svelte/src/Icon.svelte
+++ b/packages/svelte/src/Icon.svelte
@@ -1,17 +1,26 @@
 <script lang="ts">
   import defaultAttributes from './defaultAttributes';
   import type { IconProps } from './types';
+  import { getLucideContext } from './context';
+
+  const globalProps = getLucideContext() ?? {}
 
   const {
     name,
-    color = 'currentColor',
-    size = 24,
-    strokeWidth = 2,
-    absoluteStrokeWidth = false,
+    color = globalProps.color ?? 'currentColor',
+    size = globalProps.size ?? 24,
+    strokeWidth = globalProps.strokeWidth ?? 2,
+    absoluteStrokeWidth = globalProps.absoluteStrokeWidth ?? false,
     iconNode = [],
     children,
     ...props
   }: IconProps = $props();
+
+  const calculatedStrokeWidth = $derived(
+    absoluteStrokeWidth
+      ? (Number(strokeWidth) * 24) / Number(size)
+      : strokeWidth
+  );
 </script>
 
 <svg
@@ -20,7 +29,7 @@
   width={size}
   height={size}
   stroke={color}
-  stroke-width={absoluteStrokeWidth ? (Number(strokeWidth) * 24) / Number(size) : strokeWidth}
+  stroke-width={calculatedStrokeWidth}
   class={['lucide-icon lucide', name && `lucide-${name}`, props.class]}
 >
   {#each iconNode as [tag, attrs]}

--- a/packages/svelte/src/context.ts
+++ b/packages/svelte/src/context.ts
@@ -1,0 +1,14 @@
+import { getContext, setContext } from "svelte"
+
+const LucideContext = Symbol('lucide-context')
+
+export interface LucideGlobalContext {
+  color?: string
+  size?: number
+  strokeWidth?: number
+  absoluteStrokeWidth?: boolean
+}
+
+export const setLucideProperties = (globalProps: LucideGlobalContext) => setContext(LucideContext, globalProps)
+
+export let getLucideContext = () => getContext<LucideGlobalContext>(LucideContext)

--- a/packages/svelte/src/lucide-svelte.ts
+++ b/packages/svelte/src/lucide-svelte.ts
@@ -4,3 +4,4 @@ export * from './aliases';
 export { default as defaultAttributes } from './defaultAttributes';
 export * from './types';
 export { default as Icon } from './Icon.svelte';
+export * from './context';

--- a/packages/svelte/tests/ContextWrapper.svelte
+++ b/packages/svelte/tests/ContextWrapper.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { setContext } from 'svelte';
+  import Smile from '../src/icons/smile.svelte'
+  import { setLucideProperties } from '../src/lucide-svelte';
+
+  setLucideProperties({
+    size: 32,
+    color: 'red',
+    strokeWidth: 1,
+  });
+</script>
+
+<Smile aria-label="smile">
+  <text>Test</text>
+</Smile>

--- a/packages/svelte/tests/__snapshots__/lucide-svelte.spec.ts.snap
+++ b/packages/svelte/tests/__snapshots__/lucide-svelte.spec.ts.snap
@@ -270,3 +270,41 @@ exports[`Using lucide icon components > should render an icon slot 1`] = `
   
 </div>
 `;
+
+exports[`Using lucide icon components > should use context values from he global set properties 1`] = `
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="32"
+     height="32"
+     viewbox="0 0 24 24"
+     fill="none"
+     stroke="red"
+     stroke-width="1"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     aria-label="smile"
+     class="lucide-icon lucide lucide-smile"
+>
+  <circle cx="12"
+          cy="12"
+          r="10"
+  >
+  </circle>
+  <path d="M8 14s1.5 2 4 2 4-2 4-2">
+  </path>
+  <line x1="9"
+        x2="9.01"
+        y1="9"
+        y2="9"
+  >
+  </line>
+  <line x1="15"
+        x2="15.01"
+        y1="9"
+        y2="9"
+  >
+  </line>
+  <text>
+    Test
+  </text>
+</svg>
+`;

--- a/packages/svelte/tests/lucide-svelte.spec.ts
+++ b/packages/svelte/tests/lucide-svelte.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { Smile, Pen, Edit2 } from '../src/lucide-svelte';
 import TestSlots from './TestSlots.svelte';
+import ContextWrapper from './ContextWrapper.svelte';
 
 describe('Using lucide icon components', () => {
   afterEach(() => cleanup());
@@ -12,11 +13,9 @@ describe('Using lucide icon components', () => {
 
   it('should adjust the size, stroke color and stroke width', () => {
     const { container } = render(Smile, {
-      props: {
-        size: 48,
-        color: 'red',
-        strokeWidth: 4,
-      },
+      size: 48,
+      color: 'red',
+      strokeWidth: 4,
     });
 
     expect(container).toMatchSnapshot();
@@ -25,9 +24,7 @@ describe('Using lucide icon components', () => {
   it('should add a class to the element', () => {
     const testClass = 'my-icon';
     render(Smile, {
-      props: {
-        class: testClass,
-      },
+      class: testClass,
     });
 
     const [icon] = document.getElementsByClassName(testClass);
@@ -41,9 +38,7 @@ describe('Using lucide icon components', () => {
 
   it('should add a style attribute to the element', () => {
     render(Smile, {
-      props: {
-        style: 'position: absolute;',
-      },
+      style: 'position: absolute;',
     });
     const [icon] = document.getElementsByClassName('lucide');
 
@@ -85,6 +80,20 @@ describe('Using lucide icon components', () => {
     expect(attributes.stroke.value).toBe('red');
     expect(attributes.width.value).toBe('48');
     expect(attributes.height.value).toBe('48');
+    expect(attributes['stroke-width'].value).toBe('1');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  it('should use context values from he global set properties', () => {
+    const { container, getByLabelText } = render(ContextWrapper);
+
+    const { attributes } = getByLabelText('smile') as unknown as {
+      attributes: Record<string, { value: string }>;
+    };
+    expect(attributes.stroke.value).toBe('red');
+    expect(attributes.width.value).toBe('32');
+    expect(attributes.height.value).toBe('32');
     expect(attributes['stroke-width'].value).toBe('1');
 
     expect(container.innerHTML).toMatchSnapshot();


### PR DESCRIPTION
Adds context providers to globally adjust props on lucide icons.

Todo: 
- [x] React
- [x] Svelte
- [ ] Vue
- [ ] Solid
- [ ] Preact
- [ ] Astro

