### PR TITLE
fix(packages/angular): pass through stroke and fill presentation attributes on icon nodes

### DIFF
--- a/packages/angular/src/lucide-dynamic-icon.spec.ts
+++ b/packages/angular/src/lucide-dynamic-icon.spec.ts
@@ -52,6 +52,38 @@ describe('LucideDynamicIcon', () => {
       ['rect', { x: 1, y: 2, width: 3, height: 4, rx: 5, ry: 6, key: 'rect-key' }],
     ],
   };
+  const fillAndStrokeAttrs = {
+    fill: 'red',
+    'fill-opacity': '0.5',
+    stroke: 'blue',
+    'stroke-width': '3',
+    'stroke-linecap': 'round',
+    'stroke-linejoin': 'bevel',
+    'stroke-dasharray': '4 2',
+    'stroke-dashoffset': '1',
+    opacity: '0.75',
+  };
+  const strokeOnlyAttrs = {
+    stroke: 'blue',
+    'stroke-width': '3',
+    'stroke-linecap': 'round',
+    'stroke-linejoin': 'bevel',
+    'stroke-dasharray': '4 2',
+    'stroke-dashoffset': '1',
+    opacity: '0.75',
+  };
+  const presentationAttrsIcon: LucideIconData = {
+    name: 'presentation-attrs',
+    node: [
+      ['path', { d: 'm1 1 2 2', ...fillAndStrokeAttrs }],
+      ['line', { x1: 1, x2: 2, y1: 3, y2: 4, ...strokeOnlyAttrs }],
+      ['polygon', { points: '1 1 2 2 3 1', ...fillAndStrokeAttrs }],
+      ['polyline', { points: '1 1 2 2 3 1', ...fillAndStrokeAttrs }],
+      ['circle', { cx: 12, cy: 12, r: 8, ...fillAndStrokeAttrs }],
+      ['ellipse', { cx: 12, cy: 12, rx: 8, ry: 4, ...fillAndStrokeAttrs }],
+      ['rect', { x: 1, y: 2, width: 3, height: 4, rx: 5, ry: 6, ...fillAndStrokeAttrs }],
+    ],
+  };
   function createComponent() {
     return TestBed.createComponent(LucideDynamicIcon, {
       inferTagName: true,
@@ -95,6 +127,21 @@ describe('LucideDynamicIcon', () => {
       '<circle cx="12" cy="12" r="8" fill="currentColor"></circle>',
       '<ellipse cx="12" cy="12" rx="8" ry="4"></ellipse>',
       '<rect x="1" y="2" width="3" height="4" rx="5" ry="6"></rect>',
+    ]);
+  });
+
+  it('should render stroke and fill presentation attributes on all supported shapes', () => {
+    icon.set(presentationAttrsIcon);
+    fixture.detectChanges();
+    const children = getRenderedChildren();
+    expect(children.map((child) => child.outerHTML)).toEqual([
+      '<path d="m1 1 2 2" fill="red" fill-opacity="0.5" stroke="blue" stroke-width="3" stroke-linecap="round" stroke-linejoin="bevel" stroke-dasharray="4 2" stroke-dashoffset="1" opacity="0.75"></path>',
+      '<line x1="1" x2="2" y1="3" y2="4" stroke="blue" stroke-width="3" stroke-linecap="round" stroke-linejoin="bevel" stroke-dasharray="4 2" stroke-dashoffset="1" opacity="0.75"></line>',
+      '<polygon points="1 1 2 2 3 1" fill="red" fill-opacity="0.5" stroke="blue" stroke-width="3" stroke-linecap="round" stroke-linejoin="bevel" stroke-dasharray="4 2" stroke-dashoffset="1" opacity="0.75"></polygon>',
+      '<polyline points="1 1 2 2 3 1" fill="red" fill-opacity="0.5" stroke="blue" stroke-width="3" stroke-linecap="round" stroke-linejoin="bevel" stroke-dasharray="4 2" stroke-dashoffset="1" opacity="0.75"></polyline>',
+      '<circle cx="12" cy="12" r="8" fill="red" fill-opacity="0.5" stroke="blue" stroke-width="3" stroke-linecap="round" stroke-linejoin="bevel" stroke-dasharray="4 2" stroke-dashoffset="1" opacity="0.75"></circle>',
+      '<ellipse cx="12" cy="12" rx="8" ry="4" fill="red" fill-opacity="0.5" stroke="blue" stroke-width="3" stroke-linecap="round" stroke-linejoin="bevel" stroke-dasharray="4 2" stroke-dashoffset="1" opacity="0.75"></ellipse>',
+      '<rect x="1" y="2" width="3" height="4" rx="5" ry="6" fill="red" fill-opacity="0.5" stroke="blue" stroke-width="3" stroke-linecap="round" stroke-linejoin="bevel" stroke-dasharray="4 2" stroke-dashoffset="1" opacity="0.75"></rect>',
     ]);
   });
 

--- a/packages/angular/src/lucide-icon-template.ts
+++ b/packages/angular/src/lucide-icon-template.ts
@@ -13,6 +13,14 @@ export const lucideIconTemplate = `@if (title(); as titleValue) {
       <svg:path
         [attr.d]="attrs['d']"
         [attr.fill]="attrs['fill']"
+        [attr.fill-opacity]="attrs['fill-opacity']"
+        [attr.stroke]="attrs['stroke']"
+        [attr.stroke-width]="attrs['stroke-width']"
+        [attr.stroke-linecap]="attrs['stroke-linecap']"
+        [attr.stroke-linejoin]="attrs['stroke-linejoin']"
+        [attr.stroke-dasharray]="attrs['stroke-dasharray']"
+        [attr.stroke-dashoffset]="attrs['stroke-dashoffset']"
+        [attr.opacity]="attrs['opacity']"
         [attr.vector-effect]="attrs['vector-effect']"
       />
     }
@@ -22,18 +30,43 @@ export const lucideIconTemplate = `@if (title(); as titleValue) {
         [attr.x2]="attrs['x2']"
         [attr.y1]="attrs['y1']"
         [attr.y2]="attrs['y2']"
+        [attr.stroke]="attrs['stroke']"
+        [attr.stroke-width]="attrs['stroke-width']"
+        [attr.stroke-linecap]="attrs['stroke-linecap']"
+        [attr.stroke-linejoin]="attrs['stroke-linejoin']"
+        [attr.stroke-dasharray]="attrs['stroke-dasharray']"
+        [attr.stroke-dashoffset]="attrs['stroke-dashoffset']"
+        [attr.opacity]="attrs['opacity']"
         [attr.vector-effect]="attrs['vector-effect']"
       />
     }
     @case ('polygon') {
       <svg:polygon
         [attr.points]="attrs['points']"
+        [attr.fill]="attrs['fill']"
+        [attr.fill-opacity]="attrs['fill-opacity']"
+        [attr.stroke]="attrs['stroke']"
+        [attr.stroke-width]="attrs['stroke-width']"
+        [attr.stroke-linecap]="attrs['stroke-linecap']"
+        [attr.stroke-linejoin]="attrs['stroke-linejoin']"
+        [attr.stroke-dasharray]="attrs['stroke-dasharray']"
+        [attr.stroke-dashoffset]="attrs['stroke-dashoffset']"
+        [attr.opacity]="attrs['opacity']"
         [attr.vector-effect]="attrs['vector-effect']"
       />
     }
     @case ('polyline') {
       <svg:polyline
         [attr.points]="attrs['points']"
+        [attr.fill]="attrs['fill']"
+        [attr.fill-opacity]="attrs['fill-opacity']"
+        [attr.stroke]="attrs['stroke']"
+        [attr.stroke-width]="attrs['stroke-width']"
+        [attr.stroke-linecap]="attrs['stroke-linecap']"
+        [attr.stroke-linejoin]="attrs['stroke-linejoin']"
+        [attr.stroke-dasharray]="attrs['stroke-dasharray']"
+        [attr.stroke-dashoffset]="attrs['stroke-dashoffset']"
+        [attr.opacity]="attrs['opacity']"
         [attr.vector-effect]="attrs['vector-effect']"
       />
     }
@@ -43,6 +76,14 @@ export const lucideIconTemplate = `@if (title(); as titleValue) {
         [attr.cy]="attrs['cy']"
         [attr.r]="attrs['r']"
         [attr.fill]="attrs['fill']"
+        [attr.fill-opacity]="attrs['fill-opacity']"
+        [attr.stroke]="attrs['stroke']"
+        [attr.stroke-width]="attrs['stroke-width']"
+        [attr.stroke-linecap]="attrs['stroke-linecap']"
+        [attr.stroke-linejoin]="attrs['stroke-linejoin']"
+        [attr.stroke-dasharray]="attrs['stroke-dasharray']"
+        [attr.stroke-dashoffset]="attrs['stroke-dashoffset']"
+        [attr.opacity]="attrs['opacity']"
         [attr.vector-effect]="attrs['vector-effect']"
       />
     }
@@ -52,6 +93,15 @@ export const lucideIconTemplate = `@if (title(); as titleValue) {
         [attr.cy]="attrs['cy']"
         [attr.rx]="attrs['rx']"
         [attr.ry]="attrs['ry']"
+        [attr.fill]="attrs['fill']"
+        [attr.fill-opacity]="attrs['fill-opacity']"
+        [attr.stroke]="attrs['stroke']"
+        [attr.stroke-width]="attrs['stroke-width']"
+        [attr.stroke-linecap]="attrs['stroke-linecap']"
+        [attr.stroke-linejoin]="attrs['stroke-linejoin']"
+        [attr.stroke-dasharray]="attrs['stroke-dasharray']"
+        [attr.stroke-dashoffset]="attrs['stroke-dashoffset']"
+        [attr.opacity]="attrs['opacity']"
         [attr.vector-effect]="attrs['vector-effect']"
       />
     }
@@ -63,6 +113,15 @@ export const lucideIconTemplate = `@if (title(); as titleValue) {
         [attr.height]="attrs['height']"
         [attr.rx]="attrs['rx']"
         [attr.ry]="attrs['ry']"
+        [attr.fill]="attrs['fill']"
+        [attr.fill-opacity]="attrs['fill-opacity']"
+        [attr.stroke]="attrs['stroke']"
+        [attr.stroke-width]="attrs['stroke-width']"
+        [attr.stroke-linecap]="attrs['stroke-linecap']"
+        [attr.stroke-linejoin]="attrs['stroke-linejoin']"
+        [attr.stroke-dasharray]="attrs['stroke-dasharray']"
+        [attr.stroke-dashoffset]="attrs['stroke-dashoffset']"
+        [attr.opacity]="attrs['opacity']"
         [attr.vector-effect]="attrs['vector-effect']"
       />
     }


### PR DESCRIPTION
Addresses https://github.com/lucide-icons/lucide/pull/4519#issuecomment-5028975970

## Description

#4519 moved child icon node rendering from an imperative effect to a declarative template, which only binds a fixed subset of attributes per SVG element type (mostly positional attributes, plus `fill` on `path` and `circle` only).

This is fine for the built-in icon set, since those icons always inherit stroke and fill from the root `<svg>`. It's a silent regression for consumers of `LucideIconData`, the [documented public API](https://lucide.dev/guide/angular/advanced/icon-provider#registering-custom-icons) for custom icons, who rely on per-node overrides like `stroke`, `stroke-width`, `stroke-linecap`, `stroke-linejoin`, `stroke-dasharray`, `stroke-dashoffset`, `fill-opacity`, and `opacity`. These attributes are now dropped with no warning, and `fill` is also missing entirely on `rect`, `ellipse`, `line`, `polygon`, and `polyline`.

This PR adds the standard SVG presentation attributes to every element case in the template, matching what custom multi-color and multi-stroke-width icons need, while keeping the declarative, SSR-safe rendering approach introduced in #4519. No changes to the built-in icon set's rendered output, since none of those icons use the newly-bound attributes.