### PR TITLE
feat(icons): add digital-watch icon

### DIFF
--- a/icons/digital-watch.json
+++ b/icons/digital-watch.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "akinshaywai"
+  ],
+  "tags": [
+    "watch",
+    "smartwatch",
+    "wearable",
+    "time",
+    "clock",
+    "digital",
+    "fitness tracker"
+  ],
+  "categories": [
+    "devices",
+    "time"
+  ]
+}

--- a/icons/digital-watch.svg
+++ b/icons/digital-watch.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M8 6h8" />
+  <path d="M8 6a3 3 0 0 0-3 3v6a3 3 0 0 0 3 3" />
+  <path d="M16 6a3 3 0 0 1 3 3v6a3 3 0 0 1-3 3" />
+  <path d="M16 18H8" />
+  <path d="M8 6c0-2 1-4 4-4s4 2 4 4" />
+  <path d="M8 18c0 2 1 4 4 4s4-2 4-4" />
+  <path d="M11 12h2" />
+</svg>


### PR DESCRIPTION
## Description

Adds a `digital-watch` icon — a smartwatch / digital watch with a band and a horizontal bar on the screen representing a digital display.

This extends the existing `watch` icon (analog face with hands) with a digital/smart variant. The two icons form a complementary pair.

## Preview

The icon is composed of:
- Watch face body: left and right sides with `rx=3` rounded corners
- Top and bottom bands curving to the 12 o'clock and 6 o'clock positions
- A short horizontal bar in the center of the screen (digital display indicator)

## Possible use cases

- Smartwatch / wearable device settings
- Fitness tracker apps
- Time and health monitoring UI
- Device pairing or connectivity screens

## Checklist

- [x] Icon follows the [Lucide icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] SVG uses `stroke="currentColor"`, `fill="none"`, `stroke-width="2"`, `stroke-linecap="round"`, `stroke-linejoin="round"`
- [x] 24×24 viewBox
- [x] Complements existing `watch` icon
- [x] JSON metadata includes tags and categories