### PR TITLE
feat(icons): add power and quick tags to zap and zap-off

### DIFF
--- a/icons/zap-off.json
+++ b/icons/zap-off.json
@@ -3,7 +3,7 @@
   "contributors": [
     "colebemis",
     "karsa-mistmere",
-    "ericfennis",
+    "ericfennis"
   ],
   "tags": [
     "flash",

--- a/icons/zap-off.json
+++ b/icons/zap-off.json
@@ -10,7 +10,8 @@
     "camera",
     "lightning",
     "electricity",
-    "energy"
+    "energy",
+    "power"
   ],
   "categories": [
     "connectivity",

--- a/icons/zap-off.json
+++ b/icons/zap-off.json
@@ -4,7 +4,6 @@
     "colebemis",
     "karsa-mistmere",
     "ericfennis",
-    "swastik7805"
   ],
   "tags": [
     "flash",

--- a/icons/zap-off.json
+++ b/icons/zap-off.json
@@ -3,7 +3,8 @@
   "contributors": [
     "colebemis",
     "karsa-mistmere",
-    "ericfennis"
+    "ericfennis",
+    "swastik7805"
   ],
   "tags": [
     "flash",

--- a/icons/zap.json
+++ b/icons/zap.json
@@ -2,7 +2,7 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "colebemis",
-    "karsa-mistmere",
+    "karsa-mistmere"
   ],
   "tags": [
     "flash",

--- a/icons/zap.json
+++ b/icons/zap.json
@@ -3,7 +3,6 @@
   "contributors": [
     "colebemis",
     "karsa-mistmere",
-    "swastik7805"
   ],
   "tags": [
     "flash",

--- a/icons/zap.json
+++ b/icons/zap.json
@@ -2,14 +2,17 @@
   "$schema": "../icon.schema.json",
   "contributors": [
     "colebemis",
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "swastik7805"
   ],
   "tags": [
     "flash",
     "camera",
     "lightning",
     "electricity",
-    "energy"
+    "energy",
+    "power",
+    "quick"
   ],
   "categories": [
     "connectivity",


### PR DESCRIPTION
closes #3899

## Description
Added `power` and `quick` tags to the `zap.json` and `zap-off.json` meta files. 

- Adds "power" tag to represent energy, electricity, or charging states.
- Adds "quick" tag to represent speed or quick actions.
- Improves overall discoverability for these icons.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.