### PR TITLE
fix(scripts): correct import extension in optimizeStagedSvgs.mts

### DIFF
--- a/scripts/optimizeStagedSvgs.mts
+++ b/scripts/optimizeStagedSvgs.mts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import processSvg from './render/processSvg.mjs';
+import processSvg from './render/processSvg.mts';
 
 const svgFiles = process.argv.slice(2);
 


### PR DESCRIPTION
## What is the purpose of this pull request?
- [x] Other: Bug fix in pre-commit hook script

### Description

`scripts/optimizeStagedSvgs.mts` imports from `./render/processSvg.mjs`, but the file on disk is `processSvg.mts`. There is no `.mjs` version of this file.

This was introduced in 4dda4324 when the lint-staged config was updated to call `.mts` files directly, but the import path inside `optimizeStagedSvgs.mts` was not updated to match.

The result is that the pre-commit hook fails for any commit that touches SVG files:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '/scripts/render/processSvg.mjs'
  imported from /scripts/optimizeStagedSvgs.mts
```

This blocks external contributors from committing icon changes locally. I ran into this while submitting new icons in #4184.

The fix is one line: `.mjs` -> `.mts` in the import path.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.