### PR TITLE
feat(icons): added `list-chevrons-down-up` icon

### DIFF
--- a/icons/list-chevrons-down-up.json
+++ b/icons/list-chevrons-down-up.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "colebemis",
+    "ericfennis",
+    "ocavue",
+    "jguddas",
+    "PeterlitsZo",
+    "mittalyashu",
+    "juliankellydesign"
+  ],
+  "tags": [
+    "options",
+    "items",
+    "collapse",
+    "expand",
+    "details",
+    "disclosure",
+    "show",
+    "hide",
+    "toggle",
+    "accordion",
+    "more",
+    "less",
+    "fold",
+    "unfold",
+    "vertical"
+  ],
+  "categories": [
+    "text",
+    "arrows"
+  ]
+}

--- a/icons/list-chevrons-down-up.svg
+++ b/icons/list-chevrons-down-up.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m15 18 3-3 3 3" />
+  <path d="m15 6 3 3 3-3" />
+  <path d="M3 12h8" />
+  <path d="M3 18h8" />
+  <path d="M3 6h8" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `list-chevrons-down-up` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
We use this icon in collapsing many messages in the chat view, for instance if one is compacting with Claude Code. It references Figma's "collapse layers" action

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] The icons are solely my own creation.
- [x] The icons were originally created in #<issueNumber> by @colebemis
- [x] I've based them on the following Lucide icons: `list`, `list-collapse`, `chevrons-down-up`

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [ ] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [ ] I've made sure that the icons look sharp on low DPI displays.
- [ ] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [ ] I've made sure that the icons are visually centered.
- [ ] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.