### PR TITLE
fix(docs): prevent scrollbar layout shift on icons page

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -67,6 +67,10 @@
   animation: .3s transition 0s ease;
 } */
 
+html {
+  scrollbar-gutter: stable;
+}
+
 .VPHome {
   overflow-x: hidden;
 }


### PR DESCRIPTION
## Summary

The \`/icons/\` route caused a visible horizontal layout shift whenever the page scrollbar appeared or disappeared, notably when filtering the icons list. This happened because the scrollbar takes up space when present, pushing content right as it disappears.

\`scrollbar-gutter: stable\` on \`html\` reserves that space permanently, so the layout width never changes regardless of whether the scrollbar is visible. See [https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scrollbar-gutter](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scrollbar-gutter)

- Adds \`scrollbar-gutter: stable\` to the \`html\` element in the VitePress theme's global stylesheet

## Test plan

- [ ] Run \`pnpm docs:dev\` from the \`docs/\` directory
- [ ] Navigate to \`/icons\` — confirm no horizontal layout shift occurs when filtering icons