### PR TITLE
feat(icons): added `banknote-check` icon

### DIFF
--- a/icons/banknote-check.json
+++ b/icons/banknote-check.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "ericfennis",
+    "mittalyashu",
+    "AnnaSasDev",
+    "joffx",
+    "colebemis",
+    "clapann"
+  ],
+  "tags": [
+    "currency",
+    "money",
+    "payment",
+    "bill",
+    "funds",
+    "transaction",
+    "cash",
+    "finance",
+    "error",
+    "failed",
+    "rejected",
+    "canceled",
+    "declined",
+    "lost",
+    "delete",
+    "remove",
+    "done",
+    "todo",
+    "tick",
+    "complete",
+    "task"
+  ],
+  "categories": [
+    "finance"
+  ]
+}

--- a/icons/banknote-check.svg
+++ b/icons/banknote-check.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13 18H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5" />
+  <path d="m17 18.5 2 2 3-3.5" />
+  <path d="M18 12h.01" />
+  <path d="M6 12h.01" />
+  <circle cx="12" cy="12" r="2" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
closes #3645 

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `banknote-check` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
- Approved Payments
- Cleared Check
- Validated Transfer
- Cash Accepted
- Money Accepted

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [x] The icons were originally created in #2949 by @joffx
- [x] I've based them on the following Lucide icons: `banknote`, `banknote-x`, `check`
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.