### PR TITLE
ci(ci.yml): Remove concurrency in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,6 @@ permissions:
   id-token: write # Required for OIDC
   contents: write
 
-# This is added to make sure we wait until last release is done, this is needed for the font-build process
-concurrency:
-  group: continuous-integration
-
 jobs:
   check-dispatch-gate:
     if: github.repository == 'lucide-icons/lucide' &&


### PR DESCRIPTION
Concurrency was added to prevent corrupt release for the icon font if multiple are running. But this not needed anymore since we now have dispatch gates