### PR TITLE
fix(docs): rename navigation category label

### DIFF
--- a/categories/navigation.json
+++ b/categories/navigation.json
@@ -1,5 +1,5 @@
 {
   "$schema": "../category.schema.json",
-  "title": "Navigation, Maps, and POIs",
+  "title": "Navigation & Places",
   "icon": "compass"
 }

--- a/docs/.vitepress/data/categoriesData.json
+++ b/docs/.vitepress/data/categoriesData.json
@@ -97,7 +97,7 @@
   },
   {
     "name": "navigation",
-    "title": "Navigation, Maps, and POIs"
+    "title": "Navigation & Places"
   },
   {
     "name": "notifications",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
Rename the category label from “Navigation, Maps, and POIs” to “Navigation & Places”, since the original label is noticeably longer than neighboring ones and thus causing layout issues shown below. The new label keeps the same conceptual coverage while being shorter and easier to read.

### Before

<img width="219" height="148" alt="image" src="https://github.com/user-attachments/assets/0d9b09ba-11cb-447e-a17f-4d0e498cdff8" />

### After

<img width="217" height="150" alt="image" src="https://github.com/user-attachments/assets/ddad43f3-f132-4dfe-844e-e56da350ded1" />


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.