### PR TITLE
chore(tags): Add tags to `search-` icons

### DIFF
--- a/icons/search-alert.json
+++ b/icons/search-alert.json
@@ -16,7 +16,12 @@
     "alert",
     "error",
     "anomaly",
-    "lens"
+    "lens",
+    "locate",
+    "explore",
+    "discover",
+    "enlarge",
+    "zoom"
   ],
   "categories": [
     "text",

--- a/icons/search-check.json
+++ b/icons/search-check.json
@@ -12,7 +12,12 @@
     "correct",
     "complete",
     "tick",
-    "lens"
+    "lens",
+    "locate",
+    "explore",
+    "discover",
+    "enlarge",
+    "zoom"
   ],
   "categories": [
     "text",

--- a/icons/search-code.json
+++ b/icons/search-code.json
@@ -12,7 +12,12 @@
     "grep",
     "chevrons",
     "<>",
-    "lens"
+    "lens",
+    "locate",
+    "explore",
+    "discover",
+    "enlarge",
+    "zoom"
   ],
   "categories": [
     "text",

--- a/icons/search-slash.json
+++ b/icons/search-slash.json
@@ -13,7 +13,12 @@
     "cancel",
     "abort",
     "/",
-    "lens"
+    "lens",
+    "locate",
+    "explore",
+    "discover",
+    "enlarge",
+    "zoom"
   ],
   "categories": [
     "text",

--- a/icons/search-x.json
+++ b/icons/search-x.json
@@ -12,7 +12,12 @@
     "clear",
     "cancel",
     "abort",
-    "lens"
+    "lens",
+    "locate",
+    "explore",
+    "discover",
+    "enlarge",
+    "zoom"
   ],
   "categories": [
     "text",

--- a/icons/search.json
+++ b/icons/search.json
@@ -10,7 +10,12 @@
     "scan",
     "magnifier",
     "magnifying glass",
-    "lens"
+    "lens",
+    "locate",
+    "explore",
+    "discover",
+    "enlarge",
+    "zoom"
   ],
   "categories": [
     "text",


### PR DESCRIPTION
<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description

Following on from #4097, adds tags to `search-` icons so that they appear when users search for "zoom", etc.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
