### PR TITLE
fix(icons): arcified `square-m` icon

### DIFF
--- a/icons/square-m.json
+++ b/icons/square-m.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "metro",

--- a/icons/square-m.svg
+++ b/icons/square-m.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="18" height="18" x="3" y="3" rx="2" />
-  <path d="M8 16V8l4 4 4-4v8" />
+  <path d="M8 15V9.707a.707.707 0 0 1 1.207-.5l1.94 1.94a1.207 1.207 0 0 0 1.707 0l1.94-1.94a.707.707 0 0 1 1.206.5V15" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Arcified icon.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.