### PR TITLE
fix(icons): changed `chart-no-axes-combined` icon

### DIFF
--- a/icons/chart-no-axes-combined.json
+++ b/icons/chart-no-axes-combined.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "statistics",

--- a/icons/chart-no-axes-combined.svg
+++ b/icons/chart-no-axes-combined.svg
@@ -10,9 +10,9 @@
   stroke-linejoin="round"
 >
   <path d="M12 16v5" />
-  <path d="M16 14v7" />
-  <path d="M20 10v11" />
+  <path d="M16 14.639V21" />
+  <path d="M20 10.656V21" />
   <path d="m22 3-8.646 8.646a.5.5 0 0 1-.708 0L9.354 8.354a.5.5 0 0 0-.707 0L2 15" />
-  <path d="M4 18v3" />
-  <path d="M8 14v7" />
+  <path d="M4 18.463V21" />
+  <path d="M8 14.656V21" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Fixed 2px gap violation.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.