### PR TITLE
feat(icons): add VS Code `squircle` base shape snippet

### DIFF
--- a/.vscode/svg.code-snippets
+++ b/.vscode/svg.code-snippets
@@ -51,6 +51,16 @@
     ],
     "body": "<circle cx=\"${2:12}\" cy=\"${3:$2}\" r=\"${1|10,2,.5\" fill=\"currentColor|}\" />"
   },
+  "Squircle": {
+    "scope": "xml",
+    "description": "SVG `path` with Lucide defaults.",
+    "prefix": [
+      "squircle",
+      "path",
+      "<path"
+    ],
+    "body": "<path d=\"M12 3c7.2 0 9 1.8 9 9s-1.8 9-9 9-9-1.8-9-9 1.8-9 9-9\" />"
+  },
   "Ellipse": {
     "scope": "xml",
     "description": "SVG `ellipse`.",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Add [`squircle`](https://lucide.dev/icons/squircle) to VS Code base shape snippets.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [ ] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.
