### PR TITLE
feat(icons): added `smartphone-down` and `smartphone-notch` icons

### DIFF
--- a/icons/smartphone-down.json
+++ b/icons/smartphone-down.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "../icon.schema.json",
+    "contributors": [
+      "tallneil"
+    ],
+    "tags": [
+      "phone",
+      "cellphone",
+      "device",
+      "screen", 
+      "iphone",
+      "download",
+      "import",
+      "export",
+      "app"
+    ],
+    "categories": [
+      "connectivity",
+      "devices",
+      "arrows"
+    ]
+  }
+  

--- a/icons/smartphone-down.svg
+++ b/icons/smartphone-down.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="14" height="20" x="5" y="2" rx="2" ry="2" />
+  <path d="M14 3L10 3"/>
+  <path d="M12 15V9"/>
+  <path d="M15 12L12 15L9 12"/>
+</svg>

--- a/icons/smartphone-notch.json
+++ b/icons/smartphone-notch.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "../icon.schema.json",
+    "contributors": [
+      "tallneil"
+    ],
+    "tags": [
+      "phone",
+      "cellphone",
+      "device",
+      "screen", 
+      "iphone"
+    ],
+    "categories": [
+      "connectivity",
+      "devices"
+    ]
+  }
+  

--- a/icons/smartphone-notch.svg
+++ b/icons/smartphone-notch.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="14" height="20" x="5" y="2" rx="2" ry="2" />
+  <path d="M14 3L10 3"/>
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Added 2 new smartphone icons: `smartphone-notch` and `smartphone-down`

### Icon use case <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
`smartphone` is an existing Lucide icon which represents a device with a physical home button. `smartphone-notch` represents a more modern device with no home button, and a notch at the top of the screen. This is useful for representing modern smartphones and apps.
`smartphone-down` represents downloading something related to a smartphone, for instance, downloading an app. This new icon complements the existing set of `-down` icons, including `monitor-down`, `folder-down`, and `file-down`. 

### Alternative icon designs <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- If you have any alternative icon designs, please attach them here. -->
N/A

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: <!-- provide the list of icons --> `smartphone`, `monitor-down`, `folder-down`, `file-down`
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
