### PR TITLE
feat(icons): added `cheese` icon

### DIFF
--- a/icons/cheese.json
+++ b/icons/cheese.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "MattGeiger"
+  ],
+  "tags": [
+    "dairy",
+    "milk",
+    "cheese",
+    "swiss",
+    "wedge",
+    "food",
+    "edible",
+    "lactose"
+  ],
+  "categories": [
+    "dairy",
+    "milk",
+    "cheese",
+    "food",
+    "grocery",
+    "edible"
+  ]
+}

--- a/icons/cheese.json
+++ b/icons/cheese.json
@@ -5,20 +5,17 @@
   ],
   "tags": [
     "dairy",
-    "milk",
     "cheese",
     "swiss",
     "wedge",
     "food",
     "edible",
-    "lactose"
+    "lactose",
+    "cheddar",
+    "trap",
+    "mouse"
   ],
   "categories": [
-    "dairy",
-    "milk",
-    "cheese",
-    "food",
-    "grocery",
-    "edible"
+    "food & beverage"
   ]
 }

--- a/icons/cheese.svg
+++ b/icons/cheese.svg
@@ -1,16 +1,17 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
+  width="26"
+  height="26"
+  viewBox="0 0 26 26"
   fill="none"
   stroke="currentColor"
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M20 9a2 2 0 0 0 0 4v5L4 20v-3a2 2 0 0 0 0-4V9l5-6s7 0 11 4z" />
-  <path d="m4 9 16-2" />
-  <circle cx="10" cy="16" r="2" />
-  <circle cx="14" cy="11" r="2" />
+  <path d="M13 16a1 1 0 0 1 1 1" />
+  <path d="M15 11.5a2 2 0 0 1 2 2" />
+  <path d="M3 14a2 2 0 0 1 0 4v5l20-3v-5a2 2 0 0 1 0-4V6L3 9z" />
+  <path d="m3 9 6-6s8-.5 14 3" />
+  <path d="M8 12.5a1 1 0 0 1 1 1" />
 </svg>

--- a/icons/cheese.svg
+++ b/icons/cheese.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 9a2 2 0 0 0 0 4v5L4 20v-3a2 2 0 0 0 0-4V9l5-6s7 0 11 4z" />
+  <path d="m4 9 16-2" />
+  <circle cx="10" cy="16" r="2" />
+  <circle cx="14" cy="11" r="2" />
+</svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `cheese` icon.

### Icon use case

This expands the set of Food & Beverage category icons available in Lucide.

My use is for a nonprofit food pantry inventory system, where the food category "dairy" needed a more generalized icon beyond the current option of a milk bottle.

Food & Beverage categorization: In applications beyond food pantry databases, we can imagine grocery apps, or other food inventory systems, where a cheese wedge is a clearer, more direct representation of dairy than the existing milk bottle icon.

Wayfinding & illustration: The cheese wedge can be used in maze illustrations, maps, and playful designs (e.g., traps or treasure hunts).

Metaphorical use: Beyond food, the icon can represent goals, rewards, baits in trapping systems, or “the prize at the end,” making it versatile in abstract or gamified contexts.

### Alternative icon designs

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license

- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.