### PR TITLE
fix(icons): changed `rocking-chair` icon

### DIFF
--- a/icons/rocking-chair.json
+++ b/icons/rocking-chair.json
@@ -2,12 +2,15 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "connium",
-    "ericfennis"
+    "ericfennis",
+    "jamiemlaw"
   ],
   "tags": [
     "chair",
     "furniture",
-    "seat"
+    "seat",
+    "comfort",
+    "relax"
   ],
   "categories": [
     "home"

--- a/icons/rocking-chair.svg
+++ b/icons/rocking-chair.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline points="3.5 2 6.5 12.5 18 12.5" />
-  <line x1="9.5" x2="5.5" y1="12.5" y2="20" />
-  <line x1="15" x2="18.5" y1="12.5" y2="20" />
-  <path d="M2.75 18a13 13 0 0 0 18.5 0" />
+  <path d="m15 13 3.708 7.416" />
+  <path d="M3 19a15 15 0 0 0 18 0" />
+  <path d="m3 2 3.21 9.633A2 2 0 0 0 8.109 13H18" />
+  <path d="m9 13-3.708 7.416" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Rounded the corner between the base and back of the chair, and pixel-align other areas.

Because the icon has many long straight lines, I have tried to optimise the angles of these lines for crispness rather than optimising the centres of arcs to lie on the grid.

## Alternative Designs:
With an arched back:

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Cpath+d=%22m15+13+3.708+7.416%22+/%3E%3Cpath+d=%22M3+19a15+15+0+0+0+18+0%22+/%3E%3Cpath+d=%22M3+2a15+15+0+0+1+3+9+2+2+0+0+0+2+2h10%22+/%3E%3Cpath+d=%22m9+13-3.708+7.416%22+/%3E&name=rocking-chair"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMTUgMTMgMy43MDggNy40MTYiIC8+CiAgPHBhdGggZD0iTTMgMTlhMTUgMTUgMCAwIDAgMTggMCIgLz4KICA8cGF0aCBkPSJNMyAyYTE1IDE1IDAgMCAxIDMgOSAyIDIgMCAwIDAgMiAyaDEwIiAvPgogIDxwYXRoIGQ9Im05IDEzLTMuNzA4IDcuNDE2IiAvPgo8L3N2Zz4=.svg"/><br/>Open lucide studio</a>

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.