### PR TITLE
fix(scripts): fix typo in renameIcon.function.mts

### DIFF
--- a/scripts/rename/renameIcon.function.mts
+++ b/scripts/rename/renameIcon.function.mts
@@ -50,7 +50,7 @@ export async function renameIcon(ICONS_DIR: string, oldName: string, newName: st
       ...(jsonData.aliases ?? []),
       {
         name: oldName,
-        deprecate: true,
+        deprecated: true,
         deprecationReason: 'alias.name',
         toBeRemovedInVersion: 'v1.0',
       },


### PR DESCRIPTION
## Description

Fixes a typo in `renameIcon.function.mts` (`deprecate` => `deprecated`)

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
