### PR TITLE
fix(@lucide/svelte): aria-hidden="true" was never set

### DIFF
--- a/packages/svelte/scripts/exportTemplate.mts
+++ b/packages/svelte/scripts/exportTemplate.mts
@@ -36,8 +36,6 @@ const iconNode: IconNode = ${JSON.stringify(children)};
  */
 </script>
 
-<Icon name="${iconName}" {...props} iconNode={iconNode}>
-  {@render props.children?.()}
-</Icon>
+<Icon name="${iconName}" {...props} iconNode={iconNode} />
 `;
 });

--- a/packages/svelte/tests/__snapshots__/lucide-svelte.spec.ts.snap
+++ b/packages/svelte/tests/__snapshots__/lucide-svelte.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Using lucide icon components > should add a class to the element 1`] = `
 <svg
+  aria-hidden="true"
   class="lucide-icon lucide lucide-smile my-icon"
   fill="none"
   height="24"
@@ -51,14 +52,13 @@ exports[`Using lucide icon components > should add a class to the element 1`] = 
   
   <!---->
   <!---->
-  
-  <!---->
 </svg>
 `;
 
 exports[`Using lucide icon components > should adjust the size, stroke color and stroke width 1`] = `
 <div>
   <svg
+    aria-hidden="true"
     class="lucide-icon lucide lucide-smile"
     fill="none"
     height="48"
@@ -108,8 +108,6 @@ exports[`Using lucide icon components > should adjust the size, stroke color and
     
     <!---->
     <!---->
-    
-    <!---->
   </svg>
   
   
@@ -126,6 +124,7 @@ exports[`Using lucide icon components > should not scale the strokeWidth when ab
      stroke-width="1"
      stroke-linecap="round"
      stroke-linejoin="round"
+     aria-hidden="true"
      class="lucide-icon lucide lucide-smile"
 >
   <circle cx="12"
@@ -153,6 +152,7 @@ exports[`Using lucide icon components > should not scale the strokeWidth when ab
 exports[`Using lucide icon components > should render an component 1`] = `
 <div>
   <svg
+    aria-hidden="true"
     class="lucide-icon lucide lucide-smile"
     fill="none"
     height="24"
@@ -201,8 +201,6 @@ exports[`Using lucide icon components > should render an component 1`] = `
     </line>
     
     <!---->
-    <!---->
-    
     <!---->
   </svg>
   
@@ -261,11 +259,9 @@ exports[`Using lucide icon components > should render an icon slot 1`] = `
     </line>
     
     <!---->
-    <!---->
     <text>
       Test
     </text>
-    
     <!---->
   </svg>
   

--- a/packages/svelte/tests/lucide-svelte.spec.ts
+++ b/packages/svelte/tests/lucide-svelte.spec.ts
@@ -94,3 +94,23 @@ describe('Using lucide icon components', () => {
     expect(IconComponent).toHaveAttribute('stroke-width', '1');
   });
 });
+
+describe('Icon Component Accessibility', () => {
+  it('should have aria-hidden prop when no aria prop or children are present', async () => {
+    const { container } = render(Smile, {
+      props: {
+        size: 48,
+        color: 'red',
+        absoluteStrokeWidth: true,
+      },
+    });
+
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should not have aria-hidden prop when there are children that could be a <title> element', async () => {
+    const { container } = render(TestSlots);
+
+    expect(container.firstChild).not.toHaveAttribute('aria-hidden');
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

When using icon components like `<AirVent />` the aria-hidden attribute was never set. 

That is because in `Icon.svelte` we have `!children && !hasA11yProp(props) && { 'aria-hidden': 'true' }`, so if children prop is present (and is truthy), the attribute is not set. But in the generated icon components there was:

```svelte
<Icon name="air-vent" {...props} iconNode={iconNode}>
  {@render props.children?.()}
</Icon>
```

Because of how svelte works this results in `Icon` receiving some `children` prop even if this `children` in outer component was undefined. Even though that snippet is empty in terms of markup, it's still present, so the `!children` check fails. The solution is to just do this:

```svelte
<Icon name="air-vent" {...props} iconNode={iconNode} />
```

Because `children` is simply a prop like any other it will already be forwarded, no need to do that explicitly.

I've also added tests for that and updated the snapshots for the tests, as previously they were testing for incorrect behavior. 


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
