### PR TITLE
feat(icons): add merge icon for workflow and node-based interfaces

### DIFF
--- a/icons/merge.json
+++ b/icons/merge.json
@@ -1,17 +1,16 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "karsa-mistmere",
-    "ericfennis"
+    "safvanms"
   ],
-  "use-cases": [],
   "tags": [
-    "combine",
-    "join",
-    "unite"
+    "node",
+    "workflow",
+    "merge"
   ],
   "categories": [
-    "development",
-    "arrows"
+    "merge",
+    "node",
+    "workflow"
   ]
 }

--- a/icons/merge.svg
+++ b/icons/merge.svg
@@ -9,7 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m8 6 4-4 4 4" />
-  <path d="M12 2v10.3a4 4 0 0 1-1.172 2.872L4 22" />
-  <path d="m20 22-5-5" />
+  <path d="M7 18h3c4 0 6-2 7-6" />
+  <path d="M7 6h3c4 0 6 2 7 6" />
+  <rect x="17" y="10" width="4" height="4" rx="1" />
+  <rect x="3" y="16" width="4" height="4" rx="1" />
+  <rect x="3" y="4" width="4" height="4" rx="1" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
Icon name : Merge

Use cases :

Represents multiple inputs converging into a single output. Useful for workflow builders, automation platforms, node-based editors, data pipelines, and visual programming interfaces where several branches or nodes are merged into one execution path.

Design rationale :

The icon consists of three source nodes converging into a single destination node. The simplified geometry makes the merge operation immediately recognizable at small sizes while remaining consistent with Lucide's minimal visual language. Rounded-square nodes were chosen instead of circles to better align with common workflow and node-editor representations.

Aliases :

* merge-nodes
* merge-workflow
* node-merge
* converge

Examples :

* Merging multiple workflow branches into a single step
* Combining outputs from several nodes in a visual editor
* Data aggregation points in ETL pipelines
* Synchronization or convergence stages in automation flows