### PR TITLE
Update lucide getting-started.md: Example using a CDN

### DIFF
--- a/docs/guide/lucide/getting-started.md
+++ b/docs/guide/lucide/getting-started.md
@@ -112,7 +112,7 @@ createIcons({
 
 ```html
 <!DOCTYPE html>
-<script async onload="lucide.createIcons()" src="https://unpkg.com/lucide@latest"></script>
+<script defer onload="lucide.createIcons()" src="https://unpkg.com/lucide@latest"></script>
 <body>
   <i data-lucide="volume-2" class="my-class"></i>
   <i data-lucide="x"></i>

--- a/docs/guide/lucide/getting-started.md
+++ b/docs/guide/lucide/getting-started.md
@@ -112,15 +112,11 @@ createIcons({
 
 ```html
 <!DOCTYPE html>
+<script async onload="lucide.createIcons()" src="https://unpkg.com/lucide@latest"></script>
 <body>
   <i data-lucide="volume-2" class="my-class"></i>
   <i data-lucide="x"></i>
   <i data-lucide="menu"></i>
-
-  <script src="https://unpkg.com/lucide@latest"></script>
-  <script>
-    lucide.createIcons();
-  </script>
 </body>
 ```
 


### PR DESCRIPTION
The example is blocking and should follow standards of being put in the head of the document. lucide.min.js is not a small file (~400KB) to give the best/simplest user experience defer + onload should be used.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [ x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ x] I've checked if there was an existing PR that solves the same issue.