### PR TITLE
fix(icons): changed `arrow-down-to-dot` icon

### DIFF
--- a/icons/arrow-down-to-dot.json
+++ b/icons/arrow-down-to-dot.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "direction",

--- a/icons/arrow-down-to-dot.json
+++ b/icons/arrow-down-to-dot.json
@@ -2,7 +2,8 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "danielbayley",
-    "jguddas"
+    "jguddas",
+    "karsa-mistmere"
   ],
   "tags": [
     "direction",

--- a/icons/arrow-down-to-dot.svg
+++ b/icons/arrow-down-to-dot.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 2v14" />
-  <path d="m19 9-7 7-7-7" />
-  <circle cx="12" cy="21" r="1" />
+  <path d="M12 3v11L6 8.5" />
+  <path d="M18 8.5 12 14" />
+  <circle cx="12" cy="20" r="2" />
 </svg>

--- a/icons/arrow-down-to-dot.svg
+++ b/icons/arrow-down-to-dot.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 3v11L6 8.5" />
-  <path d="M18 8.5 12 14" />
+  <path d="M12 2v12" />
+  <path d="m18 8-6 6-6-6" />
   <circle cx="12" cy="20" r="2" />
 </svg>

--- a/icons/arrow-up-from-dot.json
+++ b/icons/arrow-up-from-dot.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "direction",

--- a/icons/arrow-up-from-dot.svg
+++ b/icons/arrow-up-from-dot.svg
@@ -9,7 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m5 9 7-7 7 7" />
-  <path d="M12 16V2" />
-  <circle cx="12" cy="21" r="1" />
+  <path d="M 12 3 L 12 14" />
+  <path d="M 12 3 L 6 8.5" />
+  <path d="M 18 8.5 L 12 3" />
+  <circle cx="12" cy="20" r="2" />
 </svg>

--- a/icons/arrow-up-to-dot.json
+++ b/icons/arrow-up-to-dot.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "colebemis",
+    "ericfennis",
+    "jguddas",
+    "karsa-mistmere"
+  ],
+  "tags": [
+    "forward",
+    "direction",
+    "north"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/arrow-up-to-dot.svg
+++ b/icons/arrow-up-to-dot.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 22V10" />
+  <path d="m6 16 6-6 6 6" />
+  <circle cx="12" cy="4" r="2" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Increased size of dot.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.