### PR TITLE
fix(lucide-static): add viewBox to sprite symbol elements

### DIFF
--- a/packages/lucide-static/scripts/generateSprite.mts
+++ b/packages/lucide-static/scripts/generateSprite.mts
@@ -15,6 +15,7 @@ export default async function generateSprite(
     value: '',
     attributes: {
       id: name,
+      viewBox: parsedSvg.attributes.viewBox,
     },
     children: parsedSvg.children,
   }));


### PR DESCRIPTION
## Summary

- Adds `viewBox` attribute to `<symbol>` elements in the generated SVG sprite
- Source SVGs define `viewBox="0 0 24 24"` but it was not propagated during sprite generation
- Without `viewBox`, icons are clipped instead of scaling at smaller sizes (12x12, 16x16)

## Changes

- `packages/lucide-static/scripts/generateSprite.mts`: Added `viewBox: parsedSvg.attributes.viewBox` to symbol attributes

Fixes #2768
