### PR TITLE
docs(site): add introductions for packages in documentation

### DIFF
--- a/docs/guide/packages/lucide-angular.md
+++ b/docs/guide/packages/lucide-angular.md
@@ -1,6 +1,13 @@
 # Lucide Angular
 
-Implementation of the lucide icon library for Angular applications.
+Angular components and services for Lucide icons that integrate with Angular's dependency injection and component system. Provides both traditional module-based and modern standalone component approaches for maximum flexibility in Angular applications.
+
+**What you can accomplish:**
+- Use icons as Angular components with full dependency injection support
+- Configure icons globally through Angular services and providers
+- Choose from multiple component selectors (lucide-angular, lucide-icon, i-lucide, span-lucide)
+- Integrate with Angular's reactive forms and data binding
+- Build scalable applications with tree-shaken icon bundles and lazy loading support
 
 ## Installation
 

--- a/docs/guide/packages/lucide-astro.md
+++ b/docs/guide/packages/lucide-astro.md
@@ -1,6 +1,13 @@
 # Lucide Astro
 
-Implementation of the lucide icon library for Astro applications.
+Astro components for Lucide icons that work perfectly with Astro's island architecture and multi-framework support. Each icon is an Astro component that renders as an inline SVG, providing excellent performance for static sites and server-side rendering scenarios.
+
+**What you can accomplish:**
+- Use icons as Astro components with zero JavaScript runtime overhead
+- Build fast, static websites with optimized SVG icons
+- Integrate seamlessly with Astro's component islands and partial hydration
+- Create multi-framework applications where icons work across different UI libraries
+- Optimize performance with direct icon imports and build-time rendering
 
 ## Installation
 

--- a/docs/guide/packages/lucide-preact.md
+++ b/docs/guide/packages/lucide-preact.md
@@ -4,7 +4,14 @@ title: Lucide Preact
 
 # Lucide Preact
 
-Implementation of the lucide icon library for preact applications.
+Preact components for Lucide icons that provide React-like development experience with a smaller footprint. Each icon is a lightweight Preact component that renders as an inline SVG, perfect for applications that need React compatibility with minimal bundle size.
+
+**What you can accomplish:**
+- Use icons as Preact components with React-like syntax and patterns
+- Build lightweight applications with Preact's smaller runtime
+- Create fast, responsive interfaces with minimal JavaScript overhead
+- Maintain React compatibility while reducing bundle size
+- Integrate with existing Preact applications and component libraries
 
 ## Installation
 

--- a/docs/guide/packages/lucide-react-native.md
+++ b/docs/guide/packages/lucide-react-native.md
@@ -1,6 +1,13 @@
 # Lucide React Native
 
-Implementation of the lucide icon library for React Native applications
+React Native components for Lucide icons that work seamlessly across iOS and Android platforms. Built on top of react-native-svg, each icon renders as a native SVG component, providing consistent visual appearance and performance across mobile devices.
+
+**What you can accomplish:**
+- Use icons as React Native components with platform-consistent rendering
+- Build cross-platform mobile apps with scalable vector icons
+- Create responsive interfaces that adapt to different screen densities
+- Integrate with React Native's styling system and animation libraries
+- Maintain consistent icon appearance across iOS and Android platforms
 
 ## Installation
 

--- a/docs/guide/packages/lucide-react.md
+++ b/docs/guide/packages/lucide-react.md
@@ -1,6 +1,13 @@
 # Lucide React
 
-Implementation of the lucide icon library for react applications
+React components for Lucide icons that integrate seamlessly into your React applications. Each icon is a fully-typed React component that renders as an optimized inline SVG, giving you the flexibility of components with the performance of vector graphics.
+
+**What you can accomplish:**
+- Import icons as React components with full TypeScript support
+- Pass props to customize size, color, stroke width, and other SVG attributes
+- Use icons in JSX with the same ease as any other React component
+- Benefit from automatic tree-shaking to include only the icons you use
+- Create dynamic icon components that respond to state and user interactions
 
 ## Installation
 

--- a/docs/guide/packages/lucide-solid.md
+++ b/docs/guide/packages/lucide-solid.md
@@ -1,6 +1,13 @@
 # Lucide Solid
 
-Implementation of the lucide icon library for solid applications.
+SolidJS components for Lucide icons that leverage Solid's fine-grained reactivity system. Each icon is a reactive Solid component that renders as an inline SVG, providing exceptional performance through Solid's compile-time optimizations and reactive primitives.
+
+**What you can accomplish:**
+- Use icons as SolidJS components with fine-grained reactivity
+- Create highly performant interfaces with Solid's reactive system
+- Build dynamic icon components that respond to signals and stores
+- Integrate seamlessly with Solid's JSX and component patterns
+- Optimize performance with direct icon imports and minimal runtime overhead
 
 ## Installation
 

--- a/docs/guide/packages/lucide-static.md
+++ b/docs/guide/packages/lucide-static.md
@@ -1,5 +1,14 @@
 # Lucide Static
 
+Static assets and utilities for Lucide icons that work without JavaScript frameworks. This package provides multiple formats including individual SVG files, SVG sprites, icon fonts, and Node.js utilities for server-side rendering and static site generation.
+
+**What you can accomplish:**
+- Use individual SVG files as images or CSS background images
+- Implement icon fonts for CSS-based icon systems
+- Create SVG sprites for efficient icon loading in static sites
+- Import SVG strings in Node.js applications and server-side rendering
+- Build static websites and applications without JavaScript framework dependencies
+
 This package includes the following implementations of Lucide icons:
 
 - Individual SVG files

--- a/docs/guide/packages/lucide-svelte.md
+++ b/docs/guide/packages/lucide-svelte.md
@@ -1,6 +1,13 @@
 # Lucide Svelte
 
-Implementation of the lucide icon library for svelte applications.
+Svelte components for Lucide icons that work seamlessly with both Svelte 4 and Svelte 5. Each icon is a reactive Svelte component that renders as an inline SVG, providing excellent performance and integration with Svelte's reactive system and modern features.
+
+**What you can accomplish:**
+- Use icons as Svelte components with full reactivity and TypeScript support
+- Bind icon properties to reactive variables and stores
+- Create dynamic icon systems that respond to application state
+- Build type-safe interfaces with comprehensive TypeScript definitions
+- Optimize bundle sizes with direct icon imports and tree-shaking
 
 ## Installation
 

--- a/docs/guide/packages/lucide-vue-next.md
+++ b/docs/guide/packages/lucide-vue-next.md
@@ -1,6 +1,13 @@
 # Lucide Vue Next
 
-Implementation of the lucide icon library for Vue 3 applications.
+Vue 3 components for Lucide icons that leverage the Composition API and modern Vue features. Each icon is a reactive Vue component that renders as an inline SVG, providing excellent performance and developer experience in Vue 3 applications.
+
+**What you can accomplish:**
+- Use icons as Vue 3 components with full reactivity and TypeScript support
+- Bind icon properties to reactive data and computed values
+- Customize icons with props, slots, and Vue's powerful templating system
+- Integrate seamlessly with Vue 3's Composition API and script setup syntax
+- Build dynamic interfaces where icons respond to application state changes
 
 ## Installation
 

--- a/docs/guide/packages/lucide-vue.md
+++ b/docs/guide/packages/lucide-vue.md
@@ -1,6 +1,13 @@
 # Lucide Vue
 
-Implementation of the lucide icon library for Vue applications.
+Vue 2 components for Lucide icons that integrate with Vue's Options API and template system. Each icon is a Vue component that renders as an inline SVG, providing familiar Vue development patterns for legacy applications still using Vue 2.
+
+**What you can accomplish:**
+- Use icons as Vue 2 components with Options API integration
+- Maintain legacy Vue 2 applications with modern icon components
+- Integrate with Vue 2's template system and component lifecycle
+- Build applications using Vue 2's familiar syntax and patterns
+- Bridge the gap while planning migration to Vue 3
 
 ::: danger
 This package is deprecated. Vue 2 is EOF  See [Announcement](https://v2.vuejs.org/eol/). Migrate to Vue 3.

--- a/docs/guide/packages/lucide.md
+++ b/docs/guide/packages/lucide.md
@@ -1,6 +1,13 @@
 # Lucide
 
-Implementation of the lucide icon library for web applications.
+The core Lucide package for vanilla JavaScript applications. This package allows you to easily add scalable vector icons to any web project without framework dependencies. Perfect for static websites, legacy applications, or when you need lightweight icon integration with maximum browser compatibility.
+
+**What you can accomplish:**
+- Add icons to HTML using simple data attributes
+- Dynamically create and insert SVG icons with JavaScript
+- Customize icon appearance with CSS classes and inline styles
+- Tree-shake unused icons to keep bundle sizes minimal
+- Use icons in any JavaScript environment or plain HTML
 
 ## Installation
 


### PR DESCRIPTION
## Description
This PR adds short, practical introductions for each package in the Lucide documentation.  
Instead of only listing installation instructions, the new sections explain what each package can accomplish and how developers can use them effectively.

Closes #378

### Changes
- Added introductory descriptions for all packages in `docs/index.md`
- Focused on usage-oriented guidance rather than installation only
- Highlighted framework-specific benefits and real-world applications
- Kept formatting consistent and maintained a clear, professional tone
