### PR TITLE
docs: fix broken links in pull_request_template.md (got 404 page)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,13 +41,13 @@ Common scopes: icons, docs, studio, site, dev
 
 ### Naming <!-- ONLY for new icons -->
 <!-- All of these requirements must be fulfilled. -->
-- [ ] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
+- [ ] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
 - [ ] I've named icons by what they are rather than their use case.
 - [ ] I've provided meta JSON files in `icons/[iconName].json`.
 
 ### Design <!-- ONLY for new icons -->
 <!-- All of these requirements must be fulfilled. -->
-- [ ] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
+- [ ] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
 - [ ] I've made sure that the icons look sharp on low DPI displays.
 - [ ] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
 - [ ] I've made sure that the icons are visually centered.


### PR DESCRIPTION
docs: fix broken links in giving **404 page** in `.github/pull_request_template.md`
changed URL from `lucide.dev/guide/design/` to `lucide.dev/contribute/`
Same in #4225

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
