### PR TITLE
feat(icons): add layout-horizontal and layout-vertical alignment variants

### DIFF
--- a/icons/layout-horizontal-bottom.json
+++ b/icons/layout-horizontal-bottom.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "layout",
+    "align",
+    "alignment",
+    "horizontal",
+    "bottom",
+    "auto layout",
+    "frame",
+    "row",
+    "cross axis",
+    "arrange",
+    "position"
+  ],
+  "categories": [
+    "design",
+    "layout"
+  ]
+}

--- a/icons/layout-horizontal-bottom.svg
+++ b/icons/layout-horizontal-bottom.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="7" height="18" x="3" y="3" rx="1" />
+  <rect width="7" height="10" x="14" y="11" rx="1" />
+</svg>

--- a/icons/layout-horizontal-center.json
+++ b/icons/layout-horizontal-center.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "layout",
+    "align",
+    "alignment",
+    "horizontal",
+    "center",
+    "auto layout",
+    "frame",
+    "row",
+    "cross axis",
+    "arrange",
+    "position"
+  ],
+  "categories": [
+    "design",
+    "layout"
+  ]
+}

--- a/icons/layout-horizontal-center.svg
+++ b/icons/layout-horizontal-center.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="7" height="18" x="3" y="3" rx="1" />
+  <rect width="7" height="10" x="14" y="7" rx="1" />
+</svg>

--- a/icons/layout-horizontal-top.json
+++ b/icons/layout-horizontal-top.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "layout",
+    "align",
+    "alignment",
+    "horizontal",
+    "top",
+    "auto layout",
+    "frame",
+    "row",
+    "cross axis",
+    "arrange",
+    "position"
+  ],
+  "categories": [
+    "design",
+    "layout"
+  ]
+}

--- a/icons/layout-horizontal-top.svg
+++ b/icons/layout-horizontal-top.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="7" height="18" x="3" y="3" rx="1" />
+  <rect width="7" height="10" x="14" y="3" rx="1" />
+</svg>

--- a/icons/layout-vertical-center.json
+++ b/icons/layout-vertical-center.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "layout",
+    "align",
+    "alignment",
+    "vertical",
+    "center",
+    "auto layout",
+    "frame",
+    "column",
+    "cross axis",
+    "arrange",
+    "position"
+  ],
+  "categories": [
+    "design",
+    "layout"
+  ]
+}

--- a/icons/layout-vertical-center.svg
+++ b/icons/layout-vertical-center.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="7" x="3" y="3" rx="1" />
+  <rect width="10" height="7" x="7" y="14" rx="1" />
+</svg>

--- a/icons/layout-vertical-left.json
+++ b/icons/layout-vertical-left.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "layout",
+    "align",
+    "alignment",
+    "vertical",
+    "left",
+    "auto layout",
+    "frame",
+    "column",
+    "cross axis",
+    "arrange",
+    "position"
+  ],
+  "categories": [
+    "design",
+    "layout"
+  ]
+}

--- a/icons/layout-vertical-left.svg
+++ b/icons/layout-vertical-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="7" x="3" y="3" rx="1" />
+  <rect width="10" height="7" x="3" y="14" rx="1" />
+</svg>

--- a/icons/layout-vertical-right.json
+++ b/icons/layout-vertical-right.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "layout",
+    "align",
+    "alignment",
+    "vertical",
+    "right",
+    "auto layout",
+    "frame",
+    "column",
+    "cross axis",
+    "arrange",
+    "position"
+  ],
+  "categories": [
+    "design",
+    "layout"
+  ]
+}

--- a/icons/layout-vertical-right.svg
+++ b/icons/layout-vertical-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="7" x="3" y="3" rx="1" />
+  <rect width="10" height="7" x="11" y="14" rx="1" />
+</svg>


### PR DESCRIPTION
## Description

Adds six icons for cross-axis alignment within a layout direction.

| `layout-horizontal-top` | `layout-horizontal-center` | `layout-horizontal-bottom` |
| --- | --- | --- |
| <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%227%22%20height%3D%2218%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%221%22%20%2F%3E%0A%20%20%3Crect%20width%3D%227%22%20height%3D%2210%22%20x%3D%2214%22%20y%3D%223%22%20rx%3D%221%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=layout-horizontal-top"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iNyIgaGVpZ2h0PSIxOCIgeD0iMyIgeT0iMyIgcng9IjEiIC8+CiAgPHJlY3Qgd2lkdGg9IjciIGhlaWdodD0iMTAiIHg9IjE0IiB5PSIzIiByeD0iMSIgLz4KPC9zdmc+Cg==.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%227%22%20height%3D%2218%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%221%22%20%2F%3E%0A%20%20%3Crect%20width%3D%227%22%20height%3D%2210%22%20x%3D%2214%22%20y%3D%227%22%20rx%3D%221%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=layout-horizontal-center"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iNyIgaGVpZ2h0PSIxOCIgeD0iMyIgeT0iMyIgcng9IjEiIC8+CiAgPHJlY3Qgd2lkdGg9IjciIGhlaWdodD0iMTAiIHg9IjE0IiB5PSI3IiByeD0iMSIgLz4KPC9zdmc+Cg==.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%227%22%20height%3D%2218%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%221%22%20%2F%3E%0A%20%20%3Crect%20width%3D%227%22%20height%3D%2210%22%20x%3D%2214%22%20y%3D%2211%22%20rx%3D%221%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=layout-horizontal-bottom"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iNyIgaGVpZ2h0PSIxOCIgeD0iMyIgeT0iMyIgcng9IjEiIC8+CiAgPHJlY3Qgd2lkdGg9IjciIGhlaWdodD0iMTAiIHg9IjE0IiB5PSIxMSIgcng9IjEiIC8+Cjwvc3ZnPgo=.svg"/><br/>Open lucide studio</a> |

| `layout-vertical-left` | `layout-vertical-center` | `layout-vertical-right` |
| --- | --- | --- |
| <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%2218%22%20height%3D%227%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%221%22%20%2F%3E%0A%20%20%3Crect%20width%3D%2210%22%20height%3D%227%22%20x%3D%223%22%20y%3D%2214%22%20rx%3D%221%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=layout-vertical-left"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iNyIgeD0iMyIgeT0iMyIgcng9IjEiIC8+CiAgPHJlY3Qgd2lkdGg9IjEwIiBoZWlnaHQ9IjciIHg9IjMiIHk9IjE0IiByeD0iMSIgLz4KPC9zdmc+Cg==.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%2218%22%20height%3D%227%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%221%22%20%2F%3E%0A%20%20%3Crect%20width%3D%2210%22%20height%3D%227%22%20x%3D%227%22%20y%3D%2214%22%20rx%3D%221%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=layout-vertical-center"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iNyIgeD0iMyIgeT0iMyIgcng9IjEiIC8+CiAgPHJlY3Qgd2lkdGg9IjEwIiBoZWlnaHQ9IjciIHg9IjciIHk9IjE0IiByeD0iMSIgLz4KPC9zdmc+Cg==.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%2218%22%20height%3D%227%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%221%22%20%2F%3E%0A%20%20%3Crect%20width%3D%2210%22%20height%3D%227%22%20x%3D%2211%22%20y%3D%2214%22%20rx%3D%221%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=layout-vertical-right"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iNyIgeD0iMyIgeT0iMyIgcng9IjEiIC8+CiAgPHJlY3Qgd2lkdGg9IjEwIiBoZWlnaHQ9IjciIHg9IjExIiB5PSIxNCIgcng9IjEiIC8+Cjwvc3ZnPgo=.svg"/><br/>Open lucide studio</a> |

These are variants of the `layout-horizontal` and `layout-vertical` bases proposed in #4541, matching how a design tool's layer list shows a frame's layout mode together with its alignment. **This PR is a draft pending #4541** — if that base is renamed or rejected, these follow it.

### How these differ from `align-*`

The existing `align-{start,center,end}-{horizontal,vertical}` icons show two comparable items plus a **guideline** the items are aligned to. They depict the *align action* you perform.

These show a **full-height (or full-width) item whose extent is itself the reference**, and a shorter item positioned against it. There is no guideline — the container is the guideline. They depict the *resulting state* of a frame, which is what a layer list shows.

Construction notes:

- The reference item is 7×18, matching `layout-panel-left`'s panel; the positioned item is 7×10. That 18:10 ratio is close to the 16:9 used by `align-start-horizontal`, keeping optical volume consistent with the family this sits beside.
- 10 was chosen over 11 so the centred variant lands on integers (y7–17 against an 18-tall reference centred on 12). An 11-tall item would need y6.5 and would blur the 2px stroke.
- Uniform `rx=1` throughout, per the <8px rule. Every icon has even 2px padding and all-integer coordinates.

### Icon use case

**`layout-horizontal-{top,center,bottom}`**

- Design tool layer list: show that a frame uses horizontal layout with items aligned to the top / centre / bottom.
- Design tool inspector: the cross-axis alignment control for a horizontal auto layout.
- CSS editor: the `align-items: flex-start / center / flex-end` control on a flex row.

**`layout-vertical-{left,center,right}`**

- Design tool layer list: show that a frame uses vertical layout with items aligned left / centre / right.
- Design tool inspector: the cross-axis alignment control for a vertical auto layout.
- CSS editor: the `align-items` control on a flex column.

### Alternative icon designs

None.

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] The icons are solely my own creation.

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
