### PR TITLE
feat: add globe-check icon

### DIFF
--- a/icons/globe-check.json
+++ b/icons/globe-check.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "pratik1258m"
+  ],
+  "tags": [
+    "globe",
+    "world",
+    "browser",
+    "language",
+    "translate",
+    "internationalization",
+    "localization",
+    "done",
+    "check",
+    "status",
+    "verified",
+    "complete",
+    "success"
+  ],
+  "categories": [
+    "navigation",
+    "connectivity"
+  ]
+}

--- a/icons/globe-check.svg
+++ b/icons/globe-check.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 12h20A10 10 0 1 1 12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 4-10" />
+  <path d="m15 8 2 2 4-4" />
+</svg>


### PR DESCRIPTION
### Description
This PR adds the highly requested `globe-check` icon (Closes #4332). 
It represents fully translated resources, localizations, or verified internationalization statuses.

### Design Decisions
- Positioned a clean `6x6` checkmark in the top-right quadrant (`m15 8 2 2 4-4`).
- Utilized the exact same modified `globe` path as `globe-x` to ensure perfect visual consistency, keeping the top-right quadrant clear of overlapping circle segments and meridians.
- Created `globe-check.json` containing search tags ("translate", "language", "localization", "internationalization", "done", "verified", "success") under the `navigation` and `connectivity` categories.

### Checklist
- [x] Tested locally with `pnpm run lint` and `pnpm run build`
- [x] SVG geometry conforms to 24x24 grid, 2px stroke, round caps/joins
- [x] JSON metadata validated against `icon.schema.json`
