### PR TITLE
fix(icons): changed `a-arrow-*` icons

### DIFF
--- a/icons/a-arrow-down.svg
+++ b/icons/a-arrow-down.svg
@@ -10,7 +10,7 @@
   stroke-linejoin="round"
 >
   <path d="m14 12 4 4 4-4" />
-  <path d="M18 16V7" />
+  <path d="M18 6v10" />
   <path d="m2 16 4.039-9.69a.5.5 0 0 1 .923 0L11 16" />
   <path d="M3.304 13h6.392" />
 </svg>

--- a/icons/a-arrow-up.svg
+++ b/icons/a-arrow-up.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m14 11 4-4 4 4" />
-  <path d="M18 16V7" />
+  <path d="m14 10 4-4v10" />
+  <path d="m18 6 4 4" />
   <path d="m2 16 4.039-9.69a.5.5 0 0 1 .923 0L11 16" />
   <path d="M3.304 13h6.392" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Changed arrow height to match A.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.