### PR TITLE
fix(docs): force hide #bb-banner, if html.has-bb-banner is missing

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -162,3 +162,9 @@
   margin: 0 auto 48px;
   max-width: 480px;
 }
+
+html:not(.has-bb-banner) #bb-banner {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}


### PR DESCRIPTION
closes #4406

## Description

After having closed the certificates.dev banner, `.has-bb-banner` gets removed from `<html>` and `#bb-banner` gets removed, but when selecting different icons, the banner is replaced in the DOM.

This is a simple CSS fix that makes sure that the banner is fully hidden and non-interactive if the appropriate class is missing from `<html>`.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
