### PR TITLE
fix(astro): add Astro v7 compatibility

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -61,6 +61,6 @@
     "astro": "^6.1.10"
   },
   "peerDependencies": {
-    "astro": "^4 || ^5 || ^6"
+    "astro": "^4 || ^5 || ^6 || ^7"
   }
 }


### PR DESCRIPTION
## Description

[Astro 7](https://astro.build/) has been released. `@lucide/astro` already works with it unchanged, but its `peerDependencies` range stops at `^6`, so Astro 7 projects get an unmet peer-dependency warning on install.

This widens the peer range to include `^7`

- `peerDependencies.astro`: `^4 || ^5 || ^6` → `^4 || ^5 || ^6 || ^7`

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
