### PR TITLE
fix(gh-icon): limit icon size to a maximum of 256 pixels

### DIFF
--- a/docs/.vitepress/api/gh-icon/dpi/[...data].get.ts
+++ b/docs/.vitepress/api/gh-icon/dpi/[...data].get.ts
@@ -11,7 +11,7 @@ export default eventHandler(async (event) => {
   const name = params.data.split('/').at(-3);
   const iconSizeString = params.data.split('/').at(-2);
   const svgData = params.data.split('/').at(-1);
-  const iconSize = parseInt(iconSizeString, 10);
+  const iconSize = Math.min(parseInt(iconSizeString, 10) || imageSize, 256);
   const data = svgData.slice(0, -4);
 
   const prevSvg = iconNodes[name]


### PR DESCRIPTION
Ensure icon size does not exceed 256 pixels.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
