### PR TITLE
feat(icons): promote stairs icon family from lab

### DIFF
--- a/icons/stairs-arrow-down-left.json
+++ b/icons/stairs-arrow-down-left.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley",
+    "darrel1925"
+  ],
+  "use-cases": [
+    "marking rooms and destinations on lower floors in wayfinding interfaces",
+    "indicating descending stairs on floor plans and directional signage",
+    "identifying stair routes to ground floors, exits, and basement areas"
+  ],
+  "tags": [
+    "steps",
+    "stairwell",
+    "staircase",
+    "descending",
+    "downstairs",
+    "floor",
+    "level",
+    "wayfinding",
+    "signage",
+    "direction",
+    "diagonal"
+  ],
+  "categories": [
+    "buildings",
+    "navigation",
+    "arrows"
+  ]
+}

--- a/icons/stairs-arrow-down-left.svg
+++ b/icons/stairs-arrow-down-left.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m11 3-8 8" />
+  <path d="M3 7v4h4" />
+  <path d="M3 21h6v-6h6V9h6" />
+</svg>

--- a/icons/stairs-arrow-up-right.json
+++ b/icons/stairs-arrow-up-right.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley",
+    "darrel1925"
+  ],
+  "use-cases": [
+    "marking rooms and destinations on higher floors in wayfinding interfaces",
+    "indicating ascending stairs on floor plans and directional signage",
+    "identifying stair routes to upper floors and rooftop areas"
+  ],
+  "tags": [
+    "steps",
+    "stairwell",
+    "staircase",
+    "ascending",
+    "upstairs",
+    "floor",
+    "level",
+    "wayfinding",
+    "signage",
+    "direction",
+    "diagonal"
+  ],
+  "categories": [
+    "buildings",
+    "navigation",
+    "arrows"
+  ]
+}

--- a/icons/stairs-arrow-up-right.svg
+++ b/icons/stairs-arrow-up-right.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m3 11 8-8" />
+  <path d="M7 3h4v4" />
+  <path d="M3 21h6v-6h6V9h6" />
+</svg>

--- a/icons/stairs.json
+++ b/icons/stairs.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "danielbayley",
+    "darrel1925"
+  ],
+  "use-cases": [
+    "marking stairs on building floor plans and wayfinding maps",
+    "identifying emergency stair routes on evacuation plans",
+    "indicating movement between floors in property, architecture, and navigation interfaces",
+    "recording stair-climb activity in fitness interfaces"
+  ],
+  "tags": [
+    "steps",
+    "staircase",
+    "stairway",
+    "floor",
+    "level",
+    "building",
+    "architecture",
+    "wayfinding",
+    "egress"
+  ],
+  "categories": [
+    "buildings",
+    "navigation"
+  ]
+}

--- a/icons/stairs.svg
+++ b/icons/stairs.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 18h6v-6h6V6h6" />
+</svg>


### PR DESCRIPTION
Addresses #4506.

## Description

Promotes a simplified three-icon stairs family from Lucide Lab to the main icon set:

- [`stairs`](https://lucide.dev/icons/lab/stairs)
- [`stairs-arrow-up-right`](https://lucide.dev/icons/lab/stairs-arrow-up-right)
- [`stairs-arrow-down-left`](https://lucide.dev/icons/lab/stairs-arrow-down-left)

The Lab icons credit @danielbayley. This contribution preserves that attribution as the primary contributor and adds @darrel1925 for the simplified main-library geometry.

The directional pair covers the two primary icons requested in #4506. The optional mirrored variants are not included.

### Proposed and current Lab designs

<table>
  <thead>
    <tr>
      <th>Icon</th>
      <th>Proposed</th>
      <th>Current Lucide Lab</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><code>stairs</code></td>
      <td><img alt="Proposed stairs icon" width="160" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMyAxOGg2di02aDZWNmg2IiAvPgo8L3N2Zz4K.svg"><br><img alt="Proposed stairs icon at 24px" width="24" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMyAxOGg2di02aDZWNmg2IiAvPgo8L3N2Zz4K.svg"></td>
      <td><img alt="Current Lucide Lab stairs icon" width="160" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTAiIGhlaWdodD0iNCIgeD0iMiIgeT0iMTYiIC8+CiAgPHJlY3Qgd2lkdGg9IjEwIiBoZWlnaHQ9IjQiIHg9IjQiIHk9IjEyIiAvPgogIDxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSI0IiB4PSI2IiB5PSI4IiAvPgogIDxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSI0IiB4PSI4IiB5PSI0IiAvPgogIDxwYXRoIGQ9Ik0xMiAyMGgxMFY0aC00IiAvPgo8L3N2Zz4K.svg"><br><img alt="Current Lucide Lab stairs icon at 24px" width="24" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cmVjdCB3aWR0aD0iMTAiIGhlaWdodD0iNCIgeD0iMiIgeT0iMTYiIC8+CiAgPHJlY3Qgd2lkdGg9IjEwIiBoZWlnaHQ9IjQiIHg9IjQiIHk9IjEyIiAvPgogIDxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSI0IiB4PSI2IiB5PSI4IiAvPgogIDxyZWN0IHdpZHRoPSIxMCIgaGVpZ2h0PSI0IiB4PSI4IiB5PSI0IiAvPgogIDxwYXRoIGQ9Ik0xMiAyMGgxMFY0aC00IiAvPgo8L3N2Zz4K.svg"></td>
    </tr>
    <tr>
      <td><code>stairs-arrow-up-right</code></td>
      <td><img alt="Proposed stairs arrow up right icon" width="160" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMyAxMSA4LTgiIC8+CiAgPHBhdGggZD0iTTcgM2g0djQiIC8+CiAgPHBhdGggZD0iTTMgMjFoNnYtNmg2VjloNiIgLz4KPC9zdmc+Cg==.svg"><br><img alt="Proposed stairs arrow up right icon at 24px" width="24" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMyAxMSA4LTgiIC8+CiAgPHBhdGggZD0iTTcgM2g0djQiIC8+CiAgPHBhdGggZD0iTTMgMjFoNnYtNmg2VjloNiIgLz4KPC9zdmc+Cg==.svg"></td>
      <td><img alt="Current Lucide Lab stairs arrow up right icon" width="160" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMyAxMSA5LTkiIC8+CiAgPHBhdGggZD0iTTggMmg0djQiIC8+CiAgPHBhdGggZD0iTTIgMjBoNXYtNWg1di01aDVWNWg1IiAvPgo8L3N2Zz4K.svg"><br><img alt="Current Lucide Lab stairs arrow up right icon at 24px" width="24" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMyAxMSA5LTkiIC8+CiAgPHBhdGggZD0iTTggMmg0djQiIC8+CiAgPHBhdGggZD0iTTIgMjBoNXYtNWg1di01aDVWNWg1IiAvPgo8L3N2Zz4K.svg"></td>
    </tr>
    <tr>
      <td><code>stairs-arrow-down-left</code></td>
      <td><img alt="Proposed stairs arrow down left icon" width="160" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMTEgMy04IDgiIC8+CiAgPHBhdGggZD0iTTMgN3Y0aDQiIC8+CiAgPHBhdGggZD0iTTMgMjFoNnYtNmg2VjloNiIgLz4KPC9zdmc+Cg==.svg"><br><img alt="Proposed stairs arrow down left icon at 24px" width="24" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMTEgMy04IDgiIC8+CiAgPHBhdGggZD0iTTMgN3Y0aDQiIC8+CiAgPHBhdGggZD0iTTMgMjFoNnYtNmg2VjloNiIgLz4KPC9zdmc+Cg==.svg"></td>
      <td><img alt="Current Lucide Lab stairs arrow down left icon" width="160" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMTIgMi05IDkiIC8+CiAgPHBhdGggZD0iTTMgN3Y0aDQiIC8+CiAgPHBhdGggZD0iTTIgMjBoNXYtNWg1di01aDVWNWg1IiAvPgo8L3N2Zz4K.svg"><br><img alt="Current Lucide Lab stairs arrow down left icon at 24px" width="24" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMTIgMi05IDkiIC8+CiAgPHBhdGggZD0iTTMgN3Y0aDQiIC8+CiAgPHBhdGggZD0iTTIgMjBoNXYtNWg1di01aDVWNWg1IiAvPgo8L3N2Zz4K.svg"></td>
    </tr>
  </tbody>
</table>

### Icon use case

`stairs`:

- Marking stairs on building floor plans and wayfinding maps.
- Identifying emergency stair routes on evacuation plans.
- Indicating movement between floors in property and navigation interfaces.
- Recording stair-climb activity in fitness interfaces.

`stairs-arrow-up-right`:

- Marking rooms and destinations on higher floors in wayfinding interfaces.
- Indicating ascending stairs on floor plans and directional signage.
- Identifying stair routes to upper floors and rooftop areas.

`stairs-arrow-down-left`:

- Marking rooms and destinations on lower floors in wayfinding interfaces.
- Indicating descending stairs on floor plans and directional signage.
- Identifying stair routes to ground floors, exits, and basement areas.

### Alternative icon designs

The existing Lab icons use denser or dimensional stair geometry. These versions use a simple side profile with three horizontal levels and two rises. The directional variants retain the established upper-left arrow placement and directions.

All three icons use the same 6×6 stair shape. The standalone icon centers that shape in the canvas, while the directional pair moves it down three pixels to preserve clearance from the arrows. All paths use integer coordinates and 2px round strokes. The directional icons retain more than 2px of visible separation between the arrow and stair elements.

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for all three icons.
- [x] I have not added a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence-related, or political imagery.

### Author, credits & license

- [x] The original Lucide Lab icons were created by @danielbayley.
- [x] These simplified versions were created by @darrel1925 and are based on the existing [Lucide Lab designs](https://github.com/lucide-icons/lucide-lab/tree/main/icons).

### Naming

- [x] I have read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions).
- [x] I have retained the canonical Lab names: `stairs`, `stairs-arrow-up-right`, and `stairs-arrow-down-left`.
- [x] I have provided matching metadata files.

### Design

- [x] I have read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide).
- [x] The icons are sharp on low-DPI displays.
- [x] The icons are consistent with the set in size, optical volume, and density.
- [x] The icons are visually centered and reuse the same stair shape.
- [x] The icons use integer coordinates and optimized paths.

## Before Submitting

- [x] I have read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I have reviewed the existing Lab icons, prior stairs PRs #2492 and #2493, and the directional-icon request in #4506.

## Validation

- `pnpm run lint`
- `pnpm run lint:json:icons`
- `pnpm run checkIcons`
- `pnpm --filter @lucide/icons build` (1,751 icons generated)
- `pnpm --filter @lucide/icons test` (24 tests passed)
- Commit-time SVG optimization and icon/category validation

