### PR TITLE
fix(icons): changed `computer` icon

### DIFF
--- a/icons/computer.json
+++ b/icons/computer.json
@@ -4,6 +4,7 @@
     "danielbayley",
     "karsa-mistmere"
   ],
+  "use-cases": [],
   "tags": [
     "pc",
     "chassis",

--- a/icons/computer.json
+++ b/icons/computer.json
@@ -1,9 +1,9 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "danielbayley"
+    "danielbayley",
+    "karsa-mistmere"
   ],
-  "use-cases": [],
   "tags": [
     "pc",
     "chassis",

--- a/icons/computer.svg
+++ b/icons/computer.svg
@@ -15,5 +15,5 @@
   <path d="M14 7h8" />
   <path d="M18 17h.01" />
   <path d="M9 19v-4" />
-  <rect x="14" y="3" width="8" height="18" rx="2" />
+  <rect x="14" y="3" width="8" height="18" rx="1" />
 </svg>

--- a/icons/computer.svg
+++ b/icons/computer.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M10 15H4a2 2 0 01-2-2V7a2 2 0 012-2h6" />
+  <path d="M10 19H5" />
   <path d="M14 11h8" />
-  <path d="M14 15H4a2 2 0 01-2-2V7a2 2 0 012-2h10" />
-  <path d="M14 19H5" />
   <path d="M14 7h8" />
   <path d="M18 17h.01" />
   <path d="M9 19v-4" />

--- a/icons/computer.svg
+++ b/icons/computer.svg
@@ -9,11 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M10 15H4a2 2 0 01-2-2V7a2 2 0 012-2h6" />
-  <path d="M10 19H5" />
-  <path d="M14 11h8" />
-  <path d="M14 7h8" />
-  <path d="M18 17h.01" />
-  <path d="M9 19v-4" />
-  <rect x="14" y="3" width="8" height="18" rx="1" />
+  <path d="M12 18h6" />
+  <path d="M6 18h.01" />
+  <path d="M8 6h1" />
+  <rect x="2" y="14" width="20" height="8" rx="2" />
+  <rect x="4" y="2" width="16" height="12" rx="2" />
 </svg>

--- a/icons/computer.svg
+++ b/icons/computer.svg
@@ -9,8 +9,11 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="14" height="8" x="5" y="2" rx="2" />
-  <rect width="20" height="8" x="2" y="14" rx="2" />
-  <path d="M6 18h2" />
-  <path d="M12 18h6" />
+  <path d="M14 11h8" />
+  <path d="M14 15H4a2 2 0 01-2-2V7a2 2 0 012-2h10" />
+  <path d="M14 19H5" />
+  <path d="M14 7h8" />
+  <path d="M18 17h.01" />
+  <path d="M9 19v-4" />
+  <rect x="14" y="3" width="8" height="18" rx="2" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

## Description

Redesigned the computer icon from scratch to better reflect a contemporary PC setup instead of a retro C64-style computer.

This also fixes that weird aspect ratio the current display has.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.