### PR TITLE
feat(packages/angular): add support for Angular v22 and onwards

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -66,7 +66,7 @@
     "typescript": "~5.9.2"
   },
   "peerDependencies": {
-    "@angular/common": "17.x - 21.x",
-    "@angular/core": "17.x - 21.x"
+    "@angular/common": ">=17.0.0",
+    "@angular/core": ">=17.0.0"
   }
 }


### PR DESCRIPTION
closes #4446

## Description

Given the package’s limited surface area and reliance on stable public Angular APIs, I updated the peer dependency range in `packages/angular/package.json` from `17.x - 21.x` to `>=17.0.0`, allowing compatibility with Angular v17 and newer without requiring peer dependency updates for each new Angular major release.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
