### PR TITLE
feat(icons): add orthognal square-arrow-out icons and square-arrow-in icons for all directions

### DIFF
--- a/icons/square-arrow-in-down-left.json
+++ b/icons/square-arrow-in-down-left.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "inwards",
+    "direction",
+    "south-west",
+    "collapse",
+    "exit",
+    "close",
+    "return"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-in-down-left.svg
+++ b/icons/square-arrow-in-down-left.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M11 7v6h6" />
+  <path d="m20 4-9 9" />
+  <path d="M21 8.5V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h10.5" />
+</svg>

--- a/icons/square-arrow-in-down-right.json
+++ b/icons/square-arrow-in-down-right.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "inwards",
+    "direction",
+    "south-east"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-in-down-right.svg
+++ b/icons/square-arrow-in-down-right.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13 7v6H7" />
+  <path d="m4 4 9 9" />
+  <path d="M8.5 3H19a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8.5" />
+</svg>

--- a/icons/square-arrow-in-down.json
+++ b/icons/square-arrow-in-down.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "inwards",
+    "direction",
+    "south",
+    "input",
+    "download",
+    "press"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-in-down.svg
+++ b/icons/square-arrow-in-down.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 2v11" />
+  <path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3" />
+  <path d="m8 9 4 4 4-4" />
+</svg>

--- a/icons/square-arrow-in-left.json
+++ b/icons/square-arrow-in-left.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "inwards",
+    "direction",
+    "west",
+    "reverse",
+    "back"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-in-left.svg
+++ b/icons/square-arrow-in-left.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m15 8-4 4 4 4" />
+  <path d="M21 16v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v3" />
+  <path d="M22 12H11" />
+</svg>

--- a/icons/square-arrow-in-right.json
+++ b/icons/square-arrow-in-right.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "inwards",
+    "direction",
+    "west",
+    "input",
+    "enter"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-in-right.svg
+++ b/icons/square-arrow-in-right.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 12h11" />
+  <path d="M3 8V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-3" />
+  <path d="m9 8 4 4-4 4" />
+</svg>

--- a/icons/square-arrow-in-up-left.json
+++ b/icons/square-arrow-in-up-left.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "inwards",
+    "direction",
+    "north-west"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-in-up-left.svg
+++ b/icons/square-arrow-in-up-left.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15.5 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10.5" />
+  <path d="M17 11h-6v6" />
+  <path d="m20 20-9-9" />
+</svg>

--- a/icons/square-arrow-in-up-right.json
+++ b/icons/square-arrow-in-up-right.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "inwards",
+    "direction",
+    "north-east"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-in-up-right.svg
+++ b/icons/square-arrow-in-up-right.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13 17v-6H7" />
+  <path d="M3 15.5V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H8.5" />
+  <path d="m4 20 9-9" />
+</svg>

--- a/icons/square-arrow-in-up.json
+++ b/icons/square-arrow-in-up.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "inwards",
+    "direction",
+    "north",
+    "project"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-in-up.svg
+++ b/icons/square-arrow-in-up.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 22V11" />
+  <path d="m8 15 4-4 4 4" />
+  <path d="M8 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3" />
+</svg>

--- a/icons/square-arrow-out-down.json
+++ b/icons/square-arrow-out-down.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "outwards",
+    "direction",
+    "south",
+    "pour",
+    "empty"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-out-down.svg
+++ b/icons/square-arrow-out-down.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 22.5V12" />
+  <path d="M5 21a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2" />
+  <path d="m8 18.5 4 4 4-4" />
+</svg>

--- a/icons/square-arrow-out-left.json
+++ b/icons/square-arrow-out-left.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "outwards",
+    "direction",
+    "west",
+    "back",
+    "reverse"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-out-left.svg
+++ b/icons/square-arrow-out-left.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m1.5 12 4-4" />
+  <path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2" />
+  <path d="m5.5 16-4-4H12" />
+</svg>

--- a/icons/square-arrow-out-right.json
+++ b/icons/square-arrow-out-right.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "outwards",
+    "direction",
+    "east",
+    "output",
+    "exit"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-out-right.svg
+++ b/icons/square-arrow-out-right.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m18.5 16 4-4H12" />
+  <path d="M21 19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2" />
+  <path d="m22.5 12-4-4" />
+</svg>

--- a/icons/square-arrow-out-up.json
+++ b/icons/square-arrow-out-up.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "6teloiv"
+  ],
+  "tags": [
+    "outwards",
+    "direction",
+    "north",
+    "upload",
+    "share"
+  ],
+  "categories": [
+    "arrows",
+    "navigation"
+  ]
+}

--- a/icons/square-arrow-out-up.svg
+++ b/icons/square-arrow-out-up.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 1.5V12" />
+  <path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2" />
+  <path d="m8 5.5 4-4 4 4" />
+</svg>


### PR DESCRIPTION
closes #3614

### Icon use case

All of these collectively can be used in a grid or window UI for expanding/contracting into/from neighboring cells. Think splitting and merging panes in a code editor, or a dashboard ui with buttons for resizing.

Additionally, some have more specific usages:

- `square-arrow-out-up`: alternative upload icon, share icon (iOS style)
- `square-arrow-in-down`: alternative download icon
- `square-arrow-in-up`: project to a screen
- `square-arrow-in-down-left`: collapse, return floating pane (to an editor, for example)
- `square-arrow-in-right`: data or flow input
- `square-arrow-out-right`: data or flow output

### Alternative icon designs

For most of these, I've offset them to be visually centered and to have a similar feel for how much the pierce the edge of the square. While the existing "square-arrow-out" icons are exactly aligned with the center/edge of the square, these rounding of the arrow doesn't match that of the square, meaning it appears to piece the shape slightly, so I've tried to keep that feel.

These could be changed if anyone feels they don't look balanced.

## Icon Design Checklist

### Concept <!-- ONLY for new icons -->
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: square-arrow-out-up-left, square-arrow-out-up-right, square-arrow-out-down-left, square-arrow-out-down-right
- [x] I've based them on the following design: https://github.com/lucide-icons/lucide/pull/3615

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue: There is, #3615, but I belive this is a more complete approach.
