### PR TITLE
feat(icons): add `app-window-sidebar` and `app-window-sidebar-right` icons

### DIFF
--- a/icons/app-window-sidebar-right.json
+++ b/icons/app-window-sidebar-right.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley",
+    "richardhenry"
+  ],
+  "tags": [
+    "application",
+    "pane",
+    "executable",
+    "sidebar",
+    "secondary"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development",
+    "files"
+  ]
+}

--- a/icons/app-window-sidebar-right.svg
+++ b/icons/app-window-sidebar-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M 16 4 L 16 20" />
+  <rect x="2" y="4" width="20" height="16" rx="2" />
+</svg>

--- a/icons/app-window-sidebar.json
+++ b/icons/app-window-sidebar.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley",
+    "richardhenry"
+  ],
+  "tags": [
+    "application",
+    "pane",
+    "executable",
+    "sidebar",
+    "secondary"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development",
+    "files"
+  ]
+}

--- a/icons/app-window-sidebar.svg
+++ b/icons/app-window-sidebar.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M 8 4 L 8 20" />
+  <rect x="2" y="4" width="20" height="16" rx="2" />
+</svg>


### PR DESCRIPTION
## Description
These icons are similar to `panel-left` and `panel-right`, but use a rectangular shape instead of a square one (same dimensions as `app-window` and `app-window-mac`). I find that this reads a lot better as an app sidebar open/close icon in a toolbar.

<img width="268" height="265" alt="Screenshot 2025-07-25 at 10 59 16 PM" src="https://github.com/user-attachments/assets/44f7bcd4-4ea7-44a7-80fa-cdcae826df2d" />
<img width="266" height="264" alt="Screenshot 2025-07-25 at 10 59 22 PM" src="https://github.com/user-attachments/assets/ed9099ad-11ad-4f62-bfd7-85541d0dde1f" />

Example of consistency with `app-window` and `app-window-mac` dimensions:

<img width="285" height="170" alt="Screenshot 2025-07-25 at 11 02 01 PM" src="https://github.com/user-attachments/assets/59c6a257-875a-4bc6-8e1c-5d7a3840a797" />

### Icon use case
I expect that people will generally use these icons to open/close a sidebar in a web app or Electron app.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: app-window and app-window-mac
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
