### PR TITLE
docs(): added official statement on brand logos in Lucide

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/01_icon_request.yml
@@ -7,8 +7,10 @@ body:
       value: |
         Before submitting an icon request check if it has already been requested. If there is an open request, please add a 👍.
 
-        **Important note**: No new brand logos are allowed, see https://github.com/lucide-icons/lucide/issues/670.
-        Existing brand icons will also be phased out. For brand icons, consider using https://simpleicons.org, which offers purpose-built SVGs that are also on a 24×24px grid.
+        > [!CAUTION]
+        > No new brand logos are allowed, see our official statement: https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md.
+        >
+        > Existing brand icons will also be phased out. For brand icons, consider using https://simpleicons.org, which offers purpose-built SVGs that are also on a 24×24px grid.
   - type: input
     id: name
     attributes:
@@ -41,7 +43,7 @@ body:
           required: true
         - label: I have searched existing icons to make sure it does not already exist and I didn't find any.
           required: true
-        - label: I am not requesting a brand logo and the art is not protected by copyright.
+        - label: I am not requesting a brand logo and the art is not protected by copyright, see more at https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md
           required: true
         - label: I am not requesting an icon that includes religious, war/violence related, political imagery or hate symbols.
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,8 +25,10 @@ Common scopes: icons, docs, studio, site, dev
 
 ### Concept <!-- ONLY for new icons -->
 <!-- All of these requirements must be fulfilled. -->
+<!-- IMPORTANT! Please read our official statement on brand logos in Lucide: -->
+<!-- https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md -->
 - [ ] I have provided valid use cases for each icon.
-- [ ] I have not added any a brand or logo icon.
+- [ ] I have [not added any a brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
 - [ ] I have not used any hate symbols.
 - [ ] I have not included any religious, war/violence related or political imagery.
 

--- a/BRAND_LOGOS_STATEMENT.md
+++ b/BRAND_LOGOS_STATEMENT.md
@@ -1,0 +1,83 @@
+# Our Official Stance on Including Brand Logos in Lucide
+
+## TL;DR
+
+Lucide **does not accept** brand logos, and we do not plan to add them in the future. This is due to a combination of **legal restrictions**, **design consistency concerns**, and **practical maintenance reasons**.
+
+If you need brand icons, we recommend [Simple Icons](https://simpleicons.org/), which provides an extensive, legally safer collection of brand marks in SVG format.
+
+---
+
+## 1. Historical Context
+
+This is not a new debate — other icon sets have gone through the same discussion:
+
+- **Material Design Icons** [deprecated all brand icon](https://github.com/Templarian/MaterialDesign/issues/6602) because they were not stylistically consistent, did not fit within a single-color / 24×24px grid in a recognisable way, and were a poor match for the overall set.
+- **Feather Icons** [reached a similar conclusion](https://github.com/feathericons/feather/issues/763): brand marks have their own design language, and trying to “Feather-ify” them inevitably leads to aesthetic compromises.
+- We at **Lucide** have learnt from these lessons and choose to focus on what Lucide does best — a cohesive, consistent set of non-brand icons.
+
+---
+
+## 2. Legal Considerations
+
+Most brand logos are:
+- **Protected by trademark or copyright**.
+- Bound by **strict brand guidelines** (color, proportions, spacing, etc.).
+- Explicitly **prohibited from being modified** — even though modification would be required to match Lucide's style.
+
+Because of this, adding brand icons would:
+
+1. Risk violating trademark or copyright.
+2. Place legal responsibility on both the **user** and the **Lucide project**.
+3. Force maintainers into case-by-case legal vetting for every new brand request — something we cannot realistically do.
+
+> **Note:** Simple Icons sidesteps these issues by keeping logos unmodified, in their official forms, but even they aren't exempt from [occasional legal struggles](https://github.com/simple-icons/simple-icons/issues/11236).
+
+---
+
+## 3. Design & Consistency
+
+Lucide is built around **visual consistency**.
+
+Including brand logos would mean:
+
+- Having to break our own design rules for shape, proportion, and stroke.
+- Mixing two fundamentally different categories of graphics (pictograms vs. corporate marks).
+- Creating a library where a subset of icons always looks "out of place".
+
+If the logos are not in Lucide's style, why include them in Lucide at all? Better to use them from a dedicated brand icon source.
+
+---
+
+## 4. Maintenance Burden
+
+Even with our current **"no brand icon requests"** rule, people still request them regularly.
+
+Having *any* brand icons in the set:
+
+- Signals that we might accept new ones.
+- Creates repeated, unproductive request cycles.
+- Wastes maintainer time redirecting people to the deprecation decision.
+
+Removing them entirely solves this problem.
+
+---
+
+## 5. Recommended Alternatives
+
+If you need brand icons:
+
+- [Simple Icons](https://simpleicons.org/) — Covers a huge range of brands, consistent SVG format, 24×24 viewBox.
+- Official brand asset pages: most major companies provide downloadable SVGs.
+
+You can mix these with Lucide in your project without bloating our core library.
+
+---
+
+## Final Word
+
+Lucide is an **icon** set, not a **logo** set.
+
+Logos belong in dedicated logo resources.
+
+We're focusing on what Lucide does best: providing a clean, cohesive, and legally safe set of open-source icons.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ For more info on how to contribute please see the [contribution guidelines](http
 
 Caught a mistake or want to contribute to the documentation? [Edit this page on Github](https://github.com/lucide-icons/lucide/blob/main/README.md)
 
+## About brand logos
+
+Lucide **does not accept** brand logos, and we do not plan to add them in the future. This is due to a combination of **legal restrictions**, **design consistency concerns**, and **practical maintenance reasons**.
+
+[Click here to read our official statement about brand logos in Lucide.](./BRAND_LOGOS.md)
+
 ## Community
 
 Join the community on our [Discord](https://discord.gg/EH6nSts) server!


### PR DESCRIPTION
## Description

I added an official statement clarifying Lucide's stance on brand logos, consolidating information that was previously scattered across multiple issues (most of them outside this repository).

The new document:
- Provides historical context from other icon sets (Material Icons, Feather Icons)
- Explains the legal, design, and maintenance reasons for not including brand logos
- Suggests recommended alternatives

Also:
- Updated the main README with a concise section on brand logos, linking to the full statement
- Updated the icon request template and pull request template to reference this policy directly

This makes our position clear, consistent, and easy to reference in future discussions.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
