### PR TITLE
fix(lucide-static): properly select icons dir for tags & error if no metadata found

### DIFF
--- a/packages/lucide-static/scripts/migrateIconsToTags.mts
+++ b/packages/lucide-static/scripts/migrateIconsToTags.mts
@@ -2,7 +2,9 @@ import path from 'path';
 import { writeFile, getCurrentDirPath, readAllMetadata } from '@lucide/helpers';
 
 const currentDir = getCurrentDirPath(import.meta.url);
-const ICONS_DIR = path.resolve(currentDir, '../icons');
+
+const PACKAGE_DIR = path.resolve(currentDir, '../');
+const ICONS_DIR = path.join(PACKAGE_DIR, '../../icons');
 const icons = await readAllMetadata(ICONS_DIR);
 
 const tags = Object.keys(icons)

--- a/tools/build-helpers/src/readAllMetadata.ts
+++ b/tools/build-helpers/src/readAllMetadata.ts
@@ -16,6 +16,9 @@ export const readAllMetadata = async (directory: string): Promise<Record<string,
     .map(async (file) => [path.basename(file, '.json'), await readMetadata(file, directory)]);
 
   const metadata = await Promise.all(metaDataPromises);
+  if (metadata.length === 0) {
+    throw new Error(`No metadata files found in directory: ${directory}`);
+  }
 
   return Object.fromEntries(metadata);
 };


### PR DESCRIPTION

<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
Fixes #3359
Throwing an error in readAllMetadata now to ensure this error can't happen again in the future. The error was caused by this script being moved to a different dir, but the relative url not being updated, causing no icons to be found.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [X] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [X] I've checked if there was an existing PR that solves the same issue.
