### PR TITLE
feat(icons): removed brand names from tags & revised brand stopwords

### DIFF
--- a/brand-stopwords.json
+++ b/brand-stopwords.json
@@ -56,7 +56,6 @@
   "kubernetes": "Kubernetes",
   "leetcode": "LeetCode",
   "leet-code": "LeetCode",
-  "line": "LINE",
   "linkedin": "LinkedIn",
   "lua": "Lua",
   "mariadb": "MariaDB",
@@ -69,7 +68,7 @@
   "nestjs": "NestJS",
   "netflix": "Netflix",
   "netlify": "Netlify",
-  "next": "Next.js",
+  "nextjs": "Next.js",
   "nodejs": "Node.js",
   "notion": "Notion",
   "nostr": "Nostr",
@@ -105,7 +104,8 @@
   "shopify": "Shopify",
   "skype": "Skype",
   "slack": "Slack",
-  "solid": "SolidJS",
+  "snapchat": "Snapchat",
+  "solidjs": "SolidJS",
   "soundcloud": "SoundCloud",
   "spotify": "Spotify",
   "sqlite": "SQLite",
@@ -144,6 +144,5 @@
   "xbox": "Xbox",
   "yarn": "Yarn",
   "youtube": "YouTube",
-  "zig": "Zig",
-  "zoom": "Zoom"
+  "zig": "Zig"
 }

--- a/icons/cast.json
+++ b/icons/cast.json
@@ -7,9 +7,18 @@
   ],
   "use-cases": [],
   "tags": [
-    "chromecast",
-    "airplay",
-    "screen"
+    "stream",
+    "streaming",
+    "screen",
+    "display",
+    "wireless",
+    "broadcast",
+    "transmit",
+    "media",
+    "receiver",
+    "remote display",
+    "screen sharing",
+    "media streaming"
   ],
   "categories": [
     "devices",

--- a/icons/circle-fading-plus.json
+++ b/icons/circle-fading-plus.json
@@ -8,10 +8,6 @@
   "tags": [
     "stories",
     "social media",
-    "instagram",
-    "facebook",
-    "meta",
-    "snapchat",
     "sharing",
     "content"
   ],

--- a/icons/compass.json
+++ b/icons/compass.json
@@ -11,7 +11,6 @@
     "east",
     "south",
     "west",
-    "safari",
     "browser"
   ],
   "categories": [

--- a/icons/computer.json
+++ b/icons/computer.json
@@ -7,8 +7,7 @@
   "tags": [
     "pc",
     "chassis",
-    "codespaces",
-    "github"
+    "codespaces"
   ],
   "categories": [
     "devices",

--- a/icons/container.json
+++ b/icons/container.json
@@ -9,7 +9,6 @@
     "shipping",
     "freight",
     "supply chain",
-    "docker",
     "environment",
     "devops",
     "code",


### PR DESCRIPTION
## Description

Some of our icons included brand names in their tags, I've removed these to avoid any legal issues in the future.

I've also updated the brand stopwords list since some of our stopwords were common names (e.g. zoom, next, line, etc)

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
