### PR TITLE
chore(metadata): Added tags to `messages-square`

### DIFF
--- a/icons/messages-square.json
+++ b/icons/messages-square.json
@@ -12,7 +12,10 @@
     "feedback",
     "speech bubbles",
     "copy",
-    "multiple"
+    "multiple",
+    "discussion",
+    "interview",
+    "debate"
   ],
   "categories": [
     "social"


### PR DESCRIPTION
## Description

* Discussion - GitHub's discussions section uses this type of icon
* Interview - e.g. a category of content, alongside "article", "video", "podcast"
* Debate - in a similar vein to "interview"

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
