### PR TITLE
feat(icons): added `typewriter` icon

### DIFF
--- a/icons/typewriter.json
+++ b/icons/typewriter.json
@@ -7,10 +7,17 @@
     "writing",
     "writer",
     "paper",
-    "pages"
+    "pages",
+    "typing",
+    "retro",
+    "vintage",
+    "keyboard",
+    "author"
   ],
   "categories": [
     "text",
-    "tools"
+    "tools",
+    "devices",
+    "design"
   ]
 }

--- a/icons/typewriter.json
+++ b/icons/typewriter.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "Jepl4r"
+  ],
+  "tags": [
+    "writing",
+    "writer",
+    "paper",
+    "pages"
+  ],
+  "categories": [
+    "text",
+    "tools"
+  ]
+}

--- a/icons/typewriter.svg
+++ b/icons/typewriter.svg
@@ -1,18 +1,26 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  width="18"
-  height="18"
-  viewBox="0 0 18 18"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
   fill="none"
   stroke="currentColor"
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M1.5,7.5l0,3" />
-  <path d="M1.5,9l15,0" />
-  <path d="M16.5,7.5l0,3" />
-  <path d="M3.75,9l0,5.4c0,0.745 0.605,1.35 1.35,1.35l7.8,0c0.745,0 1.35,-0.605 1.35,-1.35l0,-5.4" />
-  <path d="M5.25,8.25l0,-4.65c0,-0.745 0.605,-1.35 1.35,-1.35l4.8,0c0.745,0 1.35,0.605 1.35,1.35l0,4.65" />
-  <path d="M7.5 12.5 L10.5 12.5" />
+  <path d="M10 18 L14 18" />
+  <path d="M16.5 2 C17.245 2 18 2.755 18 3.5" />
+  <path d="M18 22 C18.745 22 19.5 21.245 19.5 20.5" />
+  <path d="M18 3.5 L18 12" />
+  <path d="M19.5 20.5 L19.5 12" />
+  <path d="M2 10.5 L2 13.5" />
+  <path d="M2 12 L22 12" />
+  <path d="M22 10.5 L22 13.5" />
+  <path d="M4.5 12 L4.5 20.5" />
+  <path d="M4.5 20.5 C4.5 21.245 5.255 22 6 22" />
+  <path d="M6 12 L6 3.5" />
+  <path d="M6 22 L18 22" />
+  <path d="M6 3.5 C6 2.755 6.755 2 7.5 2" />
+  <path d="M7.5 2 L16.5 2" />
 </svg>

--- a/icons/typewriter.svg
+++ b/icons/typewriter.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="18"
+  height="18"
+  viewBox="0 0 18 18"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M1.5,7.5l0,3" />
+  <path d="M1.5,9l15,0" />
+  <path d="M16.5,7.5l0,3" />
+  <path d="M3.75,9l0,5.4c0,0.745 0.605,1.35 1.35,1.35l7.8,0c0.745,0 1.35,-0.605 1.35,-1.35l0,-5.4" />
+  <path d="M5.25,8.25l0,-4.65c0,-0.745 0.605,-1.35 1.35,-1.35l4.8,0c0.745,0 1.35,0.605 1.35,1.35l0,4.65" />
+  <path d="M7.5 12.5 L10.5 12.5" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `typewriter` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
Ideal for representing a toggle that changes the writing mode in writing apps, e.g. typewriter mode, where the cursor remains centered on screen as you type, mimicking a typewriter.

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [ ] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [ ] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.