### PR TITLE
fix(icons): changed `podcast` icon

### DIFF
--- a/icons/podcast.json
+++ b/icons/podcast.json
@@ -3,7 +3,8 @@
   "contributors": [
     "iiaishwarya",
     "ericfennis",
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "audio",

--- a/icons/podcast.svg
+++ b/icons/podcast.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M13 17a1 1 0 1 0-2 0l.5 4.5a0.5 0.5 0 0 0 1 0z" />
   <path d="M16.85 18.58a9 9 0 1 0-9.7 0" />
   <path d="M8 14a5 5 0 1 1 8 0" />
-  <circle cx="12" cy="11" r="1" />
-  <path d="M13 17a1 1 0 1 0-2 0l.5 4.5a.5.5 0 1 0 1 0Z" />
+  <circle cx="12" cy="11" r="1" fill="currentColor" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Filled circle, resolves #3384

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.