### PR TITLE
fix(lucide-font, lucide-static): Fixing code point allocation for unstable icons

### DIFF
--- a/tools/build-font/src/allocateCodepoints.ts
+++ b/tools/build-font/src/allocateCodepoints.ts
@@ -30,24 +30,35 @@ export async function allocateCodePoints({
 
   await Promise.all(
     iconsWithAliases.map(async ([iconName, aliases]) => {
-      // Check if a stable code point was already assigned to this icon
-      let codepoint = baseCodePoints[iconName];
-      if (!codepoint) {
+      const names = [iconName, ...aliases];
+      const existingCodePoints = [
+        ...names
+          .reduce((codePoints, name) => {
+            const codePoint = baseCodePoints[name];
+            if (codePoint !== undefined) {
+              codePoints.add(codePoint);
+            }
+            return codePoints;
+          }, new Set<number>()),
+      ].sort((a, b) => a - b);
+
+      if (existingCodePoints.length > 1) {
+        const aliasList = aliases.join(', ');
+        const codeList = existingCodePoints.join(', ');
+        console.warn(
+          `Conflicting code points found for ${iconName} and its aliases ${aliasList}: ${codeList}. Using lowest.`,
+        );
+      } else if (existingCodePoints.length === 0) {
         console.log(`Code point not found for ${iconName}. Creating new one.`);
-        codepoint = ++maxCodePoint;
-        baseCodePoints[iconName] = codepoint;
       }
 
-      aliases.forEach((alias) => {
-        if (baseCodePoints[alias]) {
-          return;
+      const codePoint = existingCodePoints.length > 0 ? existingCodePoints[0] : ++maxCodePoint;
+      for (const name of names) {
+        if (baseCodePoints[name] !== codePoint) {
+          console.log(`Assigning code point ${codePoint} to ${name}.`);
+          baseCodePoints[name] = codePoint;
         }
-
-        // If the alias does not have a stable code point yet, reuse the one
-        // assigned to the original icon
-        console.log(`Code point not found for alias ${alias}. Reusing from ${iconName}.`);
-        baseCodePoints[alias] = codepoint;
-      });
+      }
     }),
   );
 

--- a/tools/build-font/src/allocateCodepoints.ts
+++ b/tools/build-font/src/allocateCodepoints.ts
@@ -26,23 +26,27 @@ export async function allocateCodePoints({
 }: AllocateCodePointsOptions): Promise<CodePoints> {
   const baseCodePoints = await getLatestCodePoints();
 
-  const endCodePoint = Math.max(...Object.values(baseCodePoints));
+  let maxCodePoint = Math.max(...Object.values(baseCodePoints));
 
   await Promise.all(
     iconsWithAliases.map(async ([iconName, aliases]) => {
-      if (!baseCodePoints[iconName]) {
-        console.log('Code point not found creating new one for', iconName);
-        baseCodePoints[iconName] = endCodePoint + 1;
+      // Check if a stable code point was already assigned to this icon
+      let codepoint = baseCodePoints[iconName];
+      if (!codepoint) {
+        console.log(`Code point not found for ${iconName}. Creating new one.`);
+        codepoint = ++maxCodePoint;
+        baseCodePoints[iconName] = codepoint;
       }
 
-      aliases.forEach((alias, index) => {
+      aliases.forEach((alias) => {
         if (baseCodePoints[alias]) {
           return;
         }
 
-        console.log('Code point not found creating new one for', alias);
-
-        baseCodePoints[alias] = endCodePoint + index + 1;
+        // If the alias does not have a stable code point yet, reuse the one
+        // assigned to the original icon
+        console.log(`Code point not found for alias ${alias}. Reusing from ${iconName}.`);
+        baseCodePoints[alias] = codepoint;
       });
     }),
   );


### PR DESCRIPTION
Closes #4294 

## Description

When adding multiple new icons to the project and building the font, `allocateCodePoints` assigned each of the new icons the same code point. Additionally, if a new icon has multiple aliases, only the first alias got the same code point as the original icon. All other aliases got another code point assigned.

With the changes in this PR, `allocateCodePoints` will now create a new, unstable code point for every new icon. Additionally, _every_ new alias will inherit the code point assigned to the original icon, even if there are multiple aliases.

I have tested the implementation with my local clone. I don't now, if unit tests are expected for this kind of change.

Since I am not very deep into this project, please check that the implemented behavior actually matches your expectations. Thank you. 😊


## Before Submitting

- [X] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [X] I've checked if there was an existing PR that solves the same issue.
