### PR TITLE
fix(packages/lucide): replace elements inside `<template>` (#2635)

### DIFF
--- a/packages/lucide/src/lucide.ts
+++ b/packages/lucide/src/lucide.ts
@@ -21,10 +21,13 @@ const createIcons = ({
     throw new Error('`createIcons()` only works in a browser environment.');
   }
 
-  const elementsToReplace = root.querySelectorAll(`[${nameAttr}]`);
-  Array.from(elementsToReplace).forEach((element) =>
-    replaceElement(element, { nameAttr, icons, attrs }),
-  );
+  const elementsToReplace = Array.from(root.querySelectorAll(`[${nameAttr}]`));
+  const templates = Array.from(root.querySelectorAll('template'));
+  templates.forEach((template) => {
+    const contentToReplace = Array.from(template.content.querySelectorAll(`[${nameAttr}]`));
+    elementsToReplace.push.apply(elementsToReplace, contentToReplace);
+  });
+  elementsToReplace.forEach((element) => replaceElement(element, { nameAttr, icons, attrs }));
 
   /** @todo: remove this block in v1.0 */
   if (nameAttr === 'data-lucide') {


### PR DESCRIPTION
closes #2635
## Description
Find and replace elements inside `<template>` tags that are not normally selected with `document.querySelector`

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
