### PR TITLE
fix(@lucide/svelte): proper doc comments for svelte components

### DIFF
--- a/packages/svelte/scripts/appendBlockComments.mts
+++ b/packages/svelte/scripts/appendBlockComments.mts
@@ -7,6 +7,8 @@ import { getJSBanner } from './license.mts';
 const currentDir = getCurrentDirPath(import.meta.url);
 const targetDirectory = path.join(currentDir, '../dist');
 
+const jsBanner = getJSBanner();
+
 const files = await readdir(targetDirectory, {
   recursive: true,
   encoding: 'utf-8',
@@ -22,43 +24,10 @@ for (const file of files) {
 
   // eslint-disable-next-line no-await-in-loop
   const contents = (await readFile(filepath, { encoding: 'utf-8' })) as unknown as string;
-  let newContents = contents;
   const ext = path.extname(filepath);
-  let license;
 
   if (/\.(js|mjs|cjs|ts)/.test(ext)) {
-    license = getJSBanner();
-  }
-
-  if (license) {
-    newContents = license + contents;
-  }
-
-  // Places icon block comment at the top of the Svelte component class
-  if (/icons\/(.*?)\.svelte\.d\.ts/.test(filepath)) {
-    const svelteFilepath = filepath.replace('.d.ts', '');
     // eslint-disable-next-line no-await-in-loop
-    const svelteFileContents = (await readFile(svelteFilepath, { encoding: 'utf-8' })) as unknown as string;;
-
-    const blockCommentRegex = /\/\*\*\n\s\*\s(@component\s@name)[\s\S]*?\*\//;
-    const blockCommentMatch = blockCommentRegex.exec(svelteFileContents);
-
-    if (blockCommentMatch !== null) {
-      const blockComment = blockCommentMatch[0];
-
-      const exportClassRegex = /export default class (\w+) extends SvelteComponentTyped<(.*?)> {/;
-
-      if (exportClassRegex.test(newContents)) {
-        newContents = newContents.replace(
-          exportClassRegex,
-          `${blockComment}\nexport default class $1 extends SvelteComponentTyped<$2> {`,
-        );
-      }
-    }
-  }
-
-  if (newContents !== contents) {
-    // eslint-disable-next-line no-await-in-loop
-    await writeFile(filepath, newContents, { encoding: 'utf-8' });
+    await writeFile(filepath, jsBanner + contents, { encoding: 'utf-8' });
   }
 }

--- a/packages/svelte/scripts/exportTemplate.mts
+++ b/packages/svelte/scripts/exportTemplate.mts
@@ -1,41 +1,34 @@
 import base64SVG from '@lucide/build-icons/utils/base64SVG';
-import { getJSBanner } from './license.mts';
+import { getHTMLBanner } from './license.mts';
 import defineExportTemplate from '@lucide/build-icons/utils/defineExportTemplate';
 
-export default defineExportTemplate(async ({
-  iconName,
-  children,
-  componentName,
-  getSvg,
-  deprecated,
-  deprecationReason,
-}) => {
-  const svgContents = await getSvg();
-  const svgBase64 = base64SVG(svgContents);
+export default defineExportTemplate(
+  async ({ iconName, children, getSvg, deprecated, deprecationReason }) => {
+    const svgContents = await getSvg();
+    const svgBase64 = base64SVG(svgContents);
 
-  return `\
+    return `\
+${getHTMLBanner()}
 <script lang="ts">
-${getJSBanner()}
 import Icon from '../Icon.svelte';
 import type { IconNode, IconProps } from '../types.js';
 
 let props: IconProps = $props();
 
 const iconNode: IconNode = ${JSON.stringify(children)};
-
-/**
- * @component @name ${componentName}
- * @description Lucide SVG icon component, renders SVG Element with children.
- *
- * @preview ![img](data:image/svg+xml;base64,${svgBase64}) - https://lucide.dev/icons/${iconName}
- * @see https://lucide.dev/guide/packages/lucide-svelte - Documentation
- *
- * @param {Object} props - Lucide icons props and any valid SVG attribute
- * @returns {FunctionalComponent} Svelte component
- * ${deprecated ? `@deprecated ${deprecationReason}` : ''}
- */
 </script>
+
+<!--
+@component
+
+Lucide SVG icon component, renders SVG Element with children.
+
+@preview ![img](data:image/svg+xml;base64,${svgBase64}) - https://lucide.dev/icons/${iconName}
+@see https://lucide.dev/guide/packages/lucide-svelte - Documentation
+${deprecated ? `\n@deprecated ${deprecationReason}\n` : ''}\
+-->
 
 <Icon name="${iconName}" {...props} iconNode={iconNode} />
 `;
-});
+  },
+);

--- a/packages/svelte/scripts/license.mts
+++ b/packages/svelte/scripts/license.mts
@@ -8,7 +8,8 @@ export function getHTMLBanner() {
 <!--
 ${pkg.name} v${pkg.version} - ${pkg.license}
 
-${license}
+This source code is licensed under the ${pkg.license} license.
+See the LICENSE file in the root directory of this source tree.
 -->
 
 `;
@@ -20,8 +21,8 @@ export function getJSBanner() {
  * @file
  * @license ${pkg.name} v${pkg.version} - ${pkg.license}
  *
- * ${license.split('\n').join('\n * ')}
+ * This source code is licensed under the ${pkg.license} license.
+ * See the LICENSE file in the root directory of this source tree.
  */
-
 `;
 }

--- a/packages/svelte/scripts/license.mts
+++ b/packages/svelte/scripts/license.mts
@@ -3,11 +3,25 @@ import pkg from '../package.json' with { type: 'json' };
 
 const license = fs.readFileSync('LICENSE', 'utf-8');
 
+export function getHTMLBanner() {
+  return `\
+<!--
+${pkg.name} v${pkg.version} - ${pkg.license}
+
+${license}
+-->
+
+`;
+}
+
 export function getJSBanner() {
-  return `/**
+  return `\
+/**
+ * @file
  * @license ${pkg.name} v${pkg.version} - ${pkg.license}
  *
  * ${license.split('\n').join('\n * ')}
  */
+
 `;
 }


### PR DESCRIPTION
The doc comments for the icon components like `<AirVent />` are broken. The actual doc comment with information about the icon and preview is not present, instead there's just license in doc comment.

The reason why the real doc comment wasn't present is because of incorrect syntax. In this PR I swapped it for proper svelte html-style doc comment.

The reason why the license was present in the doc comment is because it was inserted into the reexporting file and jsdoc parser applied it to the `export { default } from "./air-vent.svelte";` item. To fix that I added jsdoc `@file` declaration to the license doc comment so that it applied to the file itself.

In `appendBlockComments.mts` there was also some old code leftover from Svelte 4 trying to add jsdoc comment to the component declaration. It did'n work and wasn't needed so I removed it.

## Before/after:

<img width="1019" height="533" alt="before-affter" src="https://github.com/user-attachments/assets/5098f1c1-c2d5-483a-b57b-d822b0af6ef1" />


## P.S.
It seemed very wasteful to include entire text of the license in every single file in the `./dist`. I checked, and other packages (react, preact, vue, solid) just have:

```javascript
/**
 * @license package-name v0.0.1 - ISC
 *
 * This source code is licensed under the ISC license.
 * See the LICENSE file in the root directory of this source tree.
 */
```

Should I change the svelte package to do the same?

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
