### PR TITLE
fix(icons): changed `columns-3-cog` icon

### DIFF
--- a/icons/columns-3-cog.json
+++ b/icons/columns-3-cog.json
@@ -3,7 +3,8 @@
   "contributors": [
     "irvineacosta",
     "danielbayley",
-    "karsa-mistmere"
+    "karsa-mistmere",
+    "kamilasw"
   ],
   "use-cases": [],
   "tags": [

--- a/icons/columns-3-cog.svg
+++ b/icons/columns-3-cog.svg
@@ -1,24 +1,14 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="currentColor"
-  stroke-width="2"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path d="M10.5 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v5.5" />
-  <path d="m14.3 19.6 1-.4" />
-  <path d="M15 3v7.5" />
-  <path d="m15.2 16.9-.9-.3" />
-  <path d="m16.6 21.7.3-.9" />
-  <path d="m16.8 15.3-.4-1" />
-  <path d="m19.1 15.2.3-.9" />
-  <path d="m19.6 21.7-.4-1" />
-  <path d="m20.7 16.8 1-.4" />
-  <path d="m21.7 19.4-.9-.3" />
-  <path d="M9 3v18" />
-  <circle cx="18" cy="18" r="3" />
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.5 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H19C19.5304 3 20.0391 3.21071 20.4142 3.58579C20.7893 3.96086 21 4.46957 21 5V10.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 21C19.6569 21 21 19.6569 21 18C21 16.3431 19.6569 15 18 15C16.3431 15 15 16.3431 15 18C15 19.6569 16.3431 21 18 21Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.3 19.6L14.8 19.4" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 3V10.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.3 16.6L14.75 16.75" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.6 21.7L16.75 21.25" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.4 14.3L16.6 14.8" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.4 14.3L19.25 14.75" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.6 21.7L19.4 21.2" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21.7 16.4L21.2 16.6" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21.7 19.4L21.25 19.25" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 3V21" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/icons/columns-3-cog.svg
+++ b/icons/columns-3-cog.svg
@@ -1,14 +1,24 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10.5 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H19C19.5304 3 20.0391 3.21071 20.4142 3.58579C20.7893 3.96086 21 4.46957 21 5V10.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M18 21C19.6569 21 21 19.6569 21 18C21 16.3431 19.6569 15 18 15C16.3431 15 15 16.3431 15 18C15 19.6569 16.3431 21 18 21Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M14.3 19.6L14.8 19.4" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M15 3V10.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M14.3 16.6L14.75 16.75" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M16.6 21.7L16.75 21.25" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M16.4 14.3L16.6 14.8" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M19.4 14.3L19.25 14.75" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M19.6 21.7L19.4 21.2" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M21.7 16.4L21.2 16.6" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M21.7 19.4L21.25 19.25" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M9 3V21" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10.6 21H5a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v5.6" />
+  <path d="m14.305 19.53.923-.382" />
+  <path d="M15 3v7.6" />
+  <path d="m15.229 16.852-.924-.383" />
+  <path d="m16.852 15.228-.383-.923" />
+  <path d="m16.852 20.772-.383.924" />
+  <path d="m19.148 15.228.383-.923" />
+  <path d="m19.53 21.696-.382-.924" />
+  <path d="m20.773 16.852.922-.383" />
+  <path d="m20.773 19.148.922.383" />
+  <path d="M9 3v18" />
+  <circle cx="18" cy="18" r="3" />
 </svg>


### PR DESCRIPTION

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Icon `columns-3-cog` update

- refined  `columns-3-cog`  icon to increase consistency between icons with a small cog
- shortened vectors of cog spikes by half so that they don't show from the inside

Before:
<img width="216" height="216" alt="columns-3-cog_old" src="https://github.com/user-attachments/assets/bdb4541b-df51-4c14-b5f4-0ffa1beb1e47" />

After:
<img width="216" height="216" alt="columns-3-cog" src="https://github.com/user-attachments/assets/e8a06921-cd1d-4c87-b89c-9456855c0fab" />

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
