### PR TITLE
fix(lucide-preact): add conditional exports map for ESM/CJS resolution

### DIFF
--- a/packages/lucide-preact/package.json
+++ b/packages/lucide-preact/package.json
@@ -25,6 +25,13 @@
   "amdName": "lucide-preact",
   "main": "dist/cjs/lucide-preact.js",
   "module": "dist/esm/lucide-preact.js",
+  "exports": {
+    ".": {
+      "types": "./dist/lucide-preact.d.ts",
+      "import": "./dist/esm/lucide-preact.js",
+      "require": "./dist/cjs/lucide-preact.js"
+    }
+  },
   "typings": "dist/lucide-preact.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Adds a conditional `exports` map to `packages/lucide-preact/package.json` so runtimes that follow the Node.js package resolution spec (Node.js, Bun) resolve the ESM build instead of CJS.

Without this, runtimes ignore the non-standard `module` field and fall back to `main` (CJS). Commit [`0c6dfeb6`](https://github.com/lucide-icons/lucide/commit/0c6dfeb64c6ff6194ee7fbb6542352b67dbbb608) (feat(context-providers): Adding Context providers, #3315) introduced `useContext` and `useMemo` from `preact/hooks` into [`src/context.ts`](https://github.com/lucide-icons/lucide/blob/1.0.1/packages/lucide-preact/src/context.ts), called on every icon render via [`Icon.ts`](https://github.com/lucide-icons/lucide/blob/1.0.1/packages/lucide-preact/src/Icon.ts). This makes the missing `exports` map a breaking issue: the CJS build loads a separate `preact/hooks` instance which crashes on every icon render.

Fixes #4196

## Changes

`packages/lucide-preact/package.json` — adds `exports` field:

```json
{
  "exports": {
    ".": {
      "types": "./dist/lucide-preact.d.ts",
      "import": "./dist/esm/lucide-preact.js",
      "require": "./dist/cjs/lucide-preact.js"
    }
  }
}
```

All three paths match the existing `typings`, `main`, and `module` fields respectively.

## Testing

**Minimal repro** (details in #4196): a Bun test that renders a single lucide icon crashes without this change and passes with it.

**Version bisect** confirming the causal commit:

| Version | Contains `0c6dfeb6`? | Result |
|---------|---------------------|--------|
| `0.577.0` (last 0.x) | No — `context.ts` does not exist | **PASS** |
| `1.0.0-rc.0` (git tag, unpublished) | Yes — `context.ts` present | N/A (not on npm) |
| `1.0.0-rc.1` (first published version with the commit) | Yes | **FAIL** |
| `1.0.1` | Yes | **FAIL** |

**lucide-preact test suite** — all 20 tests pass with this change:

| Environment | Result |
|-------------|--------|
| Node 22 (Alpine container), pnpm monorepo install | 4 files, 20 tests, all pass |
| Node 24 (Alpine container), pnpm monorepo install | 4 files, 20 tests, all pass |