### PR TITLE
feat(icons): added `tournament-bracket` icon

### DIFF
--- a/icons/tournament-bracket.json
+++ b/icons/tournament-bracket.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "casey-j-r"
+  ],
+  "tags": [
+    "tournament",
+    "bracket",
+    "sports",
+    "competition",
+    "pairings",
+    "round-robin",
+    "knockout"
+  ],
+  "categories": [
+    "sports"
+  ]
+}

--- a/icons/tournament-bracket.json
+++ b/icons/tournament-bracket.json
@@ -4,6 +4,13 @@
     "casey-j-r"
   ],
   "tags": [
+    "control",
+    "structure",
+    "progression",
+    "elimination",
+    "single-elimination",
+    "playoffs",
+    "matchup",
     "tournament",
     "bracket",
     "sports",

--- a/icons/tournament-bracket.svg
+++ b/icons/tournament-bracket.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12.5 6h7.75c.97 0 1.75.94 1.75 2.24v7.27c0 1.31-.78 2.36-1.75 2.36H12.5" />
+  <path d="M2 13.89h7.75c.75.11 1.75.71 1.75 1.58v4.85c0 .87-.78 1.58-1.75 1.58H2" />
+  <path d="M2 2.12h7.75c.97 0 1.75.71 1.75 1.58v4.85c0 1.45-.78 1.58-1.75 1.58H2" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `tournament-bracket` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
For sports-specific apps which have pages which deal with tournament/knockout brackets.

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [ ] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [ ] I've made sure that the icons look sharp on low DPI displays.
- [ ] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [ ] I've made sure that the icons are visually centered.
- [ ] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.