### PR TITLE
fix: remove 'less' from brand stopwords

### DIFF
--- a/brand-stopwords.json
+++ b/brand-stopwords.json
@@ -54,7 +54,6 @@
   "jira": "Jira",
   "kotlin": "Kotlin",
   "kubernetes": "Kubernetes",
-  "less": "Less",
   "leetcode": "LeetCode",
   "leet-code": "LeetCode",
   "line": "LINE",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Fix brand stop word list false positive case.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
