### PR TITLE
fix(lucide-vue-next): Support for kebabCase props

### DIFF
--- a/packages/lucide-vue-next/src/Icon.ts
+++ b/packages/lucide-vue-next/src/Icon.ts
@@ -9,12 +9,13 @@ interface IconProps {
 }
 
 const Icon: FunctionalComponent<LucideProps & IconProps> = (
-  {name, iconNode, ...props},
+  { name, iconNode, ...props },
   { slots },
 ) => {
   const size = props.size || defaultAttributes.width;
   const color = props.color || defaultAttributes.stroke;
-  const strokeWidth = props['strokeWidth'] || props['stroke-width'] || defaultAttributes['stroke-width'];
+  const strokeWidth =
+    props['strokeWidth'] || props['stroke-width'] || defaultAttributes['stroke-width'];
   const absoluteStrokeWidth = props['absoluteStrokeWidth'] || props['absolute-stroke-width'];
 
   return h(
@@ -25,7 +26,8 @@ const Icon: FunctionalComponent<LucideProps & IconProps> = (
       width: size,
       height: size,
       stroke: color,
-      'stroke-width': absoluteStrokeWidth != null ? (Number(strokeWidth) * 24) / Number(size) : strokeWidth,
+      'stroke-width':
+        absoluteStrokeWidth != null ? (Number(strokeWidth) * 24) / Number(size) : strokeWidth,
       class: mergeClasses(
         'lucide',
         props.class,

--- a/packages/lucide-vue-next/src/Icon.ts
+++ b/packages/lucide-vue-next/src/Icon.ts
@@ -9,24 +9,30 @@ interface IconProps {
 }
 
 const Icon: FunctionalComponent<LucideProps & IconProps> = (
-  { size, strokeWidth = 2, absoluteStrokeWidth, color, iconNode, name, class: classes, ...props },
+  {name, iconNode, ...props},
   { slots },
 ) => {
+  const size = props.size || defaultAttributes.width;
+  const color = props.color || defaultAttributes.stroke;
+  const strokeWidth = props['strokeWidth'] || props['stroke-width'] || defaultAttributes['stroke-width'];
+  const absoluteStrokeWidth = props['absoluteStrokeWidth'] || props['absolute-stroke-width'];
+
   return h(
     'svg',
     {
       ...defaultAttributes,
-      width: size || defaultAttributes.width,
-      height: size || defaultAttributes.height,
-      stroke: color || defaultAttributes.stroke,
-      'stroke-width': absoluteStrokeWidth ? (Number(strokeWidth) * 24) / Number(size) : strokeWidth,
+      ...props,
+      width: size,
+      height: size,
+      stroke: color,
+      'stroke-width': absoluteStrokeWidth != null ? (Number(strokeWidth) * 24) / Number(size) : strokeWidth,
       class: mergeClasses(
         'lucide',
+        props.class,
         ...(name
           ? [`lucide-${toKebabCase(toPascalCase(name))}-icon`, `lucide-${toKebabCase(name)}`]
           : ['lucide-icon']),
       ),
-      ...props,
     },
     [...iconNode.map((child) => h(...child)), ...(slots.default ? [slots.default()] : [])],
   );

--- a/packages/lucide-vue-next/src/createLucideIcon.ts
+++ b/packages/lucide-vue-next/src/createLucideIcon.ts
@@ -13,10 +13,11 @@ import Icon from './Icon';
  */
 const createLucideIcon =
   (iconName: string, iconNode: IconNode): FunctionalComponent<LucideProps> =>
-  (props, { slots }) =>
+  (props, { slots, attrs }) =>
     h(
       Icon,
       {
+        ...attrs,
         ...props,
         iconNode,
         name: iconName,

--- a/packages/lucide-vue-next/src/types.ts
+++ b/packages/lucide-vue-next/src/types.ts
@@ -1,9 +1,12 @@
 import type { FunctionalComponent, SVGAttributes } from 'vue';
 
+
+
 export interface LucideProps extends Partial<SVGAttributes> {
   size?: 24 | number;
   strokeWidth?: number | string;
   absoluteStrokeWidth?: boolean;
+  'absolute-stroke-width'?: boolean;
 }
 
 export type IconNode = [elementName: string, attrs: Record<string, string>][];

--- a/packages/lucide-vue-next/src/types.ts
+++ b/packages/lucide-vue-next/src/types.ts
@@ -1,7 +1,5 @@
 import type { FunctionalComponent, SVGAttributes } from 'vue';
 
-
-
 export interface LucideProps extends Partial<SVGAttributes> {
   size?: 24 | number;
   strokeWidth?: number | string;

--- a/packages/lucide-vue-next/tests/lucide-vue-next.spec.ts
+++ b/packages/lucide-vue-next/tests/lucide-vue-next.spec.ts
@@ -147,4 +147,36 @@ describe('Using lucide icon components', () => {
     expect(icon).toHaveAttribute('stroke', 'red');
     expect(icon).toHaveAttribute('stroke-width', '1');
   });
+
+  it('should not scale the strokeWidth when absoluteStrokeWidth is as empty value attribute', () => {
+    const { container } = render(Pen, {
+      props: {
+        size: 48,
+        color: 'red',
+        absoluteStrokeWidth: '',
+      },
+    });
+
+    const icon = container.firstElementChild;
+
+    expect(icon).toHaveAttribute('width', '48');
+    expect(icon).toHaveAttribute('stroke', 'red');
+    expect(icon).toHaveAttribute('stroke-width', '1');
+  });
+
+  it('should not scale the strokeWidth when absoluteStrokeWidth is written in kebabCase', () => {
+    const { container } = render(Pen, {
+      props: {
+        size: 48,
+        color: 'red',
+        'absolute-stroke-width': '',
+      },
+    });
+
+    const icon = container.firstElementChild;
+
+    expect(icon).toHaveAttribute('width', '48');
+    expect(icon).toHaveAttribute('stroke', 'red');
+    expect(icon).toHaveAttribute('stroke-width', '1');
+  });
 });


### PR DESCRIPTION
closes #3326
closes #3325
closes #3242

Adds support for kebabCase props in `lucide-vue-next`

```vue
<Eye :size="40" :stroke-width="1" :absolute-stroke-width="true" />
```