### PR TITLE
feat(icons): add text-margins

### DIFF
--- a/icons/text-margins.json
+++ b/icons/text-margins.json
@@ -3,7 +3,10 @@
   "contributors": [
     "samuelalake"
   ],
-  "use-cases": [],
+  "use-cases": [
+    "showing text or content constrained within left and right margins",
+    "toggling measure or layout guides in an editor"
+  ],
   "tags": [
     "text",
     "margins",
@@ -15,9 +18,13 @@
     "indent",
     "paragraph",
     "measure",
-    "readable"
+    "readable",
+    "typography",
+    "guides",
+    "layout"
   ],
   "categories": [
-    "text"
+    "text",
+    "layout"
   ]
 }

--- a/icons/text-margins.json
+++ b/icons/text-margins.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "text",
+    "margins",
+    "margin",
+    "column",
+    "width",
+    "bounds",
+    "gutter",
+    "indent",
+    "paragraph",
+    "measure",
+    "readable"
+  ],
+  "categories": [
+    "text"
+  ]
+}

--- a/icons/text-margins.svg
+++ b/icons/text-margins.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 3v18" />
+  <path d="M21 3v18" />
+  <path d="M7 8h8" />
+  <path d="M7 12h10" />
+  <path d="M7 16h6" />
+</svg>


### PR DESCRIPTION
## Description

Adds `text-margins`: lines of text bounded left and right by two vertical rules.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Cpath%20d%3D%22M3%203v18%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M21%203v18%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M7%208h8%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M7%2012h10%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M7%2016h6%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=text-margins"><img alt="text-margins" width="170px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMyAzdjE4IiAvPgogIDxwYXRoIGQ9Ik0yMSAzdjE4IiAvPgogIDxwYXRoIGQ9Ik03IDhoOCIgLz4KICA8cGF0aCBkPSJNNyAxMmgxMCIgLz4KICA8cGF0aCBkPSJNNyAxNmg2IiAvPgo8L3N2Zz4K.svg"/><br/>Open lucide studio</a>

The set has `text-quote` (a single left bar beside text) but nothing with text held between margins on both sides. It reuses the ragged text-glyph convention (`h8` / `h10` / `h6`, centred) so the lines read as running text rather than a menu.

| `text-margins` (new) | `text-quote` | `text-align-center` |
| --- | --- | --- |
| <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Cpath%20d%3D%22M3%203v18%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M21%203v18%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M7%208h8%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M7%2012h10%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M7%2016h6%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=text-margins"><img alt="text-margins" width="170px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMyAzdjE4IiAvPgogIDxwYXRoIGQ9Ik0yMSAzdjE4IiAvPgogIDxwYXRoIGQ9Ik03IDhoOCIgLz4KICA8cGF0aCBkPSJNNyAxMmgxMCIgLz4KICA8cGF0aCBkPSJNNyAxNmg2IiAvPgo8L3N2Zz4K.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Cpath%20d%3D%22M17%205H3%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M21%2012H8%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M21%2019H8%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M3%2012v7%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=text-quote"><img alt="text-quote" width="170px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTcgNUgzIiAvPgogIDxwYXRoIGQ9Ik0yMSAxMkg4IiAvPgogIDxwYXRoIGQ9Ik0yMSAxOUg4IiAvPgogIDxwYXRoIGQ9Ik0zIDEydjciIC8+Cjwvc3ZnPgo=.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Cpath%20d%3D%22M21%205H3%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M17%2012H7%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M19%2019H5%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=text-align-center"><img alt="text-align-center" width="170px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMjEgNUgzIiAvPgogIDxwYXRoIGQ9Ik0xNyAxMkg3IiAvPgogIDxwYXRoIGQ9Ik0xOSAxOUg1IiAvPgo8L3N2Zz4K.svg"/><br/>Open lucide studio</a> |

**A note on naming.** I've gone with `text-margins` as the plainest depiction — the two vertical rules read as left/right margins around the text. It's the one thing here I'm least sure of, so if a different name fits your conventions better (something in the `text-*` family, or tied to a fixed-width / resize reading), I'm glad to rename. The design itself is what I'd like a read on.

### Icon use case

- A fixed-width or bounded-width text block in a layout or design tool.
- A "text column" / readable-measure indicator in an editor.
- Horizontal margins or gutters around body text in a page builder.

### Alternative icon designs

None — though I considered shorter side rails and left-aligned text; full-height rails with centred text read most clearly as "text between margins".

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] The icons are solely my own creation.

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
