### PR TITLE
fix(icons): decreased size of arrows inside `square-arrow-*` icons

### DIFF
--- a/icons/square-arrow-down-left.json
+++ b/icons/square-arrow-down-left.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "direction",

--- a/icons/square-arrow-down-left.svg
+++ b/icons/square-arrow-down-left.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="18" height="18" x="3" y="3" rx="2" />
-  <path d="m16 8-8 8" />
-  <path d="M16 16H8V8" />
+  <path d="M15 15H9l6-6" />
+  <path d="M9 15V9" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>

--- a/icons/square-arrow-down-right.json
+++ b/icons/square-arrow-down-right.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "direction",

--- a/icons/square-arrow-down-right.svg
+++ b/icons/square-arrow-down-right.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="18" height="18" x="3" y="3" rx="2" />
-  <path d="m8 8 8 8" />
-  <path d="M16 8v8H8" />
+  <path d="M15 15 9 9" />
+  <path d="M9 15h6V9" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>

--- a/icons/square-arrow-up-left.json
+++ b/icons/square-arrow-up-left.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "direction",

--- a/icons/square-arrow-up-left.svg
+++ b/icons/square-arrow-up-left.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="18" height="18" x="3" y="3" rx="2" />
-  <path d="M8 16V8h8" />
-  <path d="M16 16 8 8" />
+  <path d="M15 15 9 9" />
+  <path d="M9 15V9h6" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>

--- a/icons/square-arrow-up-right.json
+++ b/icons/square-arrow-up-right.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "jguddas"
   ],
   "tags": [
     "direction",

--- a/icons/square-arrow-up-right.svg
+++ b/icons/square-arrow-up-right.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="18" height="18" x="3" y="3" rx="2" />
-  <path d="M8 8h8v8" />
-  <path d="m8 16 8-8" />
+  <path d="M15 15V9H9" />
+  <path d="m9 15 6-6" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Decreased arrow size.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.