### PR TITLE
Fix default prop

### DIFF
--- a/packages/lucide/src/lucide.ts
+++ b/packages/lucide/src/lucide.ts
@@ -20,7 +20,7 @@ const createIcons = ({
   attrs = {},
   root = document,
   inTemplates,
-}: CreateIconsOptions) => {
+}: CreateIconsOptions = {}) => {
   if (!Object.values(icons).length) {
     throw new Error(
       "Please provide an icons object.\nIf you want to use all the icons you can import it like:\n `import { createIcons, icons } from 'lucide';\nlucide.createIcons({icons});`",


### PR DESCRIPTION
Fixes the UMD build Lucide package.

Accidentally removed the default prop of the `createIcons` function in https://github.com/lucide-icons/lucide/pull/3576.

