### PR TITLE
feat(icons): added transmission-tower icon

### DIFF
--- a/icons/transmission-tower.json
+++ b/icons/transmission-tower.json
@@ -10,6 +10,8 @@
     "power",
     "power line",
     "pylon",
+    "tower",
+    "transmission",
     "utility"
   ],
   "categories": [

--- a/icons/transmission-tower.json
+++ b/icons/transmission-tower.json
@@ -1,6 +1,8 @@
 {
   "$schema": "../icon.schema.json",
-  "contributors": ["AJAyanbisi"],
+  "contributors": [
+    "AJAyanbisi"
+  ],
   "tags": [
     "electric",
     "electricity",

--- a/icons/transmission-tower.json
+++ b/icons/transmission-tower.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": ["AJAyanbisi"],
+  "tags": [
+    "electric",
+    "electricity",
+    "energy",
+    "grid",
+    "high voltage",
+    "power",
+    "power line",
+    "pylon",
+    "utility"
+  ],
+  "categories": [
+    "devices",
+    "navigation",
+    "science",
+    "sustainability"
+  ]
+}

--- a/icons/transmission-tower.svg
+++ b/icons/transmission-tower.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2 22H22" />
+  <path d="M4.5 22L8.916 7.281C8.972 7.095 9 6.901 9 6.706V3" />
+  <path d="M19.5 22L15.084 7.281C15.028 7.095 15 6.901 15 6.706V3" />
+  <path d="M5.5 20L17 14.5" />
+  <path d="M18.5 20L7 14.5" />
+  <path d="M7 14.5L15.5 9.5" />
+  <path d="M17 14.5L8.5 9.5" />
+  <path d="M3 9V7.937C3 7.343 3.264 6.78 3.72 6.4L8.444 2.464C8.803 2.164 9.256 2 9.724 2H14.276C14.744 2 15.197 2.164 15.556 2.464L20.28 6.4C20.736 6.78 21 7.343 21 7.937V9" />
+  <path d="M4 7H20" />
+</svg>

--- a/icons/transmission-tower.svg
+++ b/icons/transmission-tower.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="M2 22H22" />
   <path d="M4.5 22L8.916 7.281C8.972 7.095 9 6.901 9 6.706V3" />
   <path d="M19.5 22L15.084 7.281C15.028 7.095 15 6.901 15 6.706V3" />


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added a new `transmission-tower` icon depicting an electricity pylon / high-voltage transmission structure.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
For interfaces related to energy, electricity, utilities, the power grid, infrastructure dashboards, and sustainability/clean-energy contexts.

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->
N/A

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.