### PR TITLE
Add user-student and user-teacher icons

### DIFF
--- a/icons/user-student.json
+++ b/icons/user-student.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "MercedesFraga"
+  ],
+  "use-cases": [],
+  "tags": [
+    "person",
+    "student",
+    "school",
+    "university",
+    "learn",
+    "study",
+    "graduate",
+    "education",
+    "book",
+    "reading",
+    "account"
+  ],
+  "categories": [
+    "account",
+    "people"
+  ]
+}

--- a/icons/user-student.svg
+++ b/icons/user-student.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="8" r="5" />
+  <path d="M20 21a8 8 0 0 0-16 0" />
+  <path d="M6 16v4l6 2 6-2v-4l-6 2z" />
+  <line x1="12" x2="12" y1="18" y2="22" />
+</svg>

--- a/icons/user-teacher.json
+++ b/icons/user-teacher.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "MercedesFraga"
+  ],
+  "use-cases": [],
+  "tags": [
+    "person",
+    "teacher",
+    "teach",
+    "instructor",
+    "professor",
+    "education",
+    "wand",
+    "pointer",
+    "book",
+    "account"
+  ],
+  "categories": [
+    "account",
+    "people"
+  ]
+}

--- a/icons/user-teacher.svg
+++ b/icons/user-teacher.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="8" r="5" />
+  <path d="M20 21a8 8 0 0 0-16 0" />
+  <path d="M6 16v4l6 2 6-2v-4l-6 2z" />
+  <line x1="12" x2="12" y1="18" y2="22" />
+  <line x1="20" x2="22" y1="21" y2="10" />
+  <line x1="20" x2="21" y1="7" y2="8" />
+</svg>


### PR DESCRIPTION
## Summary

Two new icons for the `user-*` family:

- **user-student** — the round-shoulder person from `user-round.svg`, holding an open book at chest height (with a center spine line), instead of a corner badge.
- **user-teacher** — the same body + book, plus a wand anchored at the lowest point of the right side of the body (the hem, where a lowered hand would be), rising up over the shoulder.

Both are built with only `circle`/`path`/`line`, a centered 2px stroke, and round line caps/joins, following the [icon design guide](https://lucide.dev/contribute/icon-design-guide).

## Test plan

- [x] Verified against `scripts/checkIconsAndCategories.mts` (categories/tags schema)
- [x] Verified against `scripts/lintFilenames.mts`
- [x] Checked with `prettier --check` on the new `.json` files
- [ ] Maintainer review of stroke curves / spacing (happy to iterate in [Lucide Studio](https://studio.lucide.dev/) based on feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)