### PR TITLE
fix(site): hide native search input clear "X" icon

### DIFF
--- a/docs/.vitepress/theme/components/base/Input.vue
+++ b/docs/.vitepress/theme/components/base/Input.vue
@@ -35,6 +35,8 @@ const updateShortcutSpacing = () => {
   });
 };
 
+const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+
 onMounted(updateShortcutSpacing);
 watch(() => props.shortcut, updateShortcutSpacing);
 
@@ -73,6 +75,7 @@ defineExpose({
       v-if="type === 'search' && modelValue"
       class="clear-button"
       aria-label="Clear input"
+      :style="{ right: isMac ? '50px' : '68px' }"
     >
       <Icon
         :iconNode="x"
@@ -173,7 +176,7 @@ defineExpose({
   }
 
   .clear-button {
-    right: 16px;
+    right: 16px !important;
   }
 }
 </style>


### PR DESCRIPTION
## What is the purpose of this pull request?
- [ ] New Icon
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other:

## Description

This pull request fixes the duplicate "X" icon issue in the search bar. Previously, when the search input was focused, both the browser's native clear "X" icon and the custom clear button were displayed, causing visual inconsistency. The fix hides the browser's default clear button for search inputs, ensuring only the custom clear button is shown.

### Changes Made:

- Added CSS to hide the native search input clear "X" icon across browsers.
- Ensured only the custom clear button appears in the search bar.

Fixes: #3925 

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
