### PR TITLE
fix(action): icon preview light and dark mode

### DIFF
--- a/docs/.vitepress/api/gh-icon/stroke-width/[...data].get.ts
+++ b/docs/.vitepress/api/gh-icon/stroke-width/[...data].get.ts
@@ -27,11 +27,11 @@ export default eventHandler((event) => {
       .replace(
         />/,
         `><style>
-        @media screen and (prefers-color-scheme: light) {
-          svg { fill: transparent !important; }
-        }
-        @media screen and (prefers-color-scheme: dark) {
-          svg { stroke: #fff; fill: transparent !important; }
+        :root { color-scheme: light dark }
+        svg { stroke: currentColor }
+        _::-webkit-full-page-media, _:future, :root svg {
+          stroke: #fff;
+          mix-blend-mode: difference;
         }
       </style>`,
       ),

--- a/docs/.vitepress/lib/SvgPreview/index.tsx
+++ b/docs/.vitepress/lib/SvgPreview/index.tsx
@@ -3,18 +3,24 @@ import { PathProps, Path } from './types';
 import { getPaths, assert } from './utils';
 
 export const darkModeCss = `
-  @media screen and (prefers-color-scheme: light) {
-    .svg-preview-grid-rect { fill: none }
+  :root { color-scheme: light dark }
+  .svg-preview-grid-rect { fill: none }
+  .svg
+  .svg-preview-grid-group,
+  .svg-preview-radii-group,
+  .svg-preview-shadow-mask-group,
+  .svg-preview-shadow-group {
+    stroke: currentColor;
   }
-  @media screen and (prefers-color-scheme: dark) {
-    .svg-preview-grid-rect { fill: none }
+  _::-webkit-full-page-media, _:future, :root :where(
     .svg
     .svg-preview-grid-group,
     .svg-preview-radii-group,
     .svg-preview-shadow-mask-group,
-    .svg-preview-shadow-group {
-      stroke: #fff;
-    }
+    .svg-preview-shadow-group
+  ) {
+    stroke: #fff;
+    mix-blend-mode: difference;
   }
 `;
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

Fixes #1489 properly, improving on #1493.

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Fix icon preview to display correctly, cross-browser, including a temporary [bug](https://bugs.webkit.org/show_bug.cgi?id=199134) fix for WebKit.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
