### PR TITLE
docs(site): correct Vanilla icon import casing

### DIFF
--- a/docs/.vitepress/lib/codeExamples/createCodeExamples.ts
+++ b/docs/.vitepress/lib/codeExamples/createCodeExamples.ts
@@ -13,11 +13,11 @@ const getIconCodes = (): CodeExampleType => {
       title: 'Vanilla',
       code: `\
 <script>
-import { createIcons, $CamelCase } from 'lucide';
+import { createIcons, $PascalCase } from 'lucide';
 
 createIcons({
   icons: {
-    $CamelCase
+    $PascalCase
   }
 });
 </script>


### PR DESCRIPTION
Closes #4520

## Description

Updates the generated Vanilla JavaScript icon examples to use PascalCase identifiers for imports and the `createIcons` icon map.

The shared example generator previously substituted `$CamelCase`, producing invalid imports such as `pencil`. Lucide exports icons with PascalCase names such as `Pencil`.

This fixes the example for every icon page while leaving `data-lucide` attribute values unchanged.

## Validation

- Ran Prettier against the changed generator
- Ran `pnpm checkIcons`
- Verified the rendered `pencil` example uses `Pencil` in both positions
- Completed a full VitePress documentation build

## Before Submitting

- [x] I've read the Contribution Guidelines.
- [x] I've checked that there is no existing PR solving the same issue.
