### PR TITLE
feat(icons): added `traffic-light` icon

### DIFF
--- a/icons/traffic-light.json
+++ b/icons/traffic-light.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "alexisoules"
+  ],
+  "tags": [
+    "traffic light",
+    "stoplight",
+    "signal",
+    "traffic signal",
+    "lights",
+    "stop",
+    "go",
+    "caution",
+    "road",
+    "intersection",
+    "control",
+    "street",
+    "status",
+    "indicator",
+    "alert",
+    "progress",
+    "permission"
+  ],
+  "categories": [
+    "travel",
+    "transportation"
+  ]
+}

--- a/icons/traffic-light.svg
+++ b/icons/traffic-light.svg
@@ -1,0 +1,22 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 10.5h3.75" />
+  <path d="M18 15h3.75" />
+  <path d="M18 6h3.75" />
+  <path d="M2.25 10.5H6" />
+  <path d="M2.25 15H6" />
+  <path d="M2.25 6H6" />
+  <circle cx="12" cy="12" r="1" fill="currentColor" />
+  <circle cx="12" cy="17" r="1" fill="currentColor" />
+  <circle cx="12" cy="7" r="1" fill="currentColor" />
+  <rect x="6" y="1.5" width="12" height="21" rx="1" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `traffic-light` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
- Status Indicators
- Permissions or Access Levels
- Traffic & Transportation Apps
- Project or Workflow Steps

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] The icons are solely my own creation.
- [x] The icons were originally created in #<issueNumber> by @<githubUser>
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [ ] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.