### PR TITLE
ci(token-permissions): added top-level permissions to gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,17 @@ on:
     paths:
       - icons/**/*.svg
 
+permissions: read-all
+
 jobs:
   create-release:
     if: github.repository == 'lucide-icons/lucide' && startsWith(github.event.head_commit.message, 'feat(icons)')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     outputs:
       VERSION: ${{ steps.new-version.outputs.NEW_VERSION }}
 
@@ -67,6 +74,11 @@ jobs:
   test-semantic-release:
     if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - uses: actions/checkout@v4
 
@@ -103,3 +115,8 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.create-release.outputs.VERSION }}
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance

--- a/.github/workflows/close-issue-with-banned-phrases.yml
+++ b/.github/workflows/close-issue-with-banned-phrases.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types: [opened]
 
+permissions: read-all
+
 jobs:
   block_phrases:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '45 1 * * *'
 
+permissions: read-all
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/comment-icon-preview.yml
+++ b/.github/workflows/comment-icon-preview.yml
@@ -6,9 +6,13 @@ on:
     types:
       - completed
 
+permissions: read-all
+
 jobs:
   upload:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,10 +2,12 @@ name: 'Pull Request Labeler'
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     permissions:
-      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -5,6 +5,9 @@ on:
     paths-ignore:
       - icons/*.svg
 
+permissions:
+  contents: read
+
 jobs:
   lint-code:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - reopened
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     name: PR Title Lint

--- a/.github/workflows/linting-icons.yml
+++ b/.github/workflows/linting-icons.yml
@@ -5,13 +5,15 @@ on:
     paths:
       - 'icons/*'
 
+permissions:
+  contents: read
+
 jobs:
   lint-filenames:
     name: Lint Filenames
     if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -31,8 +33,6 @@ jobs:
   lint-aliases:
     name: Check Uniqueness of Aliases
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Check Uniqueness of Aliases

--- a/.github/workflows/lucide-angular.yml
+++ b/.github/workflows/lucide-angular.yml
@@ -7,6 +7,9 @@ on:
       - tools/build-icons/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-astro.yml
+++ b/.github/workflows/lucide-astro.yml
@@ -8,6 +8,9 @@ on:
       - tools/build-icons/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-font.yml
+++ b/.github/workflows/lucide-font.yml
@@ -6,6 +6,9 @@ on:
       - tools/build-font/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   lucide-font:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-preact.yml
+++ b/.github/workflows/lucide-preact.yml
@@ -9,6 +9,9 @@ on:
       - tools/rollup-plugins/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   lucide-preact:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-react-native.yml
+++ b/.github/workflows/lucide-react-native.yml
@@ -9,6 +9,9 @@ on:
       - tools/rollup-plugins/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-react.yml
+++ b/.github/workflows/lucide-react.yml
@@ -10,6 +10,9 @@ on:
       - scripts/generateNextJSAliases.mjs
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-shared.yml
+++ b/.github/workflows/lucide-shared.yml
@@ -6,6 +6,9 @@ on:
       - packages/shared/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-solid.yml
+++ b/.github/workflows/lucide-solid.yml
@@ -9,6 +9,9 @@ on:
       - tools/rollup-plugins/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-static.yml
+++ b/.github/workflows/lucide-static.yml
@@ -7,6 +7,9 @@ on:
       - tools/build-icons/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   lucide-static:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-svelte-5.yml
+++ b/.github/workflows/lucide-svelte-5.yml
@@ -9,6 +9,9 @@ on:
       - tools/rollup-plugins/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-svelte.yml
+++ b/.github/workflows/lucide-svelte.yml
@@ -9,6 +9,9 @@ on:
       - tools/rollup-plugins/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide-vue-next.yml
+++ b/.github/workflows/lucide-vue-next.yml
@@ -9,6 +9,9 @@ on:
       - tools/rollup-plugins/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lucide.yml
+++ b/.github/workflows/lucide.yml
@@ -8,6 +8,9 @@ on:
       - tools/rollup-plugins/**
       - pnpm-lock.yaml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-icon-preview.yml
+++ b/.github/workflows/pull-request-icon-preview.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - 'icons/*.svg'
 
+permissions:
+  contents: read
+
 jobs:
   generate-changed-icons-comment:
     name: Generate Changed Icons Comment
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ on:
         description: Version
         required: true
 
+permissions: read-all
+
 jobs:
   pre-release:
     if: github.repository == 'lucide-icons/lucide' && contains('["ericfennis", "karsa-mistmere"]', github.actor)

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -4,12 +4,14 @@ on:
     types: [opened]
     paths: icons/*.svg
 
+permissions:
+  contents: read
+
 jobs:
   request-review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* When using dependency review on my own repos that use lucide icons, the scorecard result is coming out a little low
* As of the last time I checked the score was 2.9/10 and the low-barrier for these dependency checks tends to be 3/10
* This PR attemps to increase the OpenSSF scorecard result
* Following advice from the OpenSSF documentation on token-permissions
* [https://github.com/ossf/scorecard/blob/ab2f6e92482462fe66246d9e32f642855a691dc1/docs/checks.md#token-permissions](https://github.com/ossf/scorecard/blob/ab2f6e92482462fe66246d9e32f642855a691dc1/docs/checks.md#token-permissions)

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
