### PR TITLE
feat(icons): added `file-pdf` icon

### DIFF
--- a/icons/file-pdf.json
+++ b/icons/file-pdf.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "ddikodroid"
+  ],
+  "tags": [
+    "document",
+    "format",
+    "paper",
+    "read",
+    "type",
+    "extension"
+  ],
+  "categories": [
+    "files"
+  ]
+}

--- a/icons/file-pdf.svg
+++ b/icons/file-pdf.svg
@@ -1,0 +1,29 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M 10.5 16 L 11.75 16" />
+  <path d="M 10.5 22 L 10.5 16" />
+  <path d="M 11.255 22 L 10.5 22" />
+  <path d="M 11.75 16 A3.01 3.01 0 1 1 11.255 22" />
+  <path d="M 15 2 L 6 2" />
+  <path d="M 17.5 16 L 20 16" />
+  <path d="M 17.5 19 L 20 19" />
+  <path d="M 17.5 22 L 17.5 16" />
+  <path d="M 20 12 L 20 7" />
+  <path d="M 20 7 L 15 2" />
+  <path d="M 4 16 L 5.5 16" />
+  <path d="M 4 22 L 4 16" />
+  <path d="M 4 4 L 4 12" />
+  <path d="M 5.5 16 A2 2 0 1 1 5.5 20" />
+  <path d="M 5.5 20 L 4 20" />
+  <path d="M 6 2 A2 2 0 0 0 4 4" />
+  <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
This PR adds the `file-pdf` icon.

This icon uses the 1px stroke exception (as per the design guide for elements smaller than 8px) for the inner text. This ensures the letters "PDF" remain legible and distinct within the standard 24x24 container, where a standard 2px stroke would cause the letters to merge.

### Icon use case <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
- CMS / File Managers: Used to explicitly differentiate PDF documents from other text files in a list of uploads or file browser.
- Download Actions: Used in "Download PDF" call-to-action buttons on invoices, receipts, or documentation sites.
- Export Options: Visual indicator for "Export as PDF" functionality in data dashboards.

### Alternative icon designs <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- If you have any alternative icon designs, please attach them here. -->
- Current `file-text` exists as a metaphor for documents, but does not explicitly indicate the .pdf extension.
- Current `file` is too generic for specific file-type actions.

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
<!-- IMPORTANT! Please read our official statement on brand logos in Lucide: -->
<!-- https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md -->
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
