### PR TITLE
fix(site): ensure Carbon Ad widget dismisses correctly

### DIFF
--- a/docs/.vitepress/theme/components/icons/CarbonAdOverlay.vue
+++ b/docs/.vitepress/theme/components/icons/CarbonAdOverlay.vue
@@ -5,13 +5,13 @@ import IconButton from '../base/IconButton.vue';
 import VPDocAsideCarbonAds from 'vitepress/dist/client/theme-default/components/VPDocAsideCarbonAds.vue';
 import { x } from '../../../data/iconNodes';
 import Icon from '@lucide/vue/src/Icon';
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
 const { theme } = useData();
-const showAd = useSessionStorage('show-carbon-ads', true, {
-  serializer: StorageSerializers.boolean,
-});
+const showAd = useSessionStorage('show-carbon-ads', true);
 const carbonLoaded = ref(true);
+const isHidden = computed(() => !showAd.value || !carbonLoaded.value);
+const closeAd = () => showAd.value = false;
 
 defineProps<{
   drawerOpen: boolean;
@@ -30,13 +30,13 @@ onMounted(() => {
   <div
     :class="{
       'drawer-open': drawerOpen,
-      'hide-ad': !(showAd && carbonLoaded),
+      'hide-ad': isHidden,
     }"
     class="floating-ad"
     v-if="theme.carbonAds"
   >
     <IconButton
-      @click="showAd = false"
+      @click="closeAd"
       class="hide-button"
     >
       <Icon
@@ -99,6 +99,7 @@ onMounted(() => {
   position: absolute;
   top: 8px;
   right: 8px;
+  z-index: 3;
   background-color: transparent;
 }
 </style>


### PR DESCRIPTION
Closes #3999 

## Description
This PR fixes a bug on the `lucide.dev` website where the floating Carbon Ad widget in the bottom-right corner could not be dismissed by clicking the Close (X) icon.

### The Problem
The issue stemmed from how JavaScript evaluates truthiness combined with session storage serialization. 
The ad was hidden using the following inline logic: `:class="{ 'hide-ad': !(showAd && carbonLoaded) }"`

However, when the `showAd` state was saved to `sessionStorage`, the boolean `false` was sometimes serialized and retrieved as the string `"false"`. Because non-empty strings are truthy in JavaScript, the string `"false"` evaluated to `true`. This caused the hide condition to fail, leaving the ad stuck on the screen despite user interaction.

### The Solution
Instead of adding complex workarounds to the template logic, this PR fixes the root cause at the storage level. 

By explicitly passing `{ serializer: StorageSerializers.boolean }` to the `useSessionStorage` hook, we ensure the value is correctly parsed back into a strict boolean (`true`/`false`) rather than a string. This elegantly resolves the truthiness issue and allows the existing inline logic to work perfectly.

**Changes made:**
* Updated `useSessionStorage` in `CarbonAdOverlay.vue` to use `StorageSerializers.boolean`.
* Cleaned up/reverted unnecessary import reordering.
### Evidence

https://github.com/user-attachments/assets/607bceeb-b67d-4d24-9467-18d479d58831





## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.