### PR TITLE
fix(icons): changed `paint-bucket` icon

### DIFF
--- a/icons/paint-bucket.json
+++ b/icons/paint-bucket.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "jguddas"
   ],
   "tags": [
     "fill",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Cut overhanging path.
<img width="211" height="193" alt="image" src="https://github.com/user-attachments/assets/d020cac5-2f57-4b9e-87ae-2d4503c66a55" />


## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.