### PR TITLE
fix(react-native-web): only add className prop to parent Icon component

### DIFF
--- a/packages/lucide-react-native/src/Icon.ts
+++ b/packages/lucide-react-native/src/Icon.ts
@@ -31,6 +31,7 @@ const Icon = forwardRef<SVGSVGElement, IconComponentProps>(
       absoluteStrokeWidth,
       children,
       iconNode,
+      className,
       ...rest
     },
     ref,
@@ -46,6 +47,7 @@ const Icon = forwardRef<SVGSVGElement, IconComponentProps>(
       {
         ref,
         ...defaultAttributes,
+        className,
         width: size,
         height: size,
         ...customAttrs,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

`<CircleStop className="h-4 …"/>` looks broken due to the className being applied to child.
<img width="584" height="113" alt="image" src="https://github.com/user-attachments/assets/8ec65f78-eaec-4b19-8814-4c65195a78fe" />

This PR makes it so the className is only applied to the svg element.

## References

https://uniwind.dev
https://nativewind.dev

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
