### PR TITLE
fix(docs): update prop name from absolute-stroke-width to absoluteStrokeWidth in vue-next guide

### DIFF
--- a/docs/guide/packages/lucide-vue-next.md
+++ b/docs/guide/packages/lucide-vue-next.md
@@ -54,7 +54,7 @@ import { Camera } from 'lucide-vue-next';
 | `size`                  | *number*  | 24           |
 | `color`                 | *string*  | currentColor |
 | `stroke-width`          | *number*  | 2            |
-| `absolute-stroke-width` | *boolean* | false        |
+| `absoluteStrokeWidth`   | *boolean* | false        |
 | `default-class`         | *string*  | lucide-icon  |
 
 ### Applying props

--- a/docs/guide/packages/lucide-vue.md
+++ b/docs/guide/packages/lucide-vue.md
@@ -60,7 +60,7 @@ Additional props can be passed to adjust the icon:
 | `size`                  | *number*  | 24           |
 | `color`                 | *string*  | currentColor |
 | `stroke-width`          | *number*  | 2            |
-| `absolute-stroke-width` | *boolean* | false        |
+| `absoluteStrokeWidth`   | *boolean* | false        |
 | `default-class`         | *string*  | lucide-icon  |
 
 ### Applying props


### PR DESCRIPTION
## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other:

## Description
This pull request fixes inconsistent prop naming in the Vue Next documentation. The `absoluteStrokeWidth` prop was incorrectly documented using kebab-case (`absolute-stroke-width`) instead of the proper camelCase format used in Vue components.

### Changes Made:
**lucide-vue-next.md**
- Updated props table to use `absoluteStrokeWidth` instead of `absolute-stroke-width`
- Ensures consistency with Vue prop naming conventions and actual component implementation
- Aligns documentation with how the prop is used in Vue templates

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
