### PR TITLE
fix(angular): reuse SSR icon nodes during hydration

### DIFF
--- a/packages/angular/src/lucide-icon-base.spec.ts
+++ b/packages/angular/src/lucide-icon-base.spec.ts
@@ -76,6 +76,22 @@ describe('LucideIconBase', () => {
     );
   });
 
+  it('reuses pre-rendered (SSR) shape nodes instead of duplicating them', () => {
+    const svg: SVGElement = fixture.nativeElement;
+    const svgNs = 'http://www.w3.org/2000/svg';
+    // simulate server-rendered markup before the effect runs
+    for (const [tag, attrs] of LucideCircleCheck.icon.node) {
+      const shape = document.createElementNS(svgNs, tag);
+      for (const [name, value] of Object.entries(attrs)) {
+        shape.setAttribute(name, `${value}`);
+      }
+      svg.appendChild(shape);
+    }
+    fixture.detectChanges();
+    const shapes = svg.querySelectorAll('circle, path');
+    expect(shapes.length).toBe(LucideCircleCheck.icon.node.length);
+  });
+
   describe('class', () => {
     it('should add all classes', () => {
       fixture.detectChanges();

--- a/packages/angular/src/lucide-icon-base.ts
+++ b/packages/angular/src/lucide-icon-base.ts
@@ -89,21 +89,24 @@ export abstract class LucideIconBase {
         }
         const contentRef = this.contentRef();
         const refChild = contentRef.nativeElement;
-        const elements = node.map(([name, attrs]) => {
-          const element = this.renderer.createElement(name, 'http://www.w3.org/2000/svg');
-          if (absoluteStrokeWidth) {
-            this.renderer.setAttribute(element, 'vector-effect', 'non-scaling-stroke');
-          }
-          Object.entries(attrs).forEach(([name, value]) =>
-            this.renderer.setAttribute(
-              element,
-              name,
-              typeof value === 'number' ? value.toString(10) : value,
-            ),
-          );
-          this.renderer.insertBefore(this.elRef.nativeElement, element, refChild);
-          return element;
-        });
+        const host = this.elRef.nativeElement;
+        const elements =
+          this.getHydratableShapeNodes(host, node) ??
+          node.map(([name, attrs]) => {
+            const element = this.renderer.createElement(name, 'http://www.w3.org/2000/svg');
+            if (absoluteStrokeWidth) {
+              this.renderer.setAttribute(element, 'vector-effect', 'non-scaling-stroke');
+            }
+            Object.entries(attrs).forEach(([name, value]) =>
+              this.renderer.setAttribute(
+                element,
+                name,
+                typeof value === 'number' ? value.toString(10) : value,
+              ),
+            );
+            this.renderer.insertBefore(host, element, refChild);
+            return element;
+          });
         onCleanup(() => {
           elements.forEach((element) =>
             this.renderer.removeChild(this.elRef.nativeElement, element),
@@ -114,5 +117,21 @@ export abstract class LucideIconBase {
         });
       }
     });
+  }
+
+  /**
+   * Returns the host's existing shape nodes when they match the icon definition.
+   */
+  private getHydratableShapeNodes(host: Element, node: LucideIconData['node']): Element[] | null {
+    const shapeNodes = Array.from(host.children).filter(
+      (child) => child.tagName.toLowerCase() !== 'title',
+    );
+    if (shapeNodes.length !== node.length) {
+      return null;
+    }
+    const matchesDefinition = node.every(
+      ([tag], index) => shapeNodes[index].tagName.toLowerCase() === tag.toLowerCase(),
+    );
+    return matchesDefinition ? shapeNodes : null;
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Problem: When a Lucide icon is server-side rendered and the app uses Angular hydration, the icon's shape nodes get duplicated in the DOM. Besides bloating the DOM, this also causes visible rendering issues when the icon uses opacity.

To reproduce:

1. Angular app with SSR + `provideClientHydration()`.
2. Render any icon, e.g. `<svg lucideActivity></svg>`.
3. Inspect the hydrated DOM: the `<svg>` contains the icon's shapes twice when the page was served via SSR.

Identified root cause: `LucideIconBase` renders the icon shapes imperatively inside an `effect()`, calling `renderer.createElement` + `insertBefore` on every run, and these nodes are not part of the component template, so Angular hydration never claims them. During SSR they are serialized into the HTML, and then on the client the same `effect()` runs and creates a second set.

Suggested fix: Detect that the shape nodes already exist in the host, and adopt them instead of creating new ones.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
