### PR TITLE
fix(site): reserve space for icon detail drawer

### DIFF
--- a/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue
@@ -156,11 +156,11 @@ function handleCloseDrawer() {
   if (searchQueryDebounced.value) {
     url.searchParams.set('search', searchQueryDebounced.value);
   }
-  
+
   if (selectedCategory.value) {
     url.hash = selectedCategory.value;
   }
-  
+
   window.history.pushState({}, '', url);
 }
 </script>
@@ -169,6 +169,7 @@ function handleCloseDrawer() {
   <div
     ref="overviewEl"
     class="overview-container"
+    :class="{ 'icon-drawer-open': activeIconName }"
   >
     <StickyBar class="category-search">
       <InputSearch

--- a/docs/.vitepress/theme/components/icons/IconsOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsOverview.vue
@@ -124,7 +124,7 @@ function handleCloseDrawer() {
   if (searchQueryDebounced.value) {
     url.searchParams.set('search', searchQueryDebounced.value);
   }
-  
+
   window.history.pushState({}, '', url);
 }
 </script>
@@ -133,6 +133,7 @@ function handleCloseDrawer() {
   <div
     ref="overviewEl"
     class="overview-container"
+    :class="{ 'icon-drawer-open': activeIconName }"
   >
     <StickyBar>
       <InputSearch

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -117,6 +117,10 @@
   padding-left: 0;
 }
 
+.overview-container.icon-drawer-open {
+  padding-bottom: 288px;
+}
+
 .VPHomeHero .container {
   flex-direction: column-reverse;
 }


### PR DESCRIPTION
## Summary

Fixes #4343 by adding bottom spacing to the icon overview only while the icon detail drawer is open.

The drawer is fixed to the bottom of the viewport and has a 288px panel height; the icon overview now reserves the same amount of scroll space while an icon is selected, so the final rows are not hidden behind the drawer.

## Validation

- `gh issue view 4343`
- Duplicate PR searches and open PR list review
- `pnpm exec prettier --check docs/.vitepress/theme/components/icons/IconsOverview.vue docs/.vitepress/theme/components/icons/IconsCategoryOverview.vue docs/.vitepress/theme/style.css`
- `pnpm --filter @lucide/docs docs:build`
- `git diff --check`
- Commit hook `checkIcons`

I did not find a repo-provided visual/E2E test for this drawer interaction, so validation is build, formatting, and static review.
