### PR TITLE
fix(icons): changed `table-rows-split` icon

### DIFF
--- a/icons/table-rows-split.json
+++ b/icons/table-rows-split.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "chessurisme"
+    "chessurisme",
+    "jguddas"
   ],
   "tags": [
     "spreadsheet",

--- a/icons/table-rows-split.svg
+++ b/icons/table-rows-split.svg
@@ -9,15 +9,15 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M14 10h2" />
-  <path d="M15 22v-8" />
-  <path d="M15 2v4" />
-  <path d="M2 10h2" />
-  <path d="M20 10h2" />
-  <path d="M3 19h18" />
-  <path d="M3 22v-6a2 2 135 0 1 2-2h14a2 2 45 0 1 2 2v6" />
-  <path d="M3 2v2a2 2 45 0 0 2 2h14a2 2 135 0 0 2-2V2" />
-  <path d="M8 10h2" />
-  <path d="M9 22v-8" />
-  <path d="M9 2v4" />
+  <path d="M10 14H8" />
+  <path d="M15 22v-4" />
+  <path d="M15 2v8" />
+  <path d="M16 14h-2" />
+  <path d="M21 22v-2a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v2" />
+  <path d="M21 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V2" />
+  <path d="M21 5H3" />
+  <path d="M22 14h-2" />
+  <path d="M4 14H2" />
+  <path d="M9 22v-4" />
+  <path d="M9 2v8" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Rotated icon.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.