### PR TITLE
fix(icons): changed `monitor-off` icon

### DIFF
--- a/icons/monitor-off.svg
+++ b/icons/monitor-off.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M17 17H4a2 2 0 0 1-2-2V5c0-1.5 1-2 1-2" />
-  <path d="M22 15V5a2 2 0 0 0-2-2H9" />
-  <path d="M8 21h8" />
   <path d="M12 17v4" />
+  <path d="M17 17H4a2 2 0 0 1-2-2V5a2 2 0 0 1 1.184-1.826" />
   <path d="m2 2 20 20" />
+  <path d="M8 21h8" />
+  <path d="M8.656 3H20a2 2 0 0 1 2 2v10a2 2 0 0 1-.293 1.042" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Offified.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.