### PR TITLE
feat(icons): added `square-square-dashed` icon

### DIFF
--- a/icons/square-square-dashed.json
+++ b/icons/square-square-dashed.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "colebemis",
+    "ericfennis",
+    "jguddas"
+  ],
+  "tags": [
+    "stop",
+    "playback",
+    "music",
+    "audio",
+    "video",
+    "rectangle",
+    "aspect ratio",
+    "1:1",
+    "shape",
+    "float",
+    "center"
+  ],
+  "categories": [
+    "shapes",
+    "multimedia",
+    "layout"
+  ]
+}

--- a/icons/square-square-dashed.json
+++ b/icons/square-square-dashed.json
@@ -6,21 +6,16 @@
     "jguddas"
   ],
   "tags": [
-    "stop",
-    "playback",
-    "music",
-    "audio",
-    "video",
-    "rectangle",
-    "aspect ratio",
-    "1:1",
+    "padding",
+    "margin",
     "shape",
     "float",
-    "center"
+    "center",
+    "expand",
+    "contract"
   ],
   "categories": [
     "shapes",
-    "multimedia",
     "layout"
   ]
 }

--- a/icons/square-square-dashed.json
+++ b/icons/square-square-dashed.json
@@ -3,19 +3,25 @@
   "contributors": [
     "colebemis",
     "ericfennis",
-    "jguddas"
+    "jguddas",
+    "irvineacosta"
   ],
   "tags": [
-    "padding",
-    "margin",
+    "stop",
+    "playback",
+    "music",
+    "audio",
+    "video",
+    "rectangle",
+    "aspect ratio",
+    "1:1",
     "shape",
     "float",
-    "center",
-    "expand",
-    "contract"
+    "center"
   ],
   "categories": [
     "shapes",
+    "multimedia",
     "layout"
   ]
 }

--- a/icons/square-square-dashed.svg
+++ b/icons/square-square-dashed.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 16H9a1 1 0 0 1-1-1v-1" />
+  <path d="M10 8H9a1 1 0 0 0-1 1v1" />
+  <path d="M14 8h1a1 1 0 0 1 1 1v1" />
+  <path d="M16 14v1a1 1 0 0 1-1 1h-1" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `square-square-dashed` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
To indicate something is expanding, useful in layout designers, etc.

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [ ] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.