### PR TITLE
feat(site): persist home page customizer settings in localStorage

### DIFF
--- a/docs/.vitepress/theme/components/home/HomeIconCustomizer.vue
+++ b/docs/.vitepress/theme/components/home/HomeIconCustomizer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { syncRef, useCssVar } from '@vueuse/core'
+import { syncRef, useCssVar, useLocalStorage } from '@vueuse/core'
 import HomeContainer from './HomeContainer.vue'
 import RangeSlider from '../base/RangeSlider.vue'
 import InputField from '../base/InputField.vue'
@@ -11,10 +11,10 @@ import Switch from '../base/Switch.vue'
 
 
 const iconContainer = ref<HTMLElement | null>()
-const color = ref('currentColor')
-const strokeWidth = ref(2)
-const size = ref(24)
-const absoluteStrokeWidth = ref(false)
+const color = useLocalStorage('lucide-custom-color', 'currentColor')
+const strokeWidth = useLocalStorage('lucide-custom-strokeWidth', 2)
+const size = useLocalStorage('lucide-custom-size', 24)
+const absoluteStrokeWidth = useLocalStorage('lucide-custom-absoluteStroke', false)
 
 const colorCssVar = useCssVar(
   '--customize-color',

--- a/docs/.vitepress/theme/components/home/HomeIconCustomizer.vue
+++ b/docs/.vitepress/theme/components/home/HomeIconCustomizer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { syncRef, useCssVar, useLocalStorage } from '@vueuse/core'
+import { syncRef, useCssVar } from '@vueuse/core'
 import HomeContainer from './HomeContainer.vue'
 import RangeSlider from '../base/RangeSlider.vue'
 import InputField from '../base/InputField.vue'
@@ -9,12 +9,13 @@ import ResetButton from '../base/ResetButton.vue'
 import HomeIconCustomizerIcons from './HomeIconCustomizerIcons.vue'
 import Switch from '../base/Switch.vue'
 
-
 const iconContainer = ref<HTMLElement | null>()
-const color = useLocalStorage('lucide-custom-color', 'currentColor')
-const strokeWidth = useLocalStorage('lucide-custom-strokeWidth', 2)
-const size = useLocalStorage('lucide-custom-size', 24)
-const absoluteStrokeWidth = useLocalStorage('lucide-custom-absoluteStroke', false)
+
+// Reverted back to standard refs so they don't persist on refresh
+const color = ref('currentColor')
+const strokeWidth = ref(2)
+const size = ref(24)
+const absoluteStrokeWidth = ref(false)
 
 const colorCssVar = useCssVar(
   '--customize-color',

--- a/docs/.vitepress/theme/components/home/HomeIconCustomizer.vue
+++ b/docs/.vitepress/theme/components/home/HomeIconCustomizer.vue
@@ -9,9 +9,8 @@ import ResetButton from '../base/ResetButton.vue'
 import HomeIconCustomizerIcons from './HomeIconCustomizerIcons.vue'
 import Switch from '../base/Switch.vue'
 
-const iconContainer = ref<HTMLElement | null>()
 
-// Reverted back to standard refs so they don't persist on refresh
+const iconContainer = ref<HTMLElement | null>()
 const color = ref('currentColor')
 const strokeWidth = ref(2)
 const size = ref(24)

--- a/docs/.vitepress/theme/composables/useIconStyle.ts
+++ b/docs/.vitepress/theme/composables/useIconStyle.ts
@@ -23,7 +23,10 @@ export const iconStyleContext = {
   size: useLocalStorage('lucide-custom-size', STYLE_DEFAULTS.size),
   strokeWidth: useLocalStorage('lucide-custom-strokeWidth', STYLE_DEFAULTS.strokeWidth),
   color: useLocalStorage('lucide-custom-color', STYLE_DEFAULTS.color),
-  absoluteStrokeWidth: useLocalStorage('lucide-custom-absoluteStroke', STYLE_DEFAULTS.absoluteStrokeWidth),
+  absoluteStrokeWidth: useLocalStorage(
+    'lucide-custom-absoluteStroke',
+    STYLE_DEFAULTS.absoluteStrokeWidth,
+  ),
 };
 
 export function useIconStyleContext(): IconSizeContext {

--- a/docs/.vitepress/theme/composables/useIconStyle.ts
+++ b/docs/.vitepress/theme/composables/useIconStyle.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import { ref, inject, Ref } from 'vue';
+import { useLocalStorage } from '@vueuse/core';
 
 export const ICON_STYLE_CONTEXT = Symbol('style');
 
@@ -19,10 +20,10 @@ export const STYLE_DEFAULTS = {
 };
 
 export const iconStyleContext = {
-  size: ref(24),
-  strokeWidth: ref(2),
-  color: ref('currentColor'),
-  absoluteStrokeWidth: ref(false),
+  size: useLocalStorage('lucide-custom-size', STYLE_DEFAULTS.size),
+  strokeWidth: useLocalStorage('lucide-custom-strokeWidth', STYLE_DEFAULTS.strokeWidth),
+  color: useLocalStorage('lucide-custom-color', STYLE_DEFAULTS.color),
+  absoluteStrokeWidth: useLocalStorage('lucide-custom-absoluteStroke', STYLE_DEFAULTS.absoluteStrokeWidth),
 };
 
 export function useIconStyleContext(): IconSizeContext {


### PR DESCRIPTION
closes #4358

## Description
This PR resolves a UX issue where user customization choices (Color, Stroke Width, Size, and Absolute Stroke Width) on the home page customizer would reset upon a page refresh or navigation change.

By replacing the standard reactive states with `useLocalStorage` from `@vueuse/core`, these configurations now gracefully persist across sessions.

## Before Submitting - [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.