### PR TITLE
feat(scripts): Enable icons dir in CLI arguments

### DIFF
--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -16,7 +16,7 @@ export type SVGAttributes = HTMLAttributes<'svg'>;
 
 export type IconNode = IconNodeChild[];
 
-type IconNodeChild = [elementName: SVGElements, attrs: SVGAttributes];
+type IconNodeChild = [elementName: SVGElements, attrs: SVGAttributes, children: IconNodeChild[]];
 
 // All possible svg elements according to the Astro definitions
 type SVGElements =

--- a/packages/lucide-angular/src/icons/types/index.ts
+++ b/packages/lucide-angular/src/icons/types/index.ts
@@ -1,5 +1,5 @@
 type HtmlAttributes = { [key: string]: string | number };
-export type LucideIconNode = readonly [string, HtmlAttributes];
+export type LucideIconNode = readonly [string, HtmlAttributes, LucideIconData];
 export type LucideIconData = readonly LucideIconNode[];
 export type LucideIcons = { [key: string]: LucideIconData };
 

--- a/packages/lucide-angular/src/lib/lucide-angular.component.spec.ts
+++ b/packages/lucide-angular/src/lib/lucide-angular.component.spec.ts
@@ -11,7 +11,7 @@ describe('LucideAngularComponent', () => {
   const getSvgAttribute = (attr: string) =>
     testHostFixture.nativeElement.querySelector('svg').getAttribute(attr);
   const testIcons: LucideIcons = {
-    Demo: [['polyline', { points: '1 1 22 22' }]],
+    Demo: [['polyline', { points: '1 1 22 22' }, []]],
   };
 
   beforeEach(async () => {

--- a/packages/lucide-react/src/types.ts
+++ b/packages/lucide-react/src/types.ts
@@ -10,12 +10,13 @@ type SVGElementType =
   | 'ellipse'
   | 'g'
   | 'line'
+  | 'mask'
   | 'path'
   | 'polygon'
   | 'polyline'
   | 'rect';
 
-export type IconNode = [elementName: SVGElementType, attrs: Record<string, string>][];
+export type IconNode = [elementName: SVGElementType, attrs: Record<string, string>, children: IconNode][];
 
 export type SVGAttributes = Partial<SVGProps<SVGSVGElement>>;
 type ElementAttributes = RefAttributes<SVGSVGElement> & SVGAttributes;

--- a/packages/lucide-solid/src/types.ts
+++ b/packages/lucide-solid/src/types.ts
@@ -1,6 +1,6 @@
 import { JSX } from 'solid-js/jsx-runtime';
 
-export type IconNode = [elementName: keyof JSX.IntrinsicElements, attrs: Record<string, string>][];
+export type IconNode = [elementName: keyof JSX.IntrinsicElements, attrs: Record<string, string>, children: IconNode][];
 export type SVGAttributes = Partial<JSX.SvgSVGAttributes<SVGSVGElement>>;
 
 export interface LucideProps extends SVGAttributes {

--- a/packages/lucide-vue/scripts/exportTemplate.mjs
+++ b/packages/lucide-vue/scripts/exportTemplate.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import base64SVG from '@lucide/build-icons/utils/base64SVG.mjs';
+import base64SVG from '@lucide/build-icons/utils/base64SVG';
 
 export default async ({
   componentName,

--- a/packages/lucide/src/types.ts
+++ b/packages/lucide/src/types.ts
@@ -1,5 +1,5 @@
 // className is not supported in svg elements
 export type SVGProps = Record<string, string | number>;
 
-export type IconNode = [tag: string, attrs: SVGProps][];
+export type IconNode = [tag: string, attrs: SVGProps, children: IconNode][];
 export type Icons = { [key: string]: IconNode };

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -3,7 +3,7 @@ import type { Snippet } from 'svelte';
 
 export type Attrs = SVGAttributes<SVGSVGElement>;
 
-export type IconNode = [elementName: keyof SvelteHTMLElements, attrs: Attrs][];
+export type IconNode = [elementName: keyof SvelteHTMLElements, attrs: Attrs, children: IconNode][];
 
 export interface IconProps extends Attrs {
   name?: string;

--- a/tools/build-icons/cli.ts
+++ b/tools/build-icons/cli.ts
@@ -32,12 +32,13 @@ interface CliArguments {
   aliasesFileExtension?: string;
   aliasImportFileExtension?: string;
   pretty?: boolean;
+  icons?: string;
   output: string | undefined;
 }
 
 const cliArguments = getArgumentOptions(process.argv.slice(2)) as unknown as CliArguments;
 
-const ICONS_DIR = path.resolve(process.cwd(), '../../icons');
+const ICONS_DIR = path.resolve(process.cwd(), cliArguments.icons || '../../icons');
 const OUTPUT_DIR = path.resolve(process.cwd(), cliArguments.output || '../build');
 
 if (!fs.existsSync(OUTPUT_DIR)) {

--- a/tools/build-icons/types.ts
+++ b/tools/build-icons/types.ts
@@ -4,12 +4,12 @@ export type SVGProps = Record<string, string | number>;
 
 export type IconNode = [tag: string, attrs: SVGProps][];
 
-export type IconNodeWithChildren = [tag: string, attrs: SVGProps, children: IconNode];
+export type IconNodeWithChildren = [tag: string, attrs: SVGProps, children: IconNodeWithChildren[]];
 
 export type TemplateFunction = (params: {
   componentName: string;
   iconName: string;
-  children: IconNode;
+  children: IconNodeWithChildren[];
   getSvg: () => Promise<string>;
   deprecated?: boolean;
   deprecationReason?: string;

--- a/tools/build-icons/utils/defineExportTemplate.ts
+++ b/tools/build-icons/utils/defineExportTemplate.ts
@@ -1,9 +1,9 @@
-import { type IconNode } from '../types.ts';
+import { type IconNodeWithChildren } from '../types.ts';
 
 export interface ExportTemplate {
   componentName: string;
   iconName: string;
-  children: IconNode;
+  children: IconNodeWithChildren[];
   getSvg: () => Promise<string>;
   deprecated: boolean;
   deprecationReason: string;


### PR DESCRIPTION
* Allow to override icons dir through CLI argument '--icons'
* Enable rescursive mapping of SVG child nodes
* Provide complete SVG with all child nodes to template function

## Description
Providing the entire SVG including child nodes to the template functions enables usage of more advanced SVG icon use cases, like using SVG masks.

Example:
```html
<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24">
    <circle cx="12" cy="12" r="9" fill="currentColor" mask="url(#a)"/>
    <mask id="a">
        <path fill="#fff" d="M0 0h24v24H0z"/>
        <path fill="none" stroke="#000" d="M9 12.75 11.25 15 15 9.75"/>
    </mask>
</svg>
```
<img width="260" height="388" alt="icons" src="https://github.com/user-attachments/assets/26101123-9246-4cc9-b189-422a62b0e090" />

If mapped correctly, modifiying stroke-width will result in a differently sized checkmark symbol on a circle, where the circle is full color and the checkmark is masked out (transparent).

This way dynamic "solid" icon variants are possible.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
