### PR TITLE
chore(icons): Add 'crypto' tag to bitcoin.json

### DIFF
--- a/icons/bitcoin.json
+++ b/icons/bitcoin.json
@@ -5,6 +5,14 @@
     "mittalyashu"
   ],
   "tags": [
+    "cryptocurrency",
+    "digital",
+    "blockchain",
+    "finance",
+    "coin",
+    "market",
+    "decentralized",
+    "investment",
     "crypto",
     "currency",
     "money",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

## Description
While searching on the site, I noticed that the bitcoin icon does not have the crypto tag. I thought that might be convenient to include. It looks like there was some talk about removing this icon, but it never was.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
