### PR TITLE
feat(icons): add naira-sign currency icon

### DIFF
--- a/icons/naira-sign.json
+++ b/icons/naira-sign.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "eberechia"
+  ],
+  "tags": [
+    "currency",
+    "money",
+    "payment",
+    "naira",
+    "nigeria",
+    "NGN"
+  ],
+  "categories": [
+    "finance"
+  ]
+}

--- a/icons/naira-sign.svg
+++ b/icons/naira-sign.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <line x1="6" x2="6" y1="3" y2="21" />
+  <line x1="18" x2="18" y1="3" y2="21" />
+  <line x1="6" x2="18" y1="4" y2="20" />
+  <line x1="3" x2="21" y1="9" y2="9" />
+  <line x1="3" x2="21" y1="15" y2="15" />
+</svg>


### PR DESCRIPTION

# Add Naira Sign Currency Icon

## Description
This PR adds the `naira-sign` icon to represent the Nigerian Naira (₦) currency symbol, complementing the existing currency icons in Lucide (dollar-sign, euro, pound-sterling, indian-rupee, japanese-yen, etc.).

## Icon Preview
The Naira sign (₦) consists of:
- Two vertical parallel lines (representing the letter 'N' from Nigeria)
- One diagonal line connecting them (forming the 'N' shape)
- Two horizontal bars crossing through (similar to dollar sign's bar)

```
    ₦
```

## Motivation
Nigeria is Africa's largest economy with a population of over 200 million people. The Naira (NGN) is a major African currency, yet Lucide currently lacks representation for it while including other major world currencies.

### Use Cases
- Financial applications serving Nigerian/African markets
- E-commerce platforms accepting Naira payments
- Banking and fintech applications
- Educational platforms (like school management systems)
- Multi-currency dashboards and analytics
- Payment processing interfaces

## Implementation Details

### SVG Structure
The icon follows Lucide's design guidelines:
- ✅ 24x24 pixel canvas
- ✅ 2-pixel stroke width
- ✅ Round stroke caps and joins
- ✅ No transforms or filters
- ✅ Visually centered
- ✅ Consistent with other currency icons
- ✅ Proper element spacing (2px)

### Icon Elements
```svg
<line x1="6" x2="6" y1="3" y2="21" />      <!-- Left vertical line -->
<line x1="18" x2="18" y1="3" y2="21" />    <!-- Right vertical line -->
<line x1="6" x2="18" y1="20" y2="4" />     <!-- Diagonal (N shape) -->
<line x1="3" x2="21" y1="9" y2="9" />      <!-- Top horizontal bar -->
<line x1="3" x2="21" y1="15" y2="15" />    <!-- Bottom horizontal bar -->
```

### Metadata (naira-sign.json)
- **Category**: Finance
- **Tags**: currency, money, payment, naira, nigeria, NGN
- **Contributors**: eberechia

## Design Consistency
The icon design is consistent with existing Lucide currency icons:
- Matches the visual weight of `dollar-sign`, `euro`, `indian-rupee`
- Uses simple geometric shapes (lines)
- Maintains optical balance
- Follows the same structural approach as `indian-rupee` (horizontal lines + symbol structure)

## Checklist
- [x] Icon follows [Lucide design guidelines](https://lucide.dev/docs/icon-design-guide)
- [x] SVG file created with proper formatting
- [x] JSON metadata file created
- [x] Icon name follows kebab-case convention
- [x] Icon is categorized correctly (finance)
- [x] Appropriate tags added
- [x] No brand logo (this is a currency symbol)
- [x] Icon is visually centered
- [x] 24x24 canvas with proper padding
- [x] 2px stroke width with round caps/joins

## Testing
Once merged, the icon will be available as:
```tsx
// React
import { NairaSign } from 'lucide-react';
<NairaSign />

// Vue
import { NairaSign } from 'lucide-vue-next';

// Other frameworks...
```

## Related Icons
This icon complements:
- `dollar-sign`
- `euro`
- `pound-sterling`
- `indian-rupee`
- `japanese-yen`
- `russian-ruble`
- `bitcoin`

## Impact
Adding this icon will:
- Enable better localization for Nigerian applications
- Support the growing African tech ecosystem
- Complete the major world currency collection
- Benefit 200+ million Naira users globally

---

**Note**: This icon was created for use in a Nigerian school management system (SchoolIT Pro) where displaying Naira currency is essential. Making it available to the broader Lucide community will help other developers building for African markets.
