### PR TITLE
fix(@lucide/vue): Clone slots before passing to icon

### DIFF
--- a/packages/vue/src/createLucideIcon.ts
+++ b/packages/vue/src/createLucideIcon.ts
@@ -19,7 +19,7 @@ const createLucideIcon =
         iconNode,
         name: iconName,
       },
-      slots,
+      slots.default ? { default: slots.default } : undefined,
     );
 
 export default createLucideIcon;

--- a/packages/vue/tests/lucide-vue.spec.ts
+++ b/packages/vue/tests/lucide-vue.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/vue';
 import { Smile, Edit2, Pen } from '../src/lucide-vue';
+import createLucideIcon from '../src/createLucideIcon';
 import defaultAttributes from '../src/defaultAttributes';
 
 describe('Using lucide icon components', () => {
@@ -106,6 +107,25 @@ describe('Using lucide icon components', () => {
 
     expect(textElement).toBeInTheDocument();
     expect(container).toMatchSnapshot();
+  });
+
+  it('should handle non-extensible slots objects', () => {
+    const Icon = createLucideIcon('test-icon', [['path', { d: 'M0 0h1', key: 'test-key' }]]);
+    const slots = Object.freeze({
+      default: () => 'Hello World',
+    });
+
+    expect(() =>
+      Icon(
+        {},
+        {
+          attrs: {},
+          emit: vi.fn(),
+          expose: vi.fn(),
+          slots,
+        },
+      ),
+    ).not.toThrow();
   });
 
   it('should render the alias icon', () => {


### PR DESCRIPTION
## What

Fixes the Vue package so that generated icon components pass a fresh slots object to the inner Icon component, instead of forwarding Vue’s setup-context slots object directly.

## Why

Vue’s VDOM runtime may annotate slot objects while normalizing children. In Vue Vapor / VDOM interop, the original slots object can be non-extensible, which can lead to errors such as: `TypeError: Cannot add property _ctx, object is not extensible`

This change preserves the default slot behavior while avoiding passing the original non-extensible slots object to h().

Fixes #3579.