### PR TITLE
fix(lucide-react-native): restore the icons entry point in the JS bundles

### DIFF
--- a/packages/lucide-react-native/rollup.config.mjs
+++ b/packages/lucide-react-native/rollup.config.mjs
@@ -5,7 +5,7 @@ import pkg from './package.json' with { type: 'json' };
 const packageName = 'LucideReact';
 const outputFileName = 'lucide-react-native';
 const outputDir = 'dist';
-const inputs = ['src/lucide-react-native.ts'];
+const inputs = ['src/lucide-react-native.ts', 'src/icons/index.ts'];
 const bundles = [
   {
     format: 'cjs',
@@ -22,34 +22,30 @@ const bundles = [
   },
 ];
 
-const configs = bundles
-  .map(({ inputs, outputDir, format, preserveModules, extension = 'js' }) =>
-    inputs.map((input) => ({
-      input,
-      plugins: plugins({ pkg }),
-      external: ['react', 'react-native-svg'],
-      output: {
-        name: packageName,
-        ...(preserveModules
-          ? {
-              dir: `${outputDir}/${format}`,
-              entryFileNames: `[name].${extension}`,
-            }
-          : {
-              file: `${outputDir}/${format}/${outputFileName}.${extension}`,
-            }),
-        format,
-        preserveModules,
-        preserveModulesRoot: 'src',
-        sourcemap: true,
-        globals: {
-          react: 'react',
-          'react-native-svg': 'react-native-svg',
-        },
-      },
-    })),
-  )
-  .flat();
+const configs = bundles.map(({ inputs, outputDir, format, preserveModules, extension = 'js' }) => ({
+  input: inputs,
+  plugins: plugins({ pkg }),
+  external: ['react', 'react-native-svg'],
+  output: {
+    name: packageName,
+    ...(preserveModules
+      ? {
+          dir: `${outputDir}/${format}`,
+          entryFileNames: `[name].${extension}`,
+        }
+      : {
+          file: `${outputDir}/${format}/${outputFileName}.${extension}`,
+        }),
+    format,
+    preserveModules,
+    preserveModulesRoot: 'src',
+    sourcemap: true,
+    globals: {
+      react: 'react',
+      'react-native-svg': 'react-native-svg',
+    },
+  },
+}));
 
 export default [
   {


### PR DESCRIPTION
Closes #4527

## Description

#4497 removed `src/icons/index.ts` from the JS bundle inputs. The barrel is a pure re-export module, so with `preserveModules` rollup optimizes it away when it is not an entry point. `dist/esm/icons/index.mjs` and `dist/cjs/icons/index.js` stopped being emitted, while `package.json` still declares the `./icons` export. `dist/icons.d.ts` is still built, so TypeScript resolves fine and this only surfaces at bundle time.

Just adding the entry back would reintroduce #4424: the config built each entry as a separate rollup config writing into the same output directory, so the icons build could overwrite shared modules with tree-shaken copies that were missing exports like `LucideProvider`.

Instead, this builds all entries in a single rollup config per format. One module graph, so shared modules are emitted once with everything any entry needs, and the barrel comes back because entry points are never optimized away.

Verified with a local `pnpm build`:

- `dist/esm/icons/index.mjs` and `dist/cjs/icons/index.js` are emitted again, same shape as the 1.21.0 publish
- `dist/esm/context.mjs` and `dist/cjs/context.js` still export `LucideProvider` and `useLucideContext`, so #4424 stays fixed
- `pnpm test` passes

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
