### PR TITLE
fix(gh-icon): update colors for ColoredPath component

### DIFF
--- a/docs/.vitepress/lib/SvgPreview/index.tsx
+++ b/docs/.vitepress/lib/SvgPreview/index.tsx
@@ -460,18 +460,18 @@ const SvgPreview = (
       <ColoredPath
         paths={paths}
         colors={[
-          "#1982c4",
-          "#4267AC",
-          "#6a4c93",
-          "#B55379",
-          "#FF595E",
-          "#FF7655",
-          "#ff924c",
-          "#FFAE43",
-          "#ffca3a",
-          "#C5CA30",
-          "#8ac926",
-          "#52A675",
+          '#1982c4',
+          '#4267AC',
+          '#6a4c93',
+          '#B55379',
+          '#FF595E',
+          '#FF7655',
+          '#ff924c',
+          '#FFAE43',
+          '#ffca3a',
+          '#C5CA30',
+          '#8ac926',
+          '#52A675',
         ]}
       />
       <Radii

--- a/docs/.vitepress/lib/SvgPreview/index.tsx
+++ b/docs/.vitepress/lib/SvgPreview/index.tsx
@@ -459,7 +459,20 @@ const SvgPreview = (
       />
       <ColoredPath
         paths={paths}
-        colors={['#dfdfd6']}
+        colors={[
+          "#1982c4",
+          "#4267AC",
+          "#6a4c93",
+          "#B55379",
+          "#FF595E",
+          "#FF7655",
+          "#ff924c",
+          "#FFAE43",
+          "#ffca3a",
+          "#C5CA30",
+          "#8ac926",
+          "#52A675",
+        ]}
       />
       <Radii
         paths={paths}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Fixes color of icon in preview comment

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.
