### PR TITLE
feat(icons): add lambda icon

### DIFF
--- a/icons/lambda.json
+++ b/icons/lambda.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "../icon.schema.json",
+    "contributors": [
+        "kaleidosium",
+        "UbaidUllah9962"
+    ],
+    "tags": [
+        "lambda",
+        "greek",
+        "symbol",
+        "math",
+        "function",
+        "programming",
+        "serverless"
+    ],
+    "categories": [
+        "development",
+        "math",
+        "text"
+    ]
+}

--- a/icons/lambda.svg
+++ b/icons/lambda.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M11.38 10 5 20" />
+    <path d="M19 18a2 2 0 0 1-2 2c-4.87-.003-5.052-16-10-16a2 2 0 0 0-2 2" />
+</svg>


### PR DESCRIPTION
Closes #4001

## Description
This PR adds the `lambda` icon to the Lucide icon set. The design follows the 24x24 grid with a 2px stroke, ensuring consistency with the existing mathematical and programming-related icons.

| Icon |
| :--- |
| |

### Icon use case
* **Programming & Computer Science:** To represent anonymous functions, functional programming concepts, or lambda expressions.
* **Cloud Computing:** Specifically for AWS Lambda functions or serverless architecture diagrams.
* **Mathematics:** To represent the Greek letter Lambda used in calculus, physics (wavelength), and linear algebra.

### Alternative icon designs 
## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #4001 by @Kaleidosium
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions).
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/lambda.json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.