### PR TITLE
fix(icons): Refine `refresh-ccw-dot` to match other `refresh-` icons

### DIFF
--- a/icons/refresh-ccw-dot.json
+++ b/icons/refresh-ccw-dot.json
@@ -1,7 +1,10 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "csandman",
+    "ericfennis",
+    "danielbayley",
+    "jamiemlaw"
   ],
   "tags": [
     "arrows",

--- a/icons/refresh-ccw-dot.svg
+++ b/icons/refresh-ccw-dot.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M3 2v6h6" />
-  <path d="M21 12A9 9 0 0 0 6 5.3L3 8" />
-  <path d="M21 22v-6h-6" />
-  <path d="M3 12a9 9 0 0 0 15 6.7l3-2.7" />
+  <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+  <path d="M3 3v5h5" />
+  <path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
+  <path d="M16 16h5v5" />
   <circle cx="12" cy="12" r="1" />
 </svg>


### PR DESCRIPTION
## Description

Shortened the tips of the arrows to match the other icons.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
