### PR TITLE
feat(lucide-react): expose SVG stroke attributes as typed props

### DIFF
--- a/packages/lucide-react/src/Icon.ts
+++ b/packages/lucide-react/src/Icon.ts
@@ -32,6 +32,12 @@ const Icon = forwardRef<SVGSVGElement, IconComponentProps>(
       className = '',
       children,
       iconNode,
+      strokeLinecap,
+      strokeLinejoin,
+      strokeDasharray,
+      strokeDashoffset,
+      opacity,
+      strokeOpacity,
       ...rest
     },
     ref,
@@ -47,6 +53,13 @@ const Icon = forwardRef<SVGSVGElement, IconComponentProps>(
         strokeWidth: absoluteStrokeWidth ? (Number(strokeWidth) * 24) / Number(size) : strokeWidth,
         className: mergeClasses('lucide', className),
         ...(!children && !hasA11yProp(rest) && { 'aria-hidden': 'true' }),
+        // Pass through SVG stroke attributes only when explicitly provided
+        ...(strokeLinecap && { strokeLinecap }),
+        ...(strokeLinejoin && { strokeLinejoin }),
+        ...(strokeDasharray !== undefined && { strokeDasharray }),
+        ...(strokeDashoffset !== undefined && { strokeDashoffset }),
+        ...(opacity !== undefined && { opacity }),
+        ...(strokeOpacity !== undefined && { strokeOpacity }),
         ...rest,
       },
       [

--- a/packages/lucide-react/src/types.ts
+++ b/packages/lucide-react/src/types.ts
@@ -23,6 +23,43 @@ type ElementAttributes = RefAttributes<SVGSVGElement> & SVGAttributes;
 export interface LucideProps extends ElementAttributes {
   size?: string | number;
   absoluteStrokeWidth?: boolean;
+
+  /**
+   * SVG stroke-linecap attribute.
+   * Controls the shape at the end of open subpaths.
+   */
+  strokeLinecap?: 'butt' | 'round' | 'square';
+
+  /**
+   * SVG stroke-linejoin attribute.
+   * Controls the shape at corners of strokes.
+   */
+  strokeLinejoin?: 'bevel' | 'miter' | 'round';
+
+  /**
+   * SVG stroke-dasharray attribute.
+   * Creates dashed or dotted strokes.
+   * @example "5 5" for dashed, "2 2" for dotted
+   */
+  strokeDasharray?: string | number;
+
+  /**
+   * SVG stroke-dashoffset attribute.
+   * Offsets the dash pattern start position.
+   */
+  strokeDashoffset?: string | number;
+
+  /**
+   * SVG opacity attribute.
+   * Controls overall icon transparency (0-1).
+   */
+  opacity?: number;
+
+  /**
+   * SVG stroke-opacity attribute.
+   * Controls stroke transparency only (0-1).
+   */
+  strokeOpacity?: number;
 }
 
 export type LucideIcon = ForwardRefExoticComponent<

--- a/packages/lucide-react/tests/Icon.strokeAttributes.spec.tsx
+++ b/packages/lucide-react/tests/Icon.strokeAttributes.spec.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { airVent } from './testIconNodes';
+import { Icon } from '../src/lucide-react';
+
+describe('SVG Stroke Attributes', () => {
+  it('should apply strokeLinecap when provided', () => {
+    const { container } = render(
+      <Icon
+        iconNode={airVent}
+        strokeLinecap="square"
+      />,
+    );
+
+    expect(container.firstChild).toHaveAttribute('stroke-linecap', 'square');
+  });
+
+  it('should apply strokeLinejoin when provided', () => {
+    const { container } = render(
+      <Icon
+        iconNode={airVent}
+        strokeLinejoin="bevel"
+      />,
+    );
+
+    expect(container.firstChild).toHaveAttribute('stroke-linejoin', 'bevel');
+  });
+
+  it('should apply strokeDasharray for dashed strokes', () => {
+    const { container } = render(
+      <Icon
+        iconNode={airVent}
+        strokeDasharray="5 5"
+      />,
+    );
+
+    expect(container.firstChild).toHaveAttribute('stroke-dasharray', '5 5');
+  });
+
+  it('should apply opacity when provided', () => {
+    const { container } = render(
+      <Icon
+        iconNode={airVent}
+        opacity={0.5}
+      />,
+    );
+
+    expect(container.firstChild).toHaveAttribute('opacity', '0.5');
+  });
+
+  it('should preserve default attributes when no stroke props provided', () => {
+    const { container } = render(<Icon iconNode={airVent} />);
+
+    expect(container.firstChild).toHaveAttribute('stroke-linecap', 'round');
+    expect(container.firstChild).toHaveAttribute('stroke-linejoin', 'round');
+  });
+
+  it('should not interfere with existing props', () => {
+    const { container } = render(
+      <Icon
+        iconNode={airVent}
+        size={48}
+        stroke="red"
+      />,
+    );
+
+    expect(container.firstChild).toHaveAttribute('width', '48');
+    expect(container.firstChild).toHaveAttribute('stroke', 'red');
+  });
+});


### PR DESCRIPTION
This PR exposes commonly-used SVG stroke attributes as first-class typed props in `lucide-react`.
### What's Added
| Prop | Type | Purpose |
|------|------|---------|
| `strokeLinecap` | `'butt' \| 'round' \| 'square'` | Line end shape |
| `strokeLinejoin` | `'bevel' \| 'miter' \| 'round'` | Corner join shape |
| `strokeDasharray` | `string \| number` | Dashed/dotted patterns |
| `strokeDashoffset` | `string \| number` | Dash pattern offset |
| `opacity` | `number` | Overall transparency |
| `strokeOpacity` | `number` | Stroke-only transparency |
### Motivation
These are valid SVG attributes already supported via rest props, but adding explicit typing:
- **Improves TypeScript autocomplete** and discoverability
- **Documents** the most common customization patterns
- **Reduces friction** for developers
### Design Choices
- **No new behavior** — pure pass-through to SVG
- **No validation** — browser handles invalid values  
- **No default changes** — fully backward compatible
- **Conditional spreading** — props only applied when explicitly provided
### Example Usage
```tsx
import { Heart } from 'lucide-react';
// Dashed stroke
<Heart strokeDasharray="5 5" />
// Semi-transparent icon
<Heart opacity={0.5} />
// Square line caps instead of round
<Heart strokeLinecap="square" />
```
### Files Changed
packages/lucide-react/src/types.ts — Added typed props with JSDoc
packages/lucide-react/src/Icon.ts — Added conditional prop spreading
packages/lucide-react/tests/Icon.strokeAttributes.spec.tsx — Added unit tests

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
