### PR TITLE
docs(site): add Deno to installation instructions

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -27,6 +27,10 @@ npm install lucide@next
 bun add lucide@next
 ```
 
+```sh [deno]
+deno add lucide@next
+```
+
 :::
 
 For more details, see the [documentation](./lucide/index.md).
@@ -51,6 +55,10 @@ npm install lucide-react@next
 
 ```sh [bun]
 bun add lucide-react@next
+```
+
+```sh [deno]
+deno add lucide-react@next
 ```
 
 :::
@@ -80,6 +88,10 @@ npm install @lucide/vue
 bun add @lucide/vue
 ```
 
+```sh [deno]
+deno add @lucide/vue
+```
+
 :::
 
 For more details, see the [documentation](./vue/index.md).
@@ -104,6 +116,10 @@ npm install @lucide/svelte@next
 
 ```sh [bun]
 bun add @lucide/svelte@next
+```
+
+```sh [deno]
+deno add @lucide/svelte@next
 ```
 :::
 > `@lucide/svelte` is only for Svelte 5, for Svelte 4 use the `lucide-svelte` package.
@@ -132,6 +148,10 @@ npm install lucide-solid@next
 bun add lucide-solid@next
 ```
 
+```sh [deno]
+deno add lucide-solid@next
+```
+
 :::
 
 For more details, see the [documentation](./solid/index.md).
@@ -158,6 +178,10 @@ npm install @lucide/angular
 bun add @lucide/angular
 ```
 
+```sh [deno]
+deno add @lucide/angular
+```
+
 :::
 
 For more details, see the [documentation](./angular/index.md).
@@ -182,6 +206,10 @@ npm install lucide-preact@next
 
 ```sh [bun]
 bun add lucide-preact@next
+```
+
+```sh [deno]
+deno add lucide-preact@next
 ```
 
 
@@ -211,6 +239,10 @@ npm install @lucide/astro@next
 bun add @lucide/astro@next
 ```
 
+```sh [deno]
+deno add @lucide/astro@next
+```
+
 :::
 
 For more details, see the [documentation](./astro/index.md).
@@ -235,6 +267,10 @@ npm install lucide-static@next
 
 ```sh [bun]
 bun add lucide-static@next
+```
+
+```sh [deno]
+deno add lucide-static@next
 ```
 
 :::


### PR DESCRIPTION
## Description

👋 Bartek from the Deno team here. Thanks for Lucide, it's widely used across the JS ecosystem, Deno users included.

This adds a `deno` tab to each `::: code-group` on the installation page, alongside the existing pnpm / yarn / npm / bun blocks, so Deno users get a copy-pasteable command. Deno is a drop-in replacement for npm these days, and `deno add` mirrors your `pnpm add` / `yarn add` / `bun add` style:

```sh
deno add lucide-react@next
```

I added it consistently across every framework section (Web, React, Vue, Svelte, Solid, Angular, Preact, Astro, Static usage) so the page stays uniform. Docs-only change, no code touched.

- [x] I've read the Contribution Guidelines.
- [x] I've checked if there was an existing PR that solves the same issue.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
