### PR TITLE
fix(angular): allow float strokeWidth (and size)

### DIFF
--- a/packages/angular/src/lucide-icon-base.spec.ts
+++ b/packages/angular/src/lucide-icon-base.spec.ts
@@ -136,6 +136,11 @@ describe('LucideIconBase', () => {
       fixture.detectChanges();
       expect(getSvgAttribute('stroke-width')).toBe('1');
     });
+    it('should allow float string stroke width', () => {
+      strokeWidth.set('1.5');
+      fixture.detectChanges();
+      expect(getSvgAttribute('stroke-width')).toBe('1.5');
+    });
   });
 
   describe('absoluteStrokeWidth', () => {

--- a/packages/angular/src/lucide-icon-base.ts
+++ b/packages/angular/src/lucide-icon-base.ts
@@ -18,7 +18,7 @@ function transformNumericStringInput(
   defaultValue: number,
 ): number {
   if (typeof value === 'string') {
-    const parsedValue = parseInt(value, 10);
+    const parsedValue = parseFloat(value);
     if (isNaN(parsedValue)) {
       return defaultValue;
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
closes #4287
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Allows strokeWidth to be specific as float string, e.g.:

```
<svg lucideStar strokeWidth="1.2" />
```

Previously this would get interpreted as `1`.

Note. This also allows `size` to be specified as float, which is not useful.
But I thought that there is no harm in that, so I didn't guard against it.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
