### PR TITLE
feat(icons): add personal-watercraft icon

### DIFF
--- a/icons/personal-watercraft.json
+++ b/icons/personal-watercraft.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "philiphohn"
+  ],
+  "tags": [
+    "jet ski",
+    "watercraft",
+    "marine",
+    "boating",
+    "water sport"
+  ],
+  "categories": [
+    "transportation"
+  ]
+}

--- a/icons/personal-watercraft.svg
+++ b/icons/personal-watercraft.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="8.47mm"
+  height="8.47mm"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3.03 10.1c0-.55.45-1 1-1h16c.55 0 1 .45 1 1 0 2.21-2.79 2.5-5 2.5h-12c-.55 0-1-.45-1-1z" />
+  <path d="M11.03 5.6h2c3.31 0 5 1 8 4m-19 7c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1s1.2 1 2.5 1c2.69 0 2.31-2 5-2 1.3 0 1.9.5 2.5 1" />
+</svg>

--- a/icons/personal-watercraft.svg
+++ b/icons/personal-watercraft.svg
@@ -1,7 +1,7 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  width="8.47mm"
-  height="8.47mm"
+  width="24"
+  height="24"
   viewBox="0 0 24 24"
   fill="none"
   stroke="currentColor"


### PR DESCRIPTION
## Description

closes #4312

This PR adds a new Lucide icon: `personal-watercraft`.

The icon depicts a personal watercraft / jet ski on water in a minimal Lucide-compatible outline style. It is intended to represent this specific type of small motorized water vehicle more clearly than using a generic boat icon.

### Icon use case

- Water sports and marine rental apps, where users can browse or book activities such as jet ski / personal watercraft rentals.
- Harbor, marina, and waterfront maps, where a distinct icon is needed for personal watercraft launch points, docking areas, or designated zones.
- Travel and excursion platforms, where guided personal watercraft tours or resort activities need a more accurate symbol than a generic transport icon.
- Safety, boating rules, and marine signage interfaces, where personal watercraft need to be distinguished from larger boats or other water vehicles.

### Alternative icon designs

I do not currently have alternative designs to include in this PR.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: ship
- [ ] I've based them on the following design:

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.