### PR TITLE
ci(ci.yml): Fix release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
       - name: Publish
-        run: pnpm publish --access public --no-git-checks --ignore-scripts --tag ${{ inputs.tag }} --access public
+        run: pnpm publish --access public --no-git-checks --ignore-scripts --tag ${{ inputs.tag }}
         working-directory: packages/${{ matrix.package }}
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
* Updated the package list in the release workflow to use simplified package names (e.g., `angular`, `astro`, `svelte`, `icons`, `vue`) instead of scoped or commented-out package names. This makes the matrix easier to read and maintain.