### PR TITLE
fix(docs): deprecated vscode exclude config

### DIFF
--- a/docs/guide/preact/advanced/aliased-names.md
+++ b/docs/guide/preact/advanced/aliased-names.md
@@ -27,7 +27,7 @@ This can be done by creating a custom module declaration file to override Lucide
 
 ```json [.vscode/settings.json]
 {
-  "typescript.preferences.autoImportFileExcludePatterns": [
+  "js/ts.preferences.autoImportFileExcludePatterns": [
     "lucide-preact",
   ]
 }

--- a/docs/guide/react-native/advanced/aliased-names.md
+++ b/docs/guide/react-native/advanced/aliased-names.md
@@ -27,7 +27,7 @@ This can be done by creating a custom module declaration file to override Lucide
 
 ```json [.vscode/settings.json]
 {
-  "typescript.preferences.autoImportFileExcludePatterns": [
+  "js/ts.preferences.autoImportFileExcludePatterns": [
     "lucide-react-native",
   ]
 }

--- a/docs/guide/react/advanced/aliased-names.md
+++ b/docs/guide/react/advanced/aliased-names.md
@@ -27,7 +27,7 @@ This can be done by creating a custom module declaration file to override Lucide
 
 ```json [.vscode/settings.json]
 {
-  "typescript.preferences.autoImportFileExcludePatterns": [
+  "js/ts.preferences.autoImportFileExcludePatterns": [
     "lucide-react",
   ]
 }

--- a/docs/guide/solid/advanced/aliased-names.md
+++ b/docs/guide/solid/advanced/aliased-names.md
@@ -22,7 +22,7 @@ import {
 
 ```json [.vscode/settings.json]
 {
-  "typescript.preferences.autoImportFileExcludePatterns": [
+  "js/ts.preferences.autoImportFileExcludePatterns": [
     "lucide-solid",
   ]
 }

--- a/docs/guide/vscode.md
+++ b/docs/guide/vscode.md
@@ -13,7 +13,7 @@ You can turn this off by adding the following setting to your VS Code settings.
 
 ```json [.vscode/settings.json]
 {
-  "typescript.preferences.autoImportFileExcludePatterns": [
+  "js/ts.preferences.autoImportFileExcludePatterns": [
     "lucide-react", // or
     "lucide-preact", // or
     "lucide-react-native", // or

--- a/docs/guide/vue/advanced/aliased-names.md
+++ b/docs/guide/vue/advanced/aliased-names.md
@@ -27,7 +27,7 @@ This can be done by creating a custom module declaration file to override Lucide
 
 ```json [.vscode/settings.json]
 {
-  "typescript.preferences.autoImportFileExcludePatterns": [
+  "js/ts.preferences.autoImportFileExcludePatterns": [
     "@lucide/vue",
   ]
 }


### PR DESCRIPTION
## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.

<img width="1110" height="185" alt="Screenshot 2026-03-22 at 12 24 14" src="https://github.com/user-attachments/assets/8c00df2e-6060-4cec-a34b-bfb47d6a6851" />
