### PR TITLE
docs(site): add @respeak/lucide-motion-vue package

### DIFF
--- a/docs/.vitepress/data/packageData.thirdParty.json
+++ b/docs/.vitepress/data/packageData.thirdParty.json
@@ -209,5 +209,24 @@
     ],
     "source": "https://github.com/shx08/strapi-lucide-icons",
     "documentation": "https://github.com/shx08/strapi-lucide-icons/blob/main/README.md"
+  },
+  {
+    "name": "@respeak/lucide-motion-vue",
+    "description": "Lucide icons animated with Motion for Vue 3. Tree-shakable, TypeScript-first — with animateOnHover, animateOnTap, animateOnView triggers and a composable <AnimateIcon> wrapper that turns any element into the trigger.",
+    "icon": "/framework-logos/vue-next.svg",
+    "shields": [
+      {
+        "alt": "Latest Stable Version",
+        "src": "https://img.shields.io/npm/v/@respeak/lucide-motion-vue",
+        "href": "https://www.npmjs.com/package/@respeak/lucide-motion-vue"
+      },
+      {
+        "alt": "Total Downloads",
+        "src": "https://img.shields.io/npm/dm/@respeak/lucide-motion-vue",
+        "href": "https://www.npmjs.com/package/@respeak/lucide-motion-vue"
+      }
+    ],
+    "source": "https://github.com/respeak-io/lucide-motion-vue",
+    "documentation": "https://respeak-io.github.io/lucide-motion-vue/"
   }
 ]


### PR DESCRIPTION
## Description

This PR adds `@respeak/lucide-motion-vue` to the third-party packages section on [lucide.dev/packages](https://lucide.dev/packages).

It includes:
- a new `@respeak/lucide-motion-vue` entry in `docs/.vitepress/data/packageData.thirdParty.json`

No new framework logo asset is needed — the existing `vue-next.svg` is reused.

`@respeak/lucide-motion-vue` is a Vue 3 package that ships 516 Lucide icons with built-in animations via Motion for Vue. Each icon accepts ergonomic triggers (`animateOnHover`, `animateOnTap`, `animateOnView`) directly, or can be driven by a composable `<AnimateIcon>` wrapper that turns any element (button, card, link) into the trigger. Tree-shakable with one chunk per icon, TypeScript-first, MIT. Animation variants are adapted from animate-ui and pqoqubbw/icons (attribution preserved in the package metadata and `ATTRIBUTIONS.md`).

- npm: https://www.npmjs.com/package/@respeak/lucide-motion-vue
- docs + live playground: https://respeak-io.github.io/lucide-motion-vue/
- repo: https://github.com/respeak-io/lucide-motion-vue

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.