### PR TITLE
feat(packages/lucide): added support for providing a custom root element

### DIFF
--- a/docs/guide/packages/lucide.md
+++ b/docs/guide/packages/lucide.md
@@ -92,7 +92,7 @@ In the `createIcons` function you can pass some extra parameters:
 
 - you can pass `nameAttr` to adjust the attribute name to replace for
 - you can pass `attrs` to pass additional custom attributes, for instance CSS classes or stroke options.
-- you can pass `context` to provide a custom DOM element the icons should be replaced in (useful when manipulating small sections of a large DOM or elements in the shadow DOM)
+- you can pass `root` to provide a custom DOM element the icons should be replaced in (useful when manipulating small sections of a large DOM or elements in the shadow DOM)
 
 Here is a full example:
 
@@ -106,7 +106,7 @@ createIcons({
     stroke: '#333'
   },
   nameAttr: 'data-lucide', // attribute for the icon name.
-  context: element, // DOM element to replace icons in.
+  root: element, // DOM element to replace icons in.
 });
 ```
 

--- a/packages/lucide/src/lucide.ts
+++ b/packages/lucide/src/lucide.ts
@@ -3,32 +3,32 @@ import * as iconAndAliases from './iconsAndAliases';
 
 /**
  * Replaces all elements with matching nameAttr with the defined icons
- * @param {{ icons?: object, nameAttr?: string, attrs?: object, context?: Element|Document }} options
+ * @param {{ icons?: object, nameAttr?: string, attrs?: object, root?: Element | Document }} options
  */
 const createIcons = ({
   icons = {},
   nameAttr = 'data-lucide',
   attrs = {},
-  context = document,
-}: { icons?: object; nameAttr?: string; attrs?: object; context?: Element|Document } = {}) => {
+  root = document,
+}: { icons?: object; nameAttr?: string; attrs?: object; root?: Element | Document } = {}) => {
   if (!Object.values(icons).length) {
     throw new Error(
       "Please provide an icons object.\nIf you want to use all the icons you can import it like:\n `import { createIcons, icons } from 'lucide';\nlucide.createIcons({icons});`",
     );
   }
 
-  if (typeof context === 'undefined') {
+  if (typeof root === 'undefined') {
     throw new Error('`createIcons()` only works in a browser environment.');
   }
 
-  const elementsToReplace = context.querySelectorAll(`[${nameAttr}]`);
+  const elementsToReplace = root.querySelectorAll(`[${nameAttr}]`);
   Array.from(elementsToReplace).forEach((element) =>
     replaceElement(element, { nameAttr, icons, attrs }),
   );
 
   /** @todo: remove this block in v1.0 */
   if (nameAttr === 'data-lucide') {
-    const deprecatedElements = context.querySelectorAll('[icon-name]');
+    const deprecatedElements = root.querySelectorAll('[icon-name]');
     if (deprecatedElements.length > 0) {
       console.warn(
         '[Lucide] Some icons were found with the now deprecated icon-name attribute. These will still be replaced for backwards compatibility, but will no longer be supported in v1.0 and you should switch to data-lucide',

--- a/packages/lucide/tests/lucide.spec.ts
+++ b/packages/lucide/tests/lucide.spec.ts
@@ -33,7 +33,7 @@ describe('createIcons', () => {
     const context = document.querySelector('#context')!;
     createIcons({
       icons,
-      context,
+      root: context,
     });
 
     const hasSvg = !!document.querySelector('svg.lucide-volume-2');


### PR DESCRIPTION
closes #3537

## Description

Added support for providing a custom root element to `createIcons` in `lucide`, for better performance when updating small parts of the DOM.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
