### PR TITLE
fix(site): Fix and unify color-picker font-size

### DIFF
--- a/docs/.vitepress/theme/components/base/ColorPicker.vue
+++ b/docs/.vitepress/theme/components/base/ColorPicker.vue
@@ -70,7 +70,7 @@ const value = computed({
   color: var(--vp-c-text-2);
   padding: 3px 8px 3px 3px;
   height: auto;
-  font-size: 14px;
+  font-size: 13px;
   text-align: left;
   border: 1px solid transparent;
   cursor: text;
@@ -90,7 +90,7 @@ const value = computed({
   border: none;
   background: transparent;
   color: var(--vp-c-text-1);
-  font-size: 14px;
+  font-size: 13px;
   text-align: left;
   border-radius: 8px;
   cursor: text;


### PR DESCRIPTION
The color-picker value was previously rendered at 14px, which caused the default light theme value (#000000) to be cut off. The "Stroke width" and "Size" inputs already use 13px, so this change aligns the color-picker value to 13px as well and resolves the cut-off issue.

Before:
<img width="208" height="321" alt="before" src="https://github.com/user-attachments/assets/5bbcf187-989d-4489-a29b-d787d78ef011" />

After:
<img width="208" height="321" alt="after" src="https://github.com/user-attachments/assets/a262c764-1c3b-4fc2-94ca-29c14e08eec6" />