### PR TITLE
fix(lucide-react-native): Fix context provider export

### DIFF
--- a/packages/lucide-react-native/rollup.config.mjs
+++ b/packages/lucide-react-native/rollup.config.mjs
@@ -5,7 +5,7 @@ import pkg from './package.json' with { type: 'json' };
 const packageName = 'LucideReact';
 const outputFileName = 'lucide-react-native';
 const outputDir = 'dist';
-const inputs = ['src/lucide-react-native.ts', 'src/icons/index.ts'];
+const inputs = ['src/lucide-react-native.ts'];
 const bundles = [
   {
     format: 'cjs',
@@ -63,7 +63,7 @@ export default [
     plugins: [dts()],
   },
   {
-    input: inputs[1],
+    input: 'src/icons/index.ts',
     output: [
       {
         file: `dist/icons.d.ts`,


### PR DESCRIPTION
Closes #4424

## Description

Some parts of the build were bundled twice. 
Resulted in 1 bundle not exporting the `LucideContextProvider` because it was tree-shaken away.

Fixed by moving the entry file for types generation from the main build config to the types build config.