### PR TITLE
fix(vue): support kebab-case icon-node prop on Icon component

### DIFF
--- a/packages/vue/src/Icon.ts
+++ b/packages/vue/src/Icon.ts
@@ -4,11 +4,12 @@ import defaultAttributes from './defaultAttributes';
 import { IconNode, LucideProps } from './types';
 import { useLucideProps } from './context';
 
-interface IconProps {
-  iconNode: IconNode;
-  'icon-node'?: IconNode;
-  name: string;
-}
+type IconProps =
+  { name: string } &
+  (
+    | { iconNode: IconNode; 'icon-node'?: never }
+    | { 'icon-node': IconNode; iconNode?: never }
+  );
 
 const Icon: FunctionalComponent<LucideProps & IconProps> = (
   {

--- a/packages/vue/src/Icon.ts
+++ b/packages/vue/src/Icon.ts
@@ -4,12 +4,10 @@ import defaultAttributes from './defaultAttributes';
 import { IconNode, LucideProps } from './types';
 import { useLucideProps } from './context';
 
-type IconProps =
-  { name: string } &
-  (
-    | { iconNode: IconNode; 'icon-node'?: never }
-    | { 'icon-node': IconNode; iconNode?: never }
-  );
+type IconProps = { name: string } & (
+  | { iconNode: IconNode; 'icon-node'?: never }
+  | { 'icon-node': IconNode; iconNode?: never }
+);
 
 const Icon: FunctionalComponent<LucideProps & IconProps> = (
   {

--- a/packages/vue/src/Icon.ts
+++ b/packages/vue/src/Icon.ts
@@ -6,6 +6,7 @@ import { useLucideProps } from './context';
 
 interface IconProps {
   iconNode: IconNode;
+  'icon-node'?: IconNode;
   name: string;
 }
 
@@ -13,6 +14,7 @@ const Icon: FunctionalComponent<LucideProps & IconProps> = (
   {
     name,
     iconNode,
+    'icon-node': iconNodeKebabCase,
     absoluteStrokeWidth,
     'absolute-stroke-width': absoluteStrokeWidthKebabCase,
     strokeWidth,
@@ -71,7 +73,10 @@ const Icon: FunctionalComponent<LucideProps & IconProps> = (
           : ['lucide-icon']),
       ),
     },
-    [...iconNode.map((child) => h(...child)), ...(slots.default ? [slots.default()] : [])],
+    [
+      ...(iconNode ?? iconNodeKebabCase ?? []).map((child) => h(...child)),
+      ...(slots.default ? [slots.default()] : []),
+    ],
   );
 };
 

--- a/packages/vue/tests/Icon.spec.ts
+++ b/packages/vue/tests/Icon.spec.ts
@@ -19,6 +19,18 @@ describe('Using Icon Component', () => {
     expect(container.firstChild).toBeDefined();
   });
 
+  it('should render when iconNode is passed as the kebab-case icon-node prop', async () => {
+    const { container } = render(Icon, {
+      props: {
+        'icon-node': airVent,
+        name: 'AirVent',
+      },
+    });
+
+    expect(container.firstChild).toBeDefined();
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
   it('should render icon and match snapshot', async () => {
     const { container } = render(Icon, {
       props: {


### PR DESCRIPTION
## Description

The Vue `Icon` component destructures its `iconNode` prop **camelCase-only**, while `stroke-width` and `absolute-stroke-width` are both destructured in camelCase *and* kebab-case forms. So the idiomatic Vue template usage:

```vue
<Icon :icon-node="myIconNode" name="Foo" />
```

leaves `iconNode` `undefined`, and the render path `iconNode.map(...)` throws `TypeError: Cannot read properties of undefined (reading 'map')` (#3485, confirmed by 3 reporters).

## Fix

Accept the `icon-node` kebab-case alias, mirroring the existing pattern for `stroke-width`/`absolute-stroke-width` in the same component, and guard the render path so a missing `iconNode` renders nothing instead of crashing:

```ts
...(iconNode ?? iconNodeKebabCase ?? []).map((child) => h(...child))
```

One shared source file (`packages/vue/src/Icon.ts`) fixes both `lucide-vue` and `lucide-vue-next`.

## Changes

- `packages/vue/src/Icon.ts`: destructure the `icon-node` kebab alias, add it to `IconProps`, resolve it in the render call with a defensive `[]` default.
- `packages/vue/tests/Icon.spec.ts`: regression test rendering `Icon` with the `:icon-node` (kebab-case) prop, asserting it renders an `<svg>` instead of throwing.

Closes #3485