### PR TITLE
feat(icons): add person-walking icon

### DIFF
--- a/icons/person-walking.json
+++ b/icons/person-walking.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "akinshaywai"
+  ],
+  "tags": [
+    "people",
+    "human",
+    "pedestrian",
+    "walk",
+    "movement",
+    "travel",
+    "stick figure"
+  ],
+  "categories": [
+    "accessibility",
+    "people",
+    "transportation"
+  ]
+}

--- a/icons/person-walking.svg
+++ b/icons/person-walking.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="13" cy="4" r="2" />
+  <path d="M13 6v8" />
+  <path d="m9 13 4-3 3 3" />
+  <path d="m13 14 4 8" />
+  <path d="m13 14-5 8" />
+</svg>


### PR DESCRIPTION
## Description

Adds a `person-walking` icon — a stick figure in a walking pose with spread arms and legs.

This complements the existing `person-standing` icon and fills a gap for use cases like pedestrian navigation, fitness apps, step counters, and accessibility indicators.

## Preview

The icon uses the standard Lucide style: 24×24 viewBox, `stroke="currentColor"`, `stroke-width="2"`, round caps and joins.

**Paths:**
- Head: `<circle cx="13" cy="4" r="2" />`
- Body: vertical line from (13,6) to (13,14)
- Arms: angled from (9,13) through (13,10) to (16,13)
- Legs: spreading from (13,14) to (8,22) and (17,22)

## Possible use cases

- Pedestrian / walking directions
- Step counter / fitness apps
- Accessibility / mobility indicators
- Travel and navigation UI

## Checklist

- [x] Icon follows the [Lucide icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] SVG uses `stroke="currentColor"`, `fill="none"`, `stroke-width="2"`, `stroke-linecap="round"`, `stroke-linejoin="round"`
- [x] 24×24 viewBox
- [x] JSON metadata includes tags and categories