### PR TITLE
fix(icons): changed `circle-parking-off` icon

### DIFF
--- a/icons/circle-parking-off.svg
+++ b/icons/circle-parking-off.svg
@@ -9,8 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="12" cy="12" r="10" />
-  <path d="m5 5 14 14" />
-  <path d="M13 13a3 3 0 1 0 0-6H9v2" />
-  <path d="M9 17v-2.34" />
+  <path d="M12.656 7H13a3 3 0 0 1 2.984 3.307" />
+  <path d="M13 13H9" />
+  <path d="M19.071 19.071A1 1 0 0 1 4.93 4.93" />
+  <path d="m2 2 20 20" />
+  <path d="M8.357 2.687a10 10 0 0 1 12.956 12.956" />
+  <path d="M9 17V9" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Use normal `-off` style.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.