### PR TITLE
chore(dev): Enable ligatures in font build configuration

### DIFF
--- a/tools/build-font/main.ts
+++ b/tools/build-font/main.ts
@@ -101,6 +101,7 @@ async function init() {
       useCSSVars: false,
       outSVGReact: false,
       outSVGPath: false,
+      addLigatures: true,
       svgicons2svgfont: {
         fontHeight: 1000, // At least 1000 is recommended
         normalize: false,


### PR DESCRIPTION
## Description

This PR enables support for text ligatures in the Lucide icon font by setting `addLigatures: true` in the `svgtofont` configuration. This allows icons to be referenced by their names (eg, `check-check`) ensuring more stable usage across various environments, especially non-web ones.

I've got a pretty specific use case for this: I'm planning to use Lucide in my custom Linux shell. 
The problem with using Unicode codes is: if I update the font, the Unicode values might change, which will break everything. 

Ligatures fix that, because the icon names stay the same no matter what.

This change also indirectly addresses the issue raised in #926. The original problem was the lack of a copy character button for Unicode codes. With ligatures, we no longer need to worry about copying Unicode values. Instead, users can easily copy the icon name (which is already available as a button), and it will work the same way across different languages and platforms. This eliminates the problems caused by different Unicode syntaxes in various environments.

This should not break anything, the Unicode codes are still working, so no problem for the current static web font.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
