### PR TITLE
fix(github-actions): resolved spelling mistake in gh issue close command

### DIFF
--- a/.github/workflows/close-issue-with-banned-phrases.yml
+++ b/.github/workflows/close-issue-with-banned-phrases.yml
@@ -28,7 +28,7 @@ jobs:
               { [ -n "$ICON_NAME_SECTION" ] && echo "$ICON_NAME_SECTION" | grep -iqE "$SAFE_KEY|$SAFE_VALUE"; }; then
 
               gh issue close ${{ github.event.issue.number }} \
-                --reason "not_planned" \
+                --reason "not planned" \
                 --comment "It looks like this request is about **${VALUE}**, which is a brand logo.
 
           Lucide **does not accept** brand logos, and we do not plan to add them in the future. This is due to a combination of **legal restrictions**, **design consistency concerns**, and **practical maintenance reasons**.


### PR DESCRIPTION
## Description
Currently the pipeline is failling: https://github.com/lucide-icons/lucide/actions/runs/21024293150/job/60445072749#step:3:41

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.
