### PR TITLE
fix(icons): changed `sword` icon

### DIFF
--- a/icons/sword.svg
+++ b/icons/sword.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="14.5 17.5 3 6 3 3 6 3 17.5 14.5" />
-  <line x1="13" x2="19" y1="19" y2="13" />
-  <line x1="16" x2="20" y1="16" y2="20" />
-  <line x1="19" x2="21" y1="21" y2="19" />
+  <path d="m11 19-6-6" />
+  <path d="m5 21-2-2" />
+  <path d="m8 16-4 4" />
+  <path d="M9.5 17.5 21 6V3h-3L6.5 14.5" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Flipped icon.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.