### PR TITLE
fix(docs): Icon Component Example for Svelte 5 does not compile

### DIFF
--- a/docs/guide/packages/lucide-svelte.md
+++ b/docs/guide/packages/lucide-svelte.md
@@ -296,7 +296,7 @@ The example below imports all ES Modules, so exercise caution when using it. Imp
 ```svelte [Svelte 5]
 <script>
   import * as icons from '@lucide/svelte';
-  let { name } = $props();
+  let { name, ...props } = $props();
 
   const Icon = icons[name];
 </script>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
The current example does not compile because `props` is not defined. This PR fixes that.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.
