### PR TITLE
fix(icons): extended metadata of `ad` icon

### DIFF
--- a/icons/ad.json
+++ b/icons/ad.json
@@ -21,10 +21,15 @@
     "paid",
     "partner",
     "promo",
-    "sponsor"
+    "sponsor",
+    "audio description",
+    "video description",
+    "described video",
+    "visual description"
   ],
   "categories": [
     "multimedia",
+    "accessibility",
     "notifications"
   ]
 }


### PR DESCRIPTION

## What is the purpose of this pull request?
- [x] New Icon

### Description

Added audio description metadata to `ad` icon, as the same sort of icon is also commonly used for this purpose (see `cc`).

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.