### PR TITLE
fix(icons): changed `building` icon

### DIFF
--- a/icons/building.svg
+++ b/icons/building.svg
@@ -9,15 +9,15 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="16" height="20" x="4" y="2" rx="2" ry="2" />
-  <path d="M9 22v-4h6v4" />
-  <path d="M8 6h.01" />
-  <path d="M16 6h.01" />
-  <path d="M12 6h.01" />
   <path d="M12 10h.01" />
   <path d="M12 14h.01" />
+  <path d="M12 6h.01" />
   <path d="M16 10h.01" />
   <path d="M16 14h.01" />
+  <path d="M16 6h.01" />
   <path d="M8 10h.01" />
   <path d="M8 14h.01" />
+  <path d="M8 6h.01" />
+  <path d="M9 22v-3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3" />
+  <rect x="4" y="2" width="16" height="20" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Not a giant fix, just some more guideline compliant rounding of the entrance 

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.