### PR TITLE
fix(lucide): Fix ESM Module output path in build

### DIFF
--- a/packages/lucide/rollup.config.mjs
+++ b/packages/lucide/rollup.config.mjs
@@ -39,12 +39,12 @@ const configs = bundles
         // This is for lucide plugin to replace an argument in createIcons so it is easier to use with UMD.
         ...(format === 'umd'
           ? [
-            replace({
-              'icons = {}': 'icons = iconAndAliases',
-              delimiters: ['', ''],
-              preventAssignment: false,
-            }),
-          ]
+              replace({
+                'icons = {}': 'icons = iconAndAliases',
+                delimiters: ['', ''],
+                preventAssignment: false,
+              }),
+            ]
           : []),
         ...plugins({ pkg, minify }),
       ],
@@ -52,11 +52,11 @@ const configs = bundles
         name: outputFileName,
         ...(preserveModules
           ? {
-            dir: `${outputDir}/${format}`,
-          }
+              dir: `${outputDir}/${format}`,
+            }
           : {
-            file: `${outputDir}/${format}/${outputFileName}${minify ? '.min' : ''}.js`,
-          }),
+              file: `${outputDir}/${format}/${outputFileName}${minify ? '.min' : ''}.js`,
+            }),
         format,
         sourcemap: true,
         preserveModules,


### PR DESCRIPTION
Closes #4027.

The ESM directory was split into separate directories with the introduction of the shared package.
Needed to add `preserveModulesRoot` option to correct the paths.