### PR TITLE
feat(icons): add terminal-off and square-terminal-off icons

### DIFF
--- a/icons/square-terminal-off.json
+++ b/icons/square-terminal-off.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "l46983284-cpu"
+  ],
+  "use-cases": [
+    "pairing with square-terminal to show a code console panel is turned off",
+    "showing that an embedded terminal widget is disabled in an IDE-like UI",
+    "indicating a blocked shell session tile in a multi-tool agent dashboard",
+    "marking unavailable CLI tools next to available web/search tool icons"
+  ],
+  "tags": [
+    "code",
+    "command line",
+    "prompt",
+    "shell",
+    "console",
+    "disabled",
+    "unavailable",
+    "offline"
+  ],
+  "categories": [
+    "development"
+  ],
+  "aliases": [
+    {
+      "name": "terminal-square-off",
+      "deprecationReason": "alias.name",
+      "deprecated": true
+    }
+  ]
+}

--- a/icons/square-terminal-off.svg
+++ b/icons/square-terminal-off.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m2 2 20 20" />
+  <path d="M13 13h2" />
+  <path d="m7 11 2-2-2-2" />
+  <path d="M5 5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12" />
+  <path d="M9 3h10a2 2 0 0 1 2 2v10" />
+</svg>

--- a/icons/terminal-off.json
+++ b/icons/terminal-off.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "l46983284-cpu"
+  ],
+  "use-cases": [
+    "showing that a code sandbox or terminal tool is unavailable in an AI assistant capability list",
+    "indicating a disabled shell/console action in a developer toolbar",
+    "marking that remote terminal access is offline in a deployment dashboard",
+    "toggling off command-line execution in a workflow builder"
+  ],
+  "tags": [
+    "code",
+    "command line",
+    "prompt",
+    "shell",
+    "console",
+    "disabled",
+    "unavailable",
+    "offline"
+  ],
+  "categories": [
+    "development"
+  ]
+}

--- a/icons/terminal-off.svg
+++ b/icons/terminal-off.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m2 2 20 20" />
+  <path d="m4 17 6-6-6-6" />
+  <path d="M12 19h8" />
+</svg>


### PR DESCRIPTION
closes #4467

## Description

Adds `terminal-off` and `square-terminal-off` as disabled companions for the existing terminal icons.

### Icon use case

- Show that a code sandbox / shell tool is unavailable in an AI assistant capability list (pair with globe-off / image-off style states).
- Mark a disabled console action in a developer toolbar or workflow builder.
- Indicate offline remote terminal access in a deployment or ops dashboard.
- Toggle off an embedded terminal panel next to `square-terminal` in IDE-like UIs.

### Alternative icon designs

Kept the base terminal / square-terminal geometry and applied the standard Lucide diagonal slash used by sibling `-off` icons (`monitor-off`, `wifi-off`, `bluetooth-off`).

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] I've based them on the following Lucide icons: `terminal`, `square-terminal`, and the slash treatment from existing `-off` icons

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
