### PR TITLE
fix(icons): changed `square-split-vertical` icon

### DIFF
--- a/icons/square-split-horizontal.json
+++ b/icons/square-split-horizontal.json
@@ -2,7 +2,8 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "Patchethium",
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "split",

--- a/icons/square-split-horizontal.svg
+++ b/icons/square-split-horizontal.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M8 19H5c-1 0-2-1-2-2V7c0-1 1-2 2-2h3" />
-  <path d="M16 5h3c1 0 2 1 2 2v10c0 1-1 2-2 2h-3" />
-  <line x1="12" x2="12" y1="4" y2="20" />
+  <path d="M12 2v20" />
+  <path d="M16 3h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-3" />
+  <path d="M8 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3" />
 </svg>

--- a/icons/square-split-vertical.json
+++ b/icons/square-split-vertical.json
@@ -2,7 +2,8 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "Patchethium",
-    "ericfennis"
+    "ericfennis",
+    "jguddas"
   ],
   "tags": [
     "split",

--- a/icons/square-split-vertical.svg
+++ b/icons/square-split-vertical.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M5 8V5c0-1 1-2 2-2h10c1 0 2 1 2 2v3" />
-  <path d="M19 16v3c0 1-1 2-2 2H7c-1 0-2-1-2-2v-3" />
-  <line x1="4" x2="20" y1="12" y2="12" />
+  <path d="M2 12h20" />
+  <path d="M21 16v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-3" />
+  <path d="M3 8V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v3" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Make it actually `square` and match the square and split icons.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.