### PR TITLE
fix(vue): add aria-hidden default attribute to icons

### DIFF
--- a/packages/vue/src/defaultAttributes.ts
+++ b/packages/vue/src/defaultAttributes.ts
@@ -8,4 +8,5 @@ export default {
   'stroke-width': 2,
   'stroke-linecap': 'round',
   'stroke-linejoin': 'round',
+  'aria-hidden': 'true',
 };

--- a/packages/vue/tests/Icon.spec.ts
+++ b/packages/vue/tests/Icon.spec.ts
@@ -44,4 +44,16 @@ describe('Using Icon Component', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('should include aria-hidden="true" by default', async () => {
+    const { container } = render(Icon, {
+      props: {
+        iconNode: airVent,
+        name: 'AirVent',
+      },
+    });
+
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
 });


### PR DESCRIPTION
Adds aria-hidden: true to defaultAttributes in @lucide/vue so SVG icons include aria-hidden by default to match other Lucide packages (fixes #4564). Added unit test in Icon.spec.ts.