### PR TITLE
fix(docs): Remove `@next` from installation instructions for`@lucide/svelte`

### DIFF
--- a/docs/guide/svelte/getting-started.md
+++ b/docs/guide/svelte/getting-started.md
@@ -15,24 +15,22 @@ Make sure you have a Svelte environment set up. If you don't have one yet, you c
 
 ## Installation
 
-<!-- TODO: v1 Remove After full release -->
-
 ::: code-group
 
 ```sh [pnpm]
-pnpm install @lucide/svelte@next
+pnpm install @lucide/svelte
 ```
 
 ```sh [yarn]
-yarn add @lucide/svelte@next
+yarn add @lucide/svelte
 ```
 
 ```sh [npm]
-npm install @lucide/svelte@next
+npm install @lucide/svelte
 ```
 
 ```sh [bun]
-bun add @lucide/svelte@next
+bun add @lucide/svelte
 ```
 
 :::


### PR DESCRIPTION



## Description

Installing `@lucide/svelte@next` currently gets version 1.3.0, which is out of date compared to installing `@lucide/svelte` (aka `@lucide/svelte@latest`), which gets version 1.17.0. It seems to make more sense to instruct users to get the latest version.

This change matches identical changes to the getting-started guides for other frameworks in 5f83bbf7e77ce5d91f2acbd146058e700d968930 - it seems like the omission of Svelte was likely an oversight (?)

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
