### PR TITLE
feat(preview-comment): add symmetry preview

### DIFF
--- a/docs/.vitepress/api/gh-icon/symmetry/[...data].get.ts
+++ b/docs/.vitepress/api/gh-icon/symmetry/[...data].get.ts
@@ -1,0 +1,55 @@
+import { eventHandler, setResponseHeader, defaultContentType } from 'h3';
+import { renderToString } from 'react-dom/server';
+import { createElement } from 'react';
+import Diff from '../../../lib/SvgPreview/Diff.tsx';
+
+export default eventHandler((event) => {
+  const { params } = event.context;
+
+  const pathData = params.data.split('/');
+  const data = pathData.at(-1).slice(0, -4);
+  const [operation] = pathData;
+
+  const newSrc = Buffer.from(data, 'base64')
+    .toString('utf8')
+    .replaceAll('\n', '')
+    .replace(/<svg[^>]*>|<\/svg>/g, '');
+
+  const width = parseInt(
+    (newSrc.includes('<svg ') ? newSrc.match(/width="(\d+)"/)?.[1] : null) ?? '24',
+  );
+  const height = parseInt(
+    (newSrc.includes('<svg ') ? newSrc.match(/height="(\d+)"/)?.[1] : null) ?? '24',
+  );
+
+  const children = [];
+
+  let oldSrc = '';
+  if (operation.startsWith('rotate-')) {
+    const degrees = parseInt(operation.replace('rotate-', ''));
+    if (isNaN(degrees)) return '';
+    oldSrc = `<g transform="rotate(${degrees} ${width / 2} ${height / 2})">${newSrc}</g>`;
+  } else if (operation === 'flip-horizontal') {
+    oldSrc = `<g transform="scale(1, -1) translate(0, -${height})">${newSrc}</g>`;
+  } else if (operation === 'flip-vertical') {
+    oldSrc = `<g transform="scale(-1, 1) translate(-${width}, 0)">${newSrc}</g>`;
+  } else if (operation === 'flip-backslash') {
+    oldSrc = `<g transform="rotate(90, ${width / 2}, ${height / 2}) scale(1, -1) translate(0, -${height})">${newSrc}</g>`;
+  } else if (operation === 'flip-slash') {
+    oldSrc = `<g transform="rotate(90, ${width / 2}, ${height / 2}) scale(-1, 1) translate(-${width}, 0)">${newSrc}</g>`;
+  } else {
+    return '';
+  }
+
+  const svg = Buffer.from(
+    // We can't use jsx here, is not supported here by nitro.
+    renderToString(
+      createElement(Diff, { oldSrc, newSrc, showGrid: true, height, width }, children),
+    ),
+  ).toString('utf8');
+
+  defaultContentType(event, 'image/svg+xml');
+  setResponseHeader(event, 'Cache-Control', 'public,max-age=31536000');
+
+  return svg;
+});

--- a/scripts/generateChangedIconsCommentMarkup.mts
+++ b/scripts/generateChangedIconsCommentMarkup.mts
@@ -52,7 +52,8 @@ const getImageTagsByFiles = (
 const svgFiles = await readSvgDirectory(ICONS_DIR);
 const svgFilePaths = svgFiles.map((file) => `icons/${file}`);
 
-const iconsFilteredByName = (search: string) => svgFilePaths.filter((file) => file.includes(search));
+const iconsFilteredByName = (search: string) =>
+  svgFilePaths.filter((file) => file.includes(search));
 
 const cohesionRandomImageTags = getImageTagsByFiles(
   shuffleArray(svgFilePaths).slice(0, changedFiles.length),
@@ -120,6 +121,30 @@ const changeFilesDiffImageTags = getImageTagsByFiles(
   400,
 ).join(' ');
 
+const changeFilesSymmetryImageTagsRotate180 = getImageTagsByFiles(
+  changedFiles,
+  () => `${BASE_URL}/symmetry/rotate-180`,
+  400,
+).join(' ');
+
+const changeFilesSymmetryImageTagsFlipHorizontal = getImageTagsByFiles(
+  changedFiles,
+  () => `${BASE_URL}/symmetry/flip-horizontal`,
+  400,
+).join(' ');
+
+const changeFilesSymmetryImageTagsFlipVertical = getImageTagsByFiles(
+  changedFiles,
+  () => `${BASE_URL}/symmetry/flip-vertical`,
+  400,
+).join(' ');
+
+const changeFilesSymmetryImageTagsFlipSlash = getImageTagsByFiles(
+  changedFiles,
+  () => `${BASE_URL}/symmetry/flip-slash`,
+  400,
+).join(' ');
+
 const readyToUseCode = changedFiles
   .map((changedFile) => {
     const svgContent = fs.readFileSync(path.join(process.cwd(), changedFile), 'utf-8');
@@ -177,6 +202,17 @@ ${changeFilesXRayImageTags}
 <details>
 <summary>Icon Diffs</summary>
 ${changeFilesDiffImageTags}
+</details>
+<details>
+<summary>Icon Symmetry</summary>
+<h4>Flip Horizontal</h4>
+${changeFilesSymmetryImageTagsFlipHorizontal}
+<h4>Flip Vertical</h4>
+${changeFilesSymmetryImageTagsFlipVertical}
+<h4>Flip Diagonal</h4>
+${changeFilesSymmetryImageTagsFlipSlash}
+<h4>Rotate 180°</h4>
+${changeFilesSymmetryImageTagsRotate180}
 </details>
 <details>
 <summary>Icons as code</summary>


### PR DESCRIPTION
## Description

### Base

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Cpath+d=%22M13+21h8%22+/%3E%3Cpath+d=%22M21.174+6.812a1+1+0+0+0-3.986-3.987L3.842+16.174a2+2+0+0+0-.5.83l-1.321+4.352a.5.5+0+0+0+.623.622l4.353-1.32a2+2+0+0+0+.83-.497z%22+/%3E&name=pen-line"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTMgMjFoOCIgLz4KICA8cGF0aCBkPSJNMjEuMTc0IDYuODEyYTEgMSAwIDAgMC0zLjk4Ni0zLjk4N0wzLjg0MiAxNi4xNzRhMiAyIDAgMCAwLS41LjgzbC0xLjMyMSA0LjM1MmEuNS41IDAgMCAwIC42MjMuNjIybDQuMzUzLTEuMzJhMiAyIDAgMCAwIC44My0uNDk3eiIgLz4KPC9zdmc+.svg"/><br/>Open lucide studio</a>

### `rotate-180`

<img width="122" height="124" alt="image" src="https://github.com/user-attachments/assets/35c0c201-fcf1-4167-84d5-1dd6ef904bb9" />



### `flip-horizontal`

<img width="128" height="132" alt="image" src="https://github.com/user-attachments/assets/a5df19ff-b393-49cb-a758-7ace231e9e7b" />

### `flip-vertical`

<img width="124" height="122" alt="image" src="https://github.com/user-attachments/assets/b75ea1f7-e551-4ce8-aff1-f3afc4c56ce7" />

### `flip-slash`
<img width="128" height="128" alt="image" src="https://github.com/user-attachments/assets/00f59aff-f804-4bdf-b81d-96ef056116cd" />



