### PR TITLE
feat(docs): add studio link

### DIFF
--- a/docs/.vitepress/theme/components/icons/IconPreview.vue
+++ b/docs/.vitepress/theme/components/icons/IconPreview.vue
@@ -89,6 +89,7 @@ const base64InnerSvg = computed(() => {
       rel="noopener noreferrer"
       class="studio-button"
       title="Open in Lucide Studio"
+      aria-label="Open in Lucide Studio"
     >
       <SquarePenIcon :size="14" />
     </a>

--- a/docs/.vitepress/theme/components/icons/IconPreview.vue
+++ b/docs/.vitepress/theme/components/icons/IconPreview.vue
@@ -3,6 +3,7 @@ import type { IconEntity } from '../../types';
 import { computed, ref } from 'vue';
 import createLucideIcon from '@lucide/vue/src/createLucideIcon';
 import { useIconStyleContext } from '../../composables/useIconStyle';
+import { squarePen } from '../../../data/iconNodes';
 
 const props = defineProps<{
   name: IconEntity['name'];
@@ -18,6 +19,31 @@ const gridLines = computed(() => Array.from({ length: size.value - 1 }));
 const iconComponent = computed(() => {
   if (!props.name || !props.iconNode) return null;
   return createLucideIcon(props.name, props.iconNode);
+});
+
+const SquarePenIcon = createLucideIcon('SquarePen', squarePen);
+
+const innerSvg = computed(() => {
+  if (!props.iconNode) return '';
+
+  const string = props.iconNode
+    .map(([tag, attrs]) => {
+      const attributes = Object.entries(attrs)
+        .map(([key, value]) => `${key}="${value}"`)
+        .join(' ');
+      return `<${tag} ${attributes}/>`;
+    })
+    .join('');
+
+  return string
+    .replace(/>[\r\n ]+</g, '><')
+    .replace(/(<.*?>)|\s+/g, (m, $1) => $1 || ' ')
+    .trim();
+});
+
+const base64InnerSvg = computed(() => {
+  if (typeof window === 'undefined') return '';
+  return btoa(innerSvg.value);
 });
 </script>
 
@@ -57,6 +83,15 @@ const iconComponent = computed(() => {
         />
       </g>
     </svg>
+    <a
+      :href="`https://studio.lucide.dev/edit?value=${encodeURIComponent(base64InnerSvg)}&name=${name}`"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="studio-button"
+      title="Open in Lucide Studio"
+    >
+      <SquarePenIcon :size="14" />
+    </a>
   </div>
 </template>
 
@@ -75,6 +110,8 @@ const iconComponent = computed(() => {
   position: relative;
   background: var(--vp-c-bg-alt);
   border-radius: 8px;
+  overflow: hidden;
+  flex-shrink: 0;
 }
 .icon-container > :deep(svg:not(.icon-grid)) {
   width: 100%;
@@ -83,6 +120,34 @@ const iconComponent = computed(() => {
   z-index: 1;
   color: var(--vp-c-neutral);
   opacity: 0.8;
+}
+
+.studio-button {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  padding: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--vp-c-text-2);
+  opacity: 0;
+  transition: opacity 0.2s, color 0.2s, background-color 0.2s;
+  z-index: 2;
+}
+
+.icon-container:hover .studio-button,
+.studio-button:focus-visible {
+  opacity: 1;
+}
+
+.studio-button:hover,
+.studio-button:focus-visible {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
 }
 
 .icon-component.customizable {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->

Adds little button that directs you to lucide studio.

**Button is only visible on hover of the preview.**

<img width="754" height="259" alt="image" src="https://github.com/user-attachments/assets/947219f6-1e43-49a3-ac97-f6f85374f39b" />


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.
