### PR TITLE
feat(docs): blur background of framework-select

### DIFF
--- a/docs/.vitepress/theme/components/guide/FrameworkSelect.vue
+++ b/docs/.vitepress/theme/components/guide/FrameworkSelect.vue
@@ -107,7 +107,6 @@ function onSelectFramework(item: { name: string; icon: string; iconDark?: string
   border-top: 1px solid var(--vp-c-divider);
   padding-top: 10px;
   margin-top: -10px;
-  backdrop-filter: blur(1px);
 }
 
 label {

--- a/docs/.vitepress/theme/components/guide/FrameworkSelect.vue
+++ b/docs/.vitepress/theme/components/guide/FrameworkSelect.vue
@@ -119,6 +119,7 @@ label {
   font-weight: bold;
   margin-bottom: 4px;
   display: block;
+  position: relative;
 }
 
 .framework-select:before {
@@ -128,17 +129,5 @@ label {
   background: color-mix(in srgb, var(--vp-c-bg-alt), transparent 50%);
   backdrop-filter: blur(4px);
   mask-image: linear-gradient(to bottom, black calc(100% - 16px), transparent 100%);
-}
-
-label {
-  color: var(--vp-c-text-1);
-  padding: 4px 0;
-  line-height: 24px;
-  font-size: 14px;
-  transition: color 0.25s;
-  font-weight: bold;
-  margin-bottom: 4px;
-  display: block;
-  position: relative;
 }
 </style>

--- a/docs/.vitepress/theme/components/guide/FrameworkSelect.vue
+++ b/docs/.vitepress/theme/components/guide/FrameworkSelect.vue
@@ -107,6 +107,7 @@ function onSelectFramework(item: { name: string; icon: string; iconDark?: string
   border-top: 1px solid var(--vp-c-divider);
   padding-top: 10px;
   margin-top: -10px;
+  backdrop-filter: blur(1px);
 }
 
 label {

--- a/docs/.vitepress/theme/components/guide/FrameworkSelect.vue
+++ b/docs/.vitepress/theme/components/guide/FrameworkSelect.vue
@@ -120,4 +120,25 @@ label {
   margin-bottom: 4px;
   display: block;
 }
+
+.framework-select:before {
+  content: ' ';
+  position: absolute;
+  inset: 0 -16px -24px;
+  background: color-mix(in srgb, var(--vp-c-bg-alt), transparent 50%);
+  backdrop-filter: blur(4px);
+  mask-image: linear-gradient(to bottom, black calc(100% - 16px), transparent 100%);
+}
+
+label {
+  color: var(--vp-c-text-1);
+  padding: 4px 0;
+  line-height: 24px;
+  font-size: 14px;
+  transition: color 0.25s;
+  font-weight: bold;
+  margin-bottom: 4px;
+  display: block;
+  position: relative;
+}
 </style>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Blurs the background of framework select.

| Before | After |
|---|---|
|<img width="183" height="184" src="https://github.com/user-attachments/assets/bc24fd24-7c38-4ef7-9336-0ed124dc7bc4" />|<img width="189" height="189" src="https://github.com/user-attachments/assets/e561792e-b497-43bf-9645-7145226eee7b" />|
|<img width="189" height="152" src="https://github.com/user-attachments/assets/955d3445-26d9-4bf0-9c55-e98a02ecec64" />|<img width="189" height="151" src="https://github.com/user-attachments/assets/8fe8bb7f-46f2-4e6e-a1c2-dc18015ee7e0" />|

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
