### PR TITLE
fix(docs): Replace `pnpm install` with `pnpm add` across documentation.

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -11,7 +11,7 @@ Implementation of the lucide icon library for web applications.
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide
+pnpm add lucide
 ```
 
 ```sh [yarn]
@@ -37,7 +37,7 @@ Implementation of the lucide icon library for React applications.
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-react
+pnpm add lucide-react
 ```
 
 ```sh [yarn]
@@ -64,7 +64,7 @@ Implementation of the lucide icon library for Vue applications.
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-vue-next
+pnpm add lucide-vue-next
 ```
 
 ```sh [yarn]
@@ -91,7 +91,7 @@ Implementation of the lucide icon library for Svelte applications.
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-svelte
+pnpm add lucide-svelte
 ```
 
 ```sh [yarn]
@@ -117,7 +117,7 @@ Implementation of the lucide icon library for Solid applications.
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-solid
+pnpm add lucide-solid
 ```
 
 ```sh [yarn]
@@ -143,7 +143,7 @@ Implementation of the lucide icon library for Angular applications.
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-angular
+pnpm add lucide-angular
 ```
 
 ```sh [yarn]
@@ -169,7 +169,7 @@ Implementation of the lucide icon library for preact applications.
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-preact
+pnpm add lucide-preact
 ```
 
 ```sh [yarn]
@@ -196,7 +196,7 @@ Implementation of the lucide icon library for Astro applications.
 ::: code-group
 
 ```sh [pnpm]
-pnpm install @lucide/astro
+pnpm add @lucide/astro
 ```
 
 ```sh [yarn]
@@ -222,7 +222,7 @@ Implementation of the lucide icon library for multiple usages that like to use: 
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-static
+pnpm add lucide-static
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide-angular.md
+++ b/docs/guide/packages/lucide-angular.md
@@ -14,7 +14,7 @@ Angular components and services for Lucide icons that integrate with Angular's d
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-angular
+pnpm add lucide-angular
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide-preact.md
+++ b/docs/guide/packages/lucide-preact.md
@@ -18,7 +18,7 @@ Preact components for Lucide icons that provide React-like development experienc
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-preact
+pnpm add lucide-preact
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide-react-native.md
+++ b/docs/guide/packages/lucide-react-native.md
@@ -16,7 +16,7 @@ First, ensure that you have `react-native-svg` (version between 12 and 15) insta
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-react-native
+pnpm add lucide-react-native
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide-react.md
+++ b/docs/guide/packages/lucide-react.md
@@ -14,7 +14,7 @@ React components for Lucide icons that integrate seamlessly into your React appl
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-react
+pnpm add lucide-react
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide-solid.md
+++ b/docs/guide/packages/lucide-solid.md
@@ -14,7 +14,7 @@ SolidJS components for Lucide icons that leverage Solid's fine-grained reactivit
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-solid
+pnpm add lucide-solid
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide-static.md
+++ b/docs/guide/packages/lucide-static.md
@@ -45,7 +45,7 @@ For production environments, we recommend using a bundler with tree-shaking supp
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-static
+pnpm add lucide-static
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide-vue-next.md
+++ b/docs/guide/packages/lucide-vue-next.md
@@ -14,7 +14,7 @@ Vue 3 components for Lucide icons that leverage the Composition API and modern V
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-vue-next
+pnpm add lucide-vue-next
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide-vue.md
+++ b/docs/guide/packages/lucide-vue.md
@@ -18,7 +18,7 @@ This package is deprecated. Vue 2 is EOF  See [Announcement](https://v2.vuejs.or
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide-vue
+pnpm add lucide-vue
 ```
 
 ```sh [yarn]

--- a/docs/guide/packages/lucide.md
+++ b/docs/guide/packages/lucide.md
@@ -16,7 +16,7 @@ The core Lucide package for vanilla JavaScript applications. This package allows
 ::: code-group
 
 ```sh [pnpm]
-pnpm install lucide
+pnpm add lucide
 ```
 
 ```sh [yarn]


### PR DESCRIPTION
<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
This PR updates installation examples across the Lucide documentation to use `pnpm add` instead of `pnpm install`.

According to the [official pnpm documentation](https://pnpm.io/cli/add), `pnpm add` is the correct command for adding new dependencies, while `pnpm install` is intended for installing existing ones listed in `package.json`.

This change improves accuracy and consistency for pnpm users.

- closes #3734 

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
