### PR TITLE
ci(release.yml): Remove concurrency field to prevent release mess

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ permissions:
   id-token: write # Required for OIDC
   contents: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-
 jobs:
   prepare:
     if: github.repository == 'lucide-icons/lucide' && contains('["ericfennis", "karsa-mistmere", "jguddas"]', github.actor)


### PR DESCRIPTION
We had some issues with releases.

If a second release is started on a day. the dispatch gated is triggered.
The next day if a release is started, for example, for `1.19.0`  the release is blocked by the dispatch gate that's waiting for approval.

I hope this fixes the blocking next day release.