### PR TITLE
fix(icons): changed `washing-machine` icon

### DIFF
--- a/icons/washing-machine.json
+++ b/icons/washing-machine.json
@@ -4,6 +4,7 @@
     "danielbayley",
     "karsa-mistmere"
   ],
+  "use-cases": [],
   "tags": [
     "tumble dryer",
     "amenities",

--- a/icons/washing-machine.json
+++ b/icons/washing-machine.json
@@ -1,9 +1,9 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "karsa-mistmere"
   ],
-  "use-cases": [],
   "tags": [
     "tumble dryer",
     "amenities",

--- a/icons/washing-machine.svg
+++ b/icons/washing-machine.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M3 6h3" />
-  <path d="M17 6h.01" />
-  <rect width="18" height="20" x="3" y="2" rx="2" />
-  <circle cx="12" cy="13" r="5" />
-  <path d="M12 18a2.5 2.5 0 0 0 0-5 2.5 2.5 0 0 1 0-5" />
+  <path d="M12 18a2 2 0 000-4 2 2 0 010-4" />
+  <path d="M16 6h.01" />
+  <path d="M8 6h4" />
+  <circle cx="12" cy="14" r="4" />
+  <rect x="4" y="2" width="16" height="20" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

## Description

Decreased optical volume of the icon.

## Alternative design ideas

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=1.LIRgbABGAWB0AMJgA4rQCwG1MCIDGAlgE54A2ApjgDQDe%2BAHjgFwgBMV%2BAnsyOh0c3QBfALpVcRcngAu1OoyZ8c3JuxwB3AgBNp0HmA7RyBAObRZq%2BPwWtRIoA&name=washing-machine"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTYgNmguMDEiIC8+CiAgPHBhdGggZD0iTTggNmg0IiAvPgogIDxjaXJjbGUgY3g9IjEyIiBjeT0iMTQiIHI9IjQiIC8+CiAgPHJlY3QgeD0iNCIgeT0iMiIgd2lkdGg9IjE2IiBoZWlnaHQ9IjIwIiByeD0iMiIgLz4KPC9zdmc+.svg"/><br/>Open lucide studio</a>

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.