### PR TITLE
docs: add missing period to TypeScript Support description

### DIFF
--- a/docs/guide/react/advanced/typescript.md
+++ b/docs/guide/react/advanced/typescript.md
@@ -5,7 +5,7 @@ description: Learn about the different types exported by the `lucide-react` pack
 # TypeScript Support
 
 List of exported types from the `lucide-react` package.
-These can be used to type your components when using Lucide icons in a TypeScript React project
+These can be used to type your components when using Lucide icons in a TypeScript React project.
 
 ## `LucideProps`
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Add missing period to the end of the sentence in the description of https://lucide.dev/guide/react/advanced/typescript.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
