### PR TITLE
feat(icons): add arrow-up-down-to-line

### DIFF
--- a/icons/arrow-up-down-to-line.json
+++ b/icons/arrow-up-down-to-line.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "arrow",
+    "collapse",
+    "converge",
+    "align",
+    "centre",
+    "center",
+    "line",
+    "vertical",
+    "distribute",
+    "fit"
+  ],
+  "categories": [
+    "arrows",
+    "design"
+  ]
+}

--- a/icons/arrow-up-down-to-line.svg
+++ b/icons/arrow-up-down-to-line.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 2v6" />
+  <path d="m9 5 3 3 3-3" />
+  <path d="M2 12h20" />
+  <path d="M12 22v-6" />
+  <path d="m9 19 3-3 3 3" />
+</svg>


### PR DESCRIPTION
## Description

Adds `arrow-up-down-to-line`: two arrows converging on a line from above and below.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Cpath%20d%3D%22M12%202v6%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22m9%205%203%203%203-3%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M2%2012h20%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M12%2022v-6%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22m9%2019%203-3%203%203%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=arrow-up-down-to-line"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTIgMnY2IiAvPgogIDxwYXRoIGQ9Im05IDUgMyAzIDMtMyIgLz4KICA8cGF0aCBkPSJNMiAxMmgyMCIgLz4KICA8cGF0aCBkPSJNMTIgMjJ2LTYiIC8+CiAgPHBhdGggZD0ibTkgMTkgMy0zIDMgMyIgLz4KPC9zdmc+Cg==.svg"/><br/>Open lucide studio</a>

The set has `arrow-{up,down,left,right}-{to,from}-line` and `arrows-up-from-line`, but nothing for two arrows meeting at a line.

Construction notes:

- Follows the `-to-line` convention: each arrow stops 4px short of the line, matching `arrow-up-to-line` and `arrow-down-to-line`.
- All coordinates are on the integer grid.

**Existing precedent — `fold-vertical`.** This is the same construction with a solid line instead of a dashed one. The two arrows are byte-identical:

| | `fold-vertical` | this icon |
| --- | --- | --- |
| top shaft | `M12 8V2` | `M12 8V2` |
| top chevron | `m15 5-3 3-3-3` | `m9 5 3 3 3-3` |
| bottom shaft | `M12 22v-6` | `M12 22v-6` |
| bottom chevron | `m15 19-3-3-3 3` | `m9 19 3-3 3 3` |
| the line | dashed — `M4 12H2` `M10 12H8` `M16 12h-2` `M22 12h-2` | solid — `M2 12h20` |

The dashed line reads as a fold line — somewhere to fold, not something that's there. The solid line reads as a real edge or boundary the arrows meet. That's the distinction I'm proposing, and it may well be too fine to justify a second icon; I'd rather put it in front of you than have it found in review.

Also worth noting: at 16px this sits fairly close to `divide`, which is also a horizontal rule with marks above and below. The arrows read as arrows because of their legs where `divide`'s marks are round dots.

### Icon use case

- Design tool inspector: collapse or fit an element's height to its contents.
- Table or spreadsheet UI: reduce row height to fit.
- Layout editor: align items to a shared horizontal centreline.

### Alternative icon designs

None.

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] The icons are solely my own creation.

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
