### PR TITLE
fix(packages/angular): allow string inputs for size

### DIFF
--- a/packages/angular/src/lucide-config.ts
+++ b/packages/angular/src/lucide-config.ts
@@ -13,7 +13,7 @@ export interface LucideConfig {
    * Width and height.
    * @default 24
    */
-  size: number;
+  size: string | number;
   /**
    * Stroke width
    * @default 2

--- a/packages/angular/src/lucide-icon-base.spec.ts
+++ b/packages/angular/src/lucide-icon-base.spec.ts
@@ -113,12 +113,6 @@ describe('LucideIconBase', () => {
       expect(getSvgAttribute('width')).toBe('18');
       expect(getSvgAttribute('height')).toBe('18');
     });
-    it('should use default on invalid string', () => {
-      size.set('large');
-      fixture.detectChanges();
-      expect(getSvgAttribute('width')).toBe('24');
-      expect(getSvgAttribute('height')).toBe('24');
-    });
   });
 
   describe('strokeWidth', () => {
@@ -132,9 +126,9 @@ describe('LucideIconBase', () => {
       expect(getSvgAttribute('stroke-width')).toBe('1.41');
     });
     it('should allow string stroke width', () => {
-      strokeWidth.set('1px');
+      strokeWidth.set('0.125rem');
       fixture.detectChanges();
-      expect(getSvgAttribute('stroke-width')).toBe('1');
+      expect(getSvgAttribute('stroke-width')).toBe('0.125rem');
     });
   });
 

--- a/packages/angular/src/lucide-icon-base.ts
+++ b/packages/angular/src/lucide-icon-base.ts
@@ -13,20 +13,6 @@ import { LucideIconData, Nullable } from './types';
 import defaultAttributes from './default-attributes';
 import { lucideIconTemplate } from './lucide-icon-template';
 
-function transformNumericStringInput(
-  value: Nullable<string | number>,
-  defaultValue: number,
-): number {
-  if (typeof value === 'string') {
-    const parsedValue = parseInt(value, 10);
-    if (isNaN(parsedValue)) {
-      return defaultValue;
-    }
-    return parsedValue;
-  }
-  return value ?? defaultValue;
-}
-
 /**
  * @internal
  */
@@ -37,10 +23,10 @@ function transformNumericStringInput(
   host: {
     ...defaultAttributes,
     class: 'lucide',
-    '[attr.width]': 'size().toString(10)',
-    '[attr.height]': 'size().toString(10)',
+    '[attr.width]': 'size()',
+    '[attr.height]': 'size()',
     '[attr.stroke]': 'color()',
-    '[attr.stroke-width]': 'strokeWidth().toString(10)',
+    '[attr.stroke-width]': 'strokeWidth()',
     '[attr.aria-hidden]': '!title()',
   },
 })
@@ -68,8 +54,7 @@ export abstract class LucideIconBase {
    * @default 24
    */
   readonly size = input(this.iconConfig.size, {
-    transform: (value: Nullable<string | number>) =>
-      transformNumericStringInput(value, this.iconConfig.size),
+    transform: (value: Nullable<string | number>) => value ?? this.iconConfig.size,
   });
   /**
    * Stroke color.
@@ -83,8 +68,7 @@ export abstract class LucideIconBase {
    * @default 2
    */
   readonly strokeWidth = input(this.iconConfig.strokeWidth, {
-    transform: (value: Nullable<string | number>) =>
-      transformNumericStringInput(value, this.iconConfig.strokeWidth),
+    transform: (value: Nullable<string | number>) => value ?? this.iconConfig.strokeWidth,
   });
   /**
    * If set to true, it adds [`vector-effect="non-scaling-stroke"`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/vector-effect) to child elements.

--- a/packages/angular/src/types.ts
+++ b/packages/angular/src/types.ts
@@ -19,9 +19,9 @@ export type LucideIconData = {
  */
 interface LucideIconProps {
   title: Signal<Nullable<string>>;
-  size: Signal<Nullable<number>>;
+  size: Signal<Nullable<number | string>>;
   color: Signal<Nullable<string>>;
-  strokeWidth: Signal<Nullable<number>>;
+  strokeWidth: Signal<Nullable<number | string>>;
   absoluteStrokeWidth: Signal<Nullable<boolean>>;
 }
 

--- a/packages/lucide-react/src/context.ts
+++ b/packages/lucide-react/src/context.ts
@@ -4,7 +4,7 @@ import { createContext, createElement, type ReactNode, useContext, useMemo } fro
 import { LucideProps } from './types';
 
 type LucideConfig = {
-  size: number;
+  size: string | number;
   color: string;
   strokeWidth: number;
   absoluteStrokeWidth: boolean;

--- a/packages/lucide-react/src/context.ts
+++ b/packages/lucide-react/src/context.ts
@@ -4,7 +4,7 @@ import { createContext, createElement, type ReactNode, useContext, useMemo } fro
 import { LucideProps } from './types';
 
 type LucideConfig = {
-  size: string | number;
+  size: number;
   color: string;
   strokeWidth: number;
   absoluteStrokeWidth: boolean;


### PR DESCRIPTION
Closes issues #4288 #4287

## Description
Allows strokeWidth to be specific as float string, e.g.:

Root Bug:

```tsx
export interface LucideConfig {
  /**
   * Stroke color.
   * @default currentColor
   */
  color: string;
  /**
   * Width and height.
   * @default 24
   */
  size: number;
```

Previously this would get interpreted as `1`.

Core update (other iclude `lucide-icon-base.spec.ts` , `lucide-icon-base.ts` and  `types.ts`):

```tsx
export interface LucideConfig {
  /**
   * Stroke color.
   * @default currentColor
   */
  color: string;
  /**
   * Width and height.
   * @default 24
   */
  size: number | string;
```

This unblocks the recommended global styling pattern from the docs:

Note. This also allows `size` to be specified as float, which is not useful.
But I thought that there is no harm in that, so I didn't guard against it.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.