### PR TITLE
fix(icons): Changed `a-large-small` icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .now
 .idea
 .env
+.backup
+.screenshots
+.vectors
 node_modules
 dist
 build

--- a/icons/a-large-small.json
+++ b/icons/a-large-small.json
@@ -4,7 +4,8 @@
     "it-is-not",
     "jguddas",
     "danielbayley",
-    "ericfennis"
+    "ericfennis",
+    "vichotech"
   ],
   "tags": [
     "letter",

--- a/icons/a-large-small.svg
+++ b/icons/a-large-small.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M21 14h-5" />
-  <path d="M16 16v-3.5a2.5 2.5 0 0 1 5 0V16" />
-  <path d="M4.5 13h6" />
-  <path d="m3 16 4.5-9 4.5 9" />
+  <path d="m15 16 3-6 3 6" />
+  <path d="M15.5 15h5" />
+  <path d="m3 16 4-8 4 8" />
+  <path d="M4 14h6" />
 </svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] Other: Icon update.

## Description
The scale of the larger "A" was reduced to make it more consistent with the other icons where this symbol is used. The shape of the smaller "A" was modified to better convey the concept: a change from one size to another (avoiding confusion with a change from one character to another). The baseline of both characters was moved 1px lower to visually center the icon more effectively.

![before](https://github.com/user-attachments/assets/eec6065f-12bf-4aaa-bf84-61cf0b03049c)
![changes](https://github.com/user-attachments/assets/6e64ee09-f173-46f5-9b19-01abcb5adb4c)
![after](https://github.com/user-attachments/assets/692b5eaa-afeb-4998-8946-410d6ee727e0)

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
