### PR TITLE
fix(docs): fix color input clipping

### DIFF
--- a/docs/.vitepress/theme/components/base/ColorPicker.vue
+++ b/docs/.vitepress/theme/components/base/ColorPicker.vue
@@ -11,6 +11,14 @@ const { isDark } = useData();
 
 const emit = defineEmits(['update:modelValue']);
 
+function limitHexInput(val: string) {
+  if (val.startsWith('#')) {
+    return val.slice(0, 9);
+  }
+
+  return val.slice(0, 8);
+}
+
 const value = computed({
   get: () => {
     if (props.modelValue == null || props.modelValue === 'currentColor') {
@@ -19,7 +27,7 @@ const value = computed({
 
     return props.modelValue;
   },
-  set: (val) => emit('update:modelValue', val),
+  set: (val) => emit('update:modelValue', limitHexInput(val)),
 });
 </script>
 
@@ -41,6 +49,7 @@ const value = computed({
       class="color-input-text"
       aria-label="Color picker input"
       v-model="value"
+      maxlength="9"
       placeholder="[default]"
     />
   </div>
@@ -91,6 +100,7 @@ const value = computed({
   background: transparent;
   color: var(--vp-c-text-1);
   font-size: 13px;
+  font-family: var(--vp-font-family-mono);
   text-align: left;
   border-radius: 8px;
   cursor: text;

--- a/docs/.vitepress/theme/components/icons/SidebarIconCustomizer.vue
+++ b/docs/.vitepress/theme/components/icons/SidebarIconCustomizer.vue
@@ -73,13 +73,11 @@ const customizingActive = computed(() => {
       id="icon-color"
       label="Color"
     >
-      <template #display>
-        <ColorPicker
-          v-model="color"
-          id="icon-color"
-          class="color-picker"
-        />
-      </template>
+      <ColorPicker
+        v-model="color"
+        id="icon-color"
+        class="color-picker"
+      />
     </InputField>
 
     <InputField
@@ -161,6 +159,6 @@ const customizingActive = computed(() => {
 }
 
 .color-picker {
-  margin-left: auto;
+  width: 100%;
 }
 </style>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

## Description

Adjust icon customizer color control:
- make color field full-width to avoid clipping input value longer than 6 chars
- use the existing mono font token to prevent `#ffffffff` and `#00000000` taking considerable different lengths to make layout easier to maintain
- long hex values are capped eight characters instead of infinite to prevent confusion

|Before|After|
|---|---|
|<img width="181" height="331" alt="image" src="https://github.com/user-attachments/assets/491a6959-6366-4137-8034-d1ddb71bcdbd" />|<img width="181" height="346" alt="image" src="https://github.com/user-attachments/assets/881b864a-fb79-4437-b461-a581eaf8d7d0" />|

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
