### PR TITLE
docs: Fix link to icon design principles in statement

### DIFF
--- a/BRAND_LOGOS_STATEMENT.md
+++ b/BRAND_LOGOS_STATEMENT.md
@@ -39,7 +39,7 @@ This means adding them could:
 Lucide is all about **visual consistency**.
 
 Adding brand logos would:
-- Break [our own design rules](https://lucide.dev/guide/design/icon-design-guide#icon-design-principles) for shapes, proportions, and stroke.
+- Break [our own design rules](https://lucide.dev/contribute/icon-design-guide#icon-design-principles) for shapes, proportions, and stroke.
 - Mix two fundamentally different categories of graphics (pictograms vs. corporate logos).
 - Create a library where a subset of icons will always look "out of place".
 


### PR DESCRIPTION
Updated the link to the icon design guide in the brand logos statement. Previous like was giving 404 error. same as #4224 
docs: fix broken links in `BRAND_LOGOS_STATEMENT.md`
changed URL from `lucide.dev/guide/design/` to `lucide.dev/contribute/`

<!-- Thank you for contributing! -->

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.