### PR TITLE
feat (icons): add 26 ui page builder icons

### DIFF
--- a/icons/align-horizontal-space-evenly.json
+++ b/icons/align-horizontal-space-evenly.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "items",
+    "flex",
+    "justify",
+    "distribute",
+    "spacing",
+    "evenly",
+    "css",
+    "flexbox"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/align-horizontal-space-evenly.svg
+++ b/icons/align-horizontal-space-evenly.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 22V2" />
+  <path d="M22 22V2" />
+  <rect width="4" height="9" x="14" y="7" rx="1" />
+  <rect width="4" height="16" x="6" y="4" rx="1" />
+</svg>

--- a/icons/align-stretch-horizontal.json
+++ b/icons/align-stretch-horizontal.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "items",
+    "flex",
+    "justify",
+    "stretch",
+    "width",
+    "css",
+    "flexbox"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/align-stretch-horizontal.svg
+++ b/icons/align-stretch-horizontal.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 22h20" />
+  <path d="M2 2h20" />
+  <rect width="6" height="12" x="14" y="6" rx="2" />
+  <rect width="6" height="12" x="4" y="6" rx="2" />
+</svg>

--- a/icons/align-stretch-vertical.json
+++ b/icons/align-stretch-vertical.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "items",
+    "flex",
+    "justify",
+    "stretch",
+    "height",
+    "css",
+    "flexbox"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/align-stretch-vertical.svg
+++ b/icons/align-stretch-vertical.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 2v20" />
+  <path d="M22 22V2" />
+  <rect width="12" height="6" x="6" y="14" rx="2" />
+  <rect width="12" height="6" x="6" y="4" rx="2" />
+</svg>

--- a/icons/align-vertical-space-evenly.json
+++ b/icons/align-vertical-space-evenly.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "items",
+    "flex",
+    "justify",
+    "distribute",
+    "spacing",
+    "evenly",
+    "css",
+    "flexbox"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/align-vertical-space-evenly.svg
+++ b/icons/align-vertical-space-evenly.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 22H2" />
+  <path d="M22 2H2" />
+  <rect width="16" height="4" x="4" y="14" rx="1" />
+  <rect width="9" height="4" x="7" y="6" rx="1" />
+</svg>

--- a/icons/border-radius-bottom-left.json
+++ b/icons/border-radius-bottom-left.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "border",
+    "radius",
+    "corner",
+    "round",
+    "rounded",
+    "style",
+    "design",
+    "css",
+    "bottom-left"
+  ],
+  "categories": [
+    "design",
+    "development",
+    "layout"
+  ]
+}

--- a/icons/border-radius-bottom-left.svg
+++ b/icons/border-radius-bottom-left.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 18h-8a4 4 0 0 1-4-4V6" />
+</svg>

--- a/icons/border-radius-bottom-right.json
+++ b/icons/border-radius-bottom-right.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "border",
+    "radius",
+    "corner",
+    "round",
+    "rounded",
+    "style",
+    "design",
+    "css",
+    "bottom-right"
+  ],
+  "categories": [
+    "design",
+    "development",
+    "layout"
+  ]
+}

--- a/icons/border-radius-bottom-right.svg
+++ b/icons/border-radius-bottom-right.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 6v8a4 4 0 0 1-4 4H6" />
+</svg>

--- a/icons/border-radius-top-left.json
+++ b/icons/border-radius-top-left.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "border",
+    "radius",
+    "corner",
+    "round",
+    "rounded",
+    "style",
+    "design",
+    "css",
+    "top-left"
+  ],
+  "categories": [
+    "design",
+    "development",
+    "layout"
+  ]
+}

--- a/icons/border-radius-top-left.svg
+++ b/icons/border-radius-top-left.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 18v-8a4 4 0 0 1 4-4h8" />
+</svg>

--- a/icons/border-radius-top-right.json
+++ b/icons/border-radius-top-right.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "border",
+    "radius",
+    "corner",
+    "round",
+    "rounded",
+    "style",
+    "design",
+    "css",
+    "top-right"
+  ],
+  "categories": [
+    "design",
+    "development",
+    "layout"
+  ]
+}

--- a/icons/border-radius-top-right.svg
+++ b/icons/border-radius-top-right.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 6h8a4 4 0 0 1 4 4v8" />
+</svg>

--- a/icons/border.json
+++ b/icons/border.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "border",
+    "outline",
+    "stroke",
+    "style",
+    "design",
+    "css",
+    "frame",
+    "box"
+  ],
+  "categories": [
+    "design",
+    "development",
+    "layout"
+  ]
+}

--- a/icons/border.svg
+++ b/icons/border.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 4H4" />
+  <rect width="16" height="5" x="4" y="15" rx="1" />
+  <rect width="16" height="3" x="4" y="8" rx="1" />
+</svg>

--- a/icons/gap-horizontal.json
+++ b/icons/gap-horizontal.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "gap",
+    "spacing",
+    "space",
+    "flex",
+    "grid",
+    "horizontal",
+    "css",
+    "layout"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/gap-horizontal.svg
+++ b/icons/gap-horizontal.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 3h-2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h2M3 21h2.118C6.158 21 7 20.105 7 19V5c0-1.105-.843-2-1.882-2H3m9 17V4" />
+</svg>

--- a/icons/gap-vertical.json
+++ b/icons/gap-vertical.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "gap",
+    "spacing",
+    "space",
+    "flex",
+    "grid",
+    "vertical",
+    "css",
+    "layout"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/gap-vertical.svg
+++ b/icons/gap-vertical.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 21v-2a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v2M3 3v2.118C3 6.158 3.895 7 5 7h14c1.105 0 2-.843 2-1.882V3M4 12h16" />
+</svg>

--- a/icons/margin-bottom.json
+++ b/icons/margin-bottom.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "margin",
+    "spacing",
+    "layout",
+    "css",
+    "bottom",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/margin-bottom.svg
+++ b/icons/margin-bottom.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 22H2" />
+  <rect width="10" height="10" x="7" y="7" rx="2" />
+</svg>

--- a/icons/margin-horizontal.json
+++ b/icons/margin-horizontal.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "margin",
+    "spacing",
+    "layout",
+    "css",
+    "horizontal",
+    "left",
+    "right",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/margin-horizontal.svg
+++ b/icons/margin-horizontal.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 2v20" />
+  <path d="M22 2v20" />
+  <rect width="10" height="10" x="7" y="7" rx="2" />
+</svg>

--- a/icons/margin-left.json
+++ b/icons/margin-left.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "margin",
+    "spacing",
+    "layout",
+    "css",
+    "left",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/margin-left.svg
+++ b/icons/margin-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 2v20" />
+  <rect width="10" height="10" x="7" y="7" rx="2" />
+</svg>

--- a/icons/margin-right.json
+++ b/icons/margin-right.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "margin",
+    "spacing",
+    "layout",
+    "css",
+    "right",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/margin-right.svg
+++ b/icons/margin-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 2v20" />
+  <rect width="10" height="10" x="7" y="7" rx="2" />
+</svg>

--- a/icons/margin-top.json
+++ b/icons/margin-top.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "margin",
+    "spacing",
+    "layout",
+    "css",
+    "top",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/margin-top.svg
+++ b/icons/margin-top.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 2H2" />
+  <rect width="10" height="10" x="7" y="7" rx="2" />
+</svg>

--- a/icons/margin-vertical.json
+++ b/icons/margin-vertical.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "margin",
+    "spacing",
+    "layout",
+    "css",
+    "vertical",
+    "top",
+    "bottom",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/margin-vertical.svg
+++ b/icons/margin-vertical.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 22H2" />
+  <path d="M22 2H2" />
+  <rect width="10" height="10" x="7" y="7" rx="2" />
+</svg>

--- a/icons/margin.json
+++ b/icons/margin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "margin",
+    "spacing",
+    "layout",
+    "css",
+    "all",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/margin.svg
+++ b/icons/margin.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M19 22H5" />
+  <path d="M19 2H5" />
+  <path d="M2 5v14" />
+  <path d="M22 5v14" />
+  <rect width="10" height="10" x="7" y="7" rx="2" />
+</svg>

--- a/icons/padding-bottom.json
+++ b/icons/padding-bottom.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "padding",
+    "spacing",
+    "layout",
+    "css",
+    "bottom",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/padding-bottom.svg
+++ b/icons/padding-bottom.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 17H6" />
+  <rect width="20" height="20" x="2" y="2" rx="2" />
+</svg>

--- a/icons/padding-horizontal.json
+++ b/icons/padding-horizontal.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "padding",
+    "spacing",
+    "layout",
+    "css",
+    "horizontal",
+    "left",
+    "right",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/padding-horizontal.svg
+++ b/icons/padding-horizontal.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M17 7v10" />
+  <path d="M7 7v10" />
+  <rect width="20" height="20" x="2" y="2" rx="2" />
+</svg>

--- a/icons/padding-left.json
+++ b/icons/padding-left.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "padding",
+    "spacing",
+    "layout",
+    "css",
+    "left",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/padding-left.svg
+++ b/icons/padding-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7 7v10" />
+  <rect width="20" height="20" x="2" y="2" rx="2" />
+</svg>

--- a/icons/padding-right.json
+++ b/icons/padding-right.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "padding",
+    "spacing",
+    "layout",
+    "css",
+    "right",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/padding-right.svg
+++ b/icons/padding-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M17 7v10" />
+  <rect width="20" height="20" x="2" y="2" rx="2" />
+</svg>

--- a/icons/padding-top.json
+++ b/icons/padding-top.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "padding",
+    "spacing",
+    "layout",
+    "css",
+    "top",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/padding-top.svg
+++ b/icons/padding-top.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 7H6" />
+  <rect width="20" height="20" x="2" y="2" rx="2" />
+</svg>

--- a/icons/padding-vertical.json
+++ b/icons/padding-vertical.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "padding",
+    "spacing",
+    "layout",
+    "css",
+    "vertical",
+    "top",
+    "bottom",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/padding-vertical.svg
+++ b/icons/padding-vertical.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7 17h10" />
+  <path d="M7 7h10" />
+  <rect width="20" height="20" x="2" y="2" rx="2" />
+</svg>

--- a/icons/padding.json
+++ b/icons/padding.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "padding",
+    "spacing",
+    "layout",
+    "css",
+    "all",
+    "space"
+  ],
+  "categories": [
+    "layout",
+    "design",
+    "development"
+  ]
+}

--- a/icons/padding.svg
+++ b/icons/padding.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 17h4" />
+  <path d="M10 7h4" />
+  <path d="M17 10v4" />
+  <path d="M7 10v4" />
+  <rect width="20" height="20" x="2" y="2" rx="2" />
+</svg>

--- a/icons/shadow.json
+++ b/icons/shadow.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "katarinasava"
+  ],
+  "tags": [
+    "shadow",
+    "effect",
+    "css",
+    "style",
+    "design",
+    "elevation",
+    "depth"
+  ],
+  "categories": [
+    "design",
+    "development",
+    "layout"
+  ]
+}

--- a/icons/shadow.svg
+++ b/icons/shadow.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 21h16" />
+  <rect width="18" height="14" x="3" y="3" rx="2" />
+</svg>


### PR DESCRIPTION
<img width="967" height="1376" alt="Screenshot 2025-10-02 at 16 31 47" src="https://github.com/user-attachments/assets/89e3765b-e7ad-4342-9f6c-253309ebd1a9" />

## Description
This PR adds a set of 26 icons designed for editor interfaces:
- `align-stretch-vertical`
- `align-vertical-space-evenly`
- `align-stretch-horizontal`
- `align-horizontal-space-evenly`
- `gap-horizontal`
- `gap-vertical`
- `margin`
- `margin-vertical`
- `margin-horizontal`
- `margin-top`
- `margin-right`
- `margin-bottom`
- `margin-left`
- `padding`
- `padding-horizontal`
- `padding-vertical`
- `padding-top`
- `padding-right`
- `padding-bottom`
- `padding-left`
- `border-radius-top-left`
- `border-radius-top-right`
- `border-radius-bottom-right`
- `border-radius-bottom-left`
- `border`
- `shadow`

### Icon use case
All icons added are designed to be used in a UI page builder tools or page editors.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons are solely my own creation.
- [x] I've based them on the following Lucide icons:
  - `align-center-vertical`
  - `align-center-horizontal`
  - `align-vertical-space-between`
  - `align-horizontal-space-between`

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
