### PR TITLE
fix(docs): rename navigation category label

### DIFF
--- a/categories/navigation.json
+++ b/categories/navigation.json
@@ -1,5 +1,5 @@
 {
   "$schema": "../category.schema.json",
-  "title": "Navigation, Maps, and POIs",
+  "title": "Places & navigation",
   "icon": "compass"
 }

--- a/docs/.vitepress/data/categoriesData.json
+++ b/docs/.vitepress/data/categoriesData.json
@@ -97,7 +97,7 @@
   },
   {
     "name": "navigation",
-    "title": "Navigation, Maps, and POIs"
+    "title": "Places & navigation"
   },
   {
     "name": "notifications",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
Rename the category label from “Navigation, Maps, and POIs” to “Places & navigation”.

This category currently uses a noticeably longer label than neighboring category names, which can cause wrapping and layout pressure at constrained widths. The new label keeps the same conceptual coverage while being shorter and easier to read.

### Before

![Before: Navigation, Maps, and POIs](https://gist.githubusercontent.com/Hsiii/82f71361741d436822e615bd352a5db4/raw/f8a96652511f68fd942f23ead3cbda549b5a8f02/lucide-category-before.svg)

### After

![After: Places & navigation](https://gist.githubusercontent.com/Hsiii/82f71361741d436822e615bd352a5db4/raw/749d0815a366cbcb0c0f6688f67ebd7bacb63f67/lucide-category-after.svg)

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [ ] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.

## Validation

- Regenerated docs category metadata with `pnpm run prebuild:categoriesJson`.
- Verified the categories page locally at `http://localhost:5174/icons/categories`.
- Confirmed the new label appears and the old label is absent.
