### PR TITLE
fix(docs): remove flex-direction CSS causing absolute stroke width toggle positioning issue (#3308)

### DIFF
--- a/docs/.vitepress/theme/components/icons/SidebarIconCustomizer.vue
+++ b/docs/.vitepress/theme/components/icons/SidebarIconCustomizer.vue
@@ -161,9 +161,4 @@ const customizingActive = computed(() => {
 .color-picker {
   margin-left: auto;
 }
-
-#absolute-stroke-width {
-  flex-direction: row-reverse;
-}
-
 </style>


### PR DESCRIPTION
## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

## Description
Fixes the absolute stroke width toggle positioning issue by removing the problematic CSS rule that was causing the switch to move out of bounds.

### Problem
The CSS rule `#absolute-stroke-width { flex-direction: row-reverse; }` was causing layout issues where:
- Toggle switch would move out of its container bounds
- Toggle switch was pseudo active
- Issue only occurred in production builds, not development

### Solution
- Removed the `#absolute-stroke-width { flex-direction: row-reverse; }` CSS rule

### Fixes
Closes #3308

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
