### PR TITLE
feat(icons): add opacity

### DIFF
--- a/icons/opacity.json
+++ b/icons/opacity.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "opacity",
+    "transparency",
+    "alpha",
+    "fade",
+    "translucent",
+    "gradient",
+    "dissolve",
+    "blend",
+    "checkerboard",
+    "visibility"
+  ],
+  "categories": [
+    "design",
+    "photography"
+  ]
+}

--- a/icons/opacity.svg
+++ b/icons/opacity.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M16 8h.01" />
+  <path d="M12 12h.01" />
+  <path d="M16 12h.01" />
+  <path d="M8 16h.01" />
+  <path d="M12 16h.01" />
+  <path d="M16 16h.01" />
+</svg>


### PR DESCRIPTION
## Description

Adds `opacity`: a frame with a dot ramp that thins from the bottom-right corner towards the top-left, reading as a fade from opaque to transparent.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%2218%22%20height%3D%2218%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%222%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%208h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M12%2012h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%2012h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M8%2016h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M12%2016h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%2016h.01%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=opacity"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHg9IjMiIHk9IjMiIHJ4PSIyIiAvPgogIDxwYXRoIGQ9Ik0xNiA4aC4wMSIgLz4KICA8cGF0aCBkPSJNMTIgMTJoLjAxIiAvPgogIDxwYXRoIGQ9Ik0xNiAxMmguMDEiIC8+CiAgPHBhdGggZD0iTTggMTZoLjAxIiAvPgogIDxwYXRoIGQ9Ik0xMiAxNmguMDEiIC8+CiAgPHBhdGggZD0iTTE2IDE2aC4wMSIgLz4KPC9zdmc+Cg==.svg"/><br/>Open lucide studio</a>

There's no icon for opacity, transparency or alpha in the set today. `contrast` covers light-vs-dark within a shape; this covers how much of the shape is there at all.

### Built from the `dice-*` construction

Rather than introduce a new vocabulary, this reuses the one the library already has for dots in a frame — the same 18×18 `rx=2` frame, the same `h.01` dot, and the same `{8,12,16}` grid that `dice-1` through `dice-6` sit on. Only the arrangement differs: a triangular ramp rather than a die face.

| `opacity` | `dice-5` | `dice-6` |
| --- | --- | --- |
| <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%2218%22%20height%3D%2218%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%222%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%208h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M12%2012h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%2012h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M8%2016h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M12%2016h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%2016h.01%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=opacity"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHg9IjMiIHk9IjMiIHJ4PSIyIiAvPgogIDxwYXRoIGQ9Ik0xNiA4aC4wMSIgLz4KICA8cGF0aCBkPSJNMTIgMTJoLjAxIiAvPgogIDxwYXRoIGQ9Ik0xNiAxMmguMDEiIC8+CiAgPHBhdGggZD0iTTggMTZoLjAxIiAvPgogIDxwYXRoIGQ9Ik0xMiAxNmguMDEiIC8+CiAgPHBhdGggZD0iTTE2IDE2aC4wMSIgLz4KPC9zdmc+Cg==.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%2218%22%20height%3D%2218%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%222%22%20ry%3D%222%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%208h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M8%208h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M8%2016h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%2016h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M12%2012h.01%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=dice-5"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHg9IjMiIHk9IjMiIHJ4PSIyIiByeT0iMiIgLz4KICA8cGF0aCBkPSJNMTYgOGguMDEiIC8+CiAgPHBhdGggZD0iTTggOGguMDEiIC8+CiAgPHBhdGggZD0iTTggMTZoLjAxIiAvPgogIDxwYXRoIGQ9Ik0xNiAxNmguMDEiIC8+CiAgPHBhdGggZD0iTTEyIDEyaC4wMSIgLz4KPC9zdmc+Cg==.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Crect%20width%3D%2218%22%20height%3D%2218%22%20x%3D%223%22%20y%3D%223%22%20rx%3D%222%22%20ry%3D%222%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%208h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%2012h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M16%2016h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M8%208h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M8%2012h.01%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M8%2016h.01%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=dice-6"><img alt="icons" width="150px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHg9IjMiIHk9IjMiIHJ4PSIyIiByeT0iMiIgLz4KICA8cGF0aCBkPSJNMTYgOGguMDEiIC8+CiAgPHBhdGggZD0iTTE2IDEyaC4wMSIgLz4KICA8cGF0aCBkPSJNMTYgMTZoLjAxIiAvPgogIDxwYXRoIGQ9Ik04IDhoLjAxIiAvPgogIDxwYXRoIGQ9Ik04IDEyaC4wMSIgLz4KICA8cGF0aCBkPSJNOCAxNmguMDEiIC8+Cjwvc3ZnPgo=.svg"/><br/>Open lucide studio</a> |

The family resemblance is intentional. A reader who knows `dice-*` already knows how to read this, and the shared-shapes guideline asks for exactly that kind of reuse. If you'd rather opacity read further from the dice family, I'm happy to rework it.

### Construction notes

- Dot pitch is 4px, giving 2px between dots — the guideline minimum, and the same pitch `dice-*` uses.
- A finer ramp isn't possible here: at 3px pitch the dots sit 1px apart, and a 2px-stroke dot can't be made smaller. This is the densest legal ramp.
- Lucide Studio labels the bottom row `ellipsis 12x4` — that's it recognising three dots in a row as a known pattern, not a violation. No spacing flags.

### Icon use case

- Design tool inspector: the opacity / alpha slider on a layer or fill.
- Image editor: set layer transparency, or toggle the transparency checkerboard.
- CSS editor: the `opacity` property control.

### Alternative icon designs

None. Earlier drafts used a finer dot grid, but nothing below 4px pitch clears the 2px spacing guideline.

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] I've based them on the following Lucide icons: `dice-5` / `dice-6` for the frame, dot and grid.

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
