### PR TITLE
feat(icons): added `rectangle-landscape-play-off` icon

### DIFF
--- a/icons/rectangle-landscape-play-off.json
+++ b/icons/rectangle-landscape-play-off.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "scottgriffinm"
+  ],
+  "use-cases": [
+    "Indicates that landscape video playback is disabled or blocked.",
+    "Indicates that autoplay or embedded video previews are turned off."
+  ],
+  "tags": [
+    "audio",
+    "video",
+    "music",
+    "start",
+    "run",
+    "off",
+    "disabled",
+    "blocked",
+    "forbidden"
+  ],
+  "categories": [
+    "multimedia"
+  ]
+}

--- a/icons/rectangle-landscape-play-off.svg
+++ b/icons/rectangle-landscape-play-off.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 4h10a2 2 0 0 1 2 2v10" />
+  <path d="m13.182 14.554-2.813 1.688a1.1 1.1 0 0 1-1.669-.946V9.5" />
+  <path d="m15 9.7 1.365.855a1.1 1.1 0 0 1 .404 1.445" />
+  <path d="m2 2 20 20" />
+  <path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 1.184-1.826" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `rectangle-landscape-play-off` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
For showing a disabled or blocked state for landscape video playback.
Embedded video previews or autoplay that have been turned off in privacy or parental-control settings.

### Alternative icon designs
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: `square-play`, `monitor-off`
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
