### PR TITLE
chore(metadata): Add tags to `x` icon

### DIFF
--- a/icons/x.json
+++ b/icons/x.json
@@ -7,7 +7,9 @@
   "tags": [
     "cancel",
     "close",
+    "cross",
     "delete",
+    "ex",
     "remove",
     "times",
     "clear",


### PR DESCRIPTION
## Description

Added 'ex' and 'cross' as tags

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
