### PR TITLE
fix(lucide-react-native): Fix provider exports

### DIFF
--- a/packages/lucide-react-native/rollup.config.mjs
+++ b/packages/lucide-react-native/rollup.config.mjs
@@ -33,7 +33,6 @@ const configs = bundles
         ...(preserveModules
           ? {
               dir: `${outputDir}/${format}`,
-              exports: 'auto',
               entryFileNames: `[name].${extension}`,
             }
           : {


### PR DESCRIPTION
Fixes #4424

- Fixed by removing the `export: auto` property in the ESM output.