### PR TITLE
fix(site): add missing titles and a title template

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,7 @@ const description = 'Beautiful & consistent icon toolkit made by the community.'
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title,
+  titleTemplate: ':title \u2013 Lucide',
   description,
   cleanUrls: true,
   outDir: '.vercel/output/static',

--- a/docs/icons/categories.md
+++ b/docs/icons/categories.md
@@ -1,4 +1,5 @@
 ---
+title: Categories
 layout: page
 outline: 2
 outlineTitle: Categories

--- a/docs/icons/index.md
+++ b/docs/icons/index.md
@@ -1,4 +1,5 @@
 ---
+title: Icons
 layout: page
 outline: 2
 outlineTitle: Categories

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
 markdownStyles: false
+titleTemplate: false
 
 head:
   - - link

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,4 +1,5 @@
 ---
+title: License
 aside: false
 editLink: false
 ---

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,4 +1,5 @@
 ---
+title: Packages
 layout: page
 outline: 2
 outlineTitle: Packages

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,4 +1,5 @@
 ---
+title: Showcase
 layout: page
 outline: 2
 outlineTitle: Showcase


### PR DESCRIPTION
Multiple pages in the Lucide docs don’t define a unique page title, which makes open browser tabs hard to distinguish – it’s unclear whether you’re looking at the same page or different ones. For example, both the home page and the icons page show “Lucide” as the title.

This PR adds the missing titles. It also introduces a title template, replacing the default pipe character (`|`) with an en-dash (`–`) for clearer separation between the page name and the site name, and a nicer overall look.

Before:
<img width="390" height="149" alt="before screenshot showing tab name for icons page: Lucide" src="https://github.com/user-attachments/assets/6e795fef-4519-43cd-8c6f-5a8a6eac710f" />

After:
<img width="390" height="149" alt="after screenshot showing tab name for icons page: Icons – Lucide" src="https://github.com/user-attachments/assets/9fc70913-aea7-44cb-aff2-f69145413e55" />