### PR TITLE
fix(packages/lucide-react-native): add preserveModulesRoot to `lucide-react-native`

### DIFF
--- a/packages/lucide-react-native/package.json
+++ b/packages/lucide-react-native/package.json
@@ -56,8 +56,8 @@
     "version": "pnpm version --git-tag-version=false"
   },
   "devDependencies": {
-    "@lucide/rollup-plugins": "workspace:*",
     "@lucide/build-icons": "workspace:*",
+    "@lucide/rollup-plugins": "workspace:*",
     "@lucide/shared": "workspace:*",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^14.1.2",

--- a/packages/lucide-react-native/rollup.config.mjs
+++ b/packages/lucide-react-native/rollup.config.mjs
@@ -39,6 +39,7 @@ const configs = bundles
             }),
         format,
         preserveModules,
+        preserveModulesRoot: 'src',
         sourcemap: true,
         globals: {
           react: 'react',


### PR DESCRIPTION
closes #4195

## Description

`@lucide/shared` was added as a devDependency of `lucide-react-native`, but our rollup config was missing `preserveModulesRoot: 'src'`, resulting in a pretty messed up `dist` folder structure:

<img width="780" height="950" alt="image" src="https://github.com/user-attachments/assets/580ec6d0-24f1-4595-bc62-d443fac41886" />

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
