### PR TITLE
feat(copilot): remove incorrect spaces clause from copilot instructions

### DIFF
--- a/.github/instructions/metadata.instructions.md
+++ b/.github/instructions/metadata.instructions.md
@@ -13,7 +13,7 @@ The `contributors` property is a required array of GitHub usernames for the peop
 
 The `tags` property is an array of strings that describe the icon and can be used for searching.
 Validate the tags against the `icon.schema.json` to ensure they are correctly formatted and adhere to the defined structure.
-Provide tag suggestions based on the name of the icon and the use cases provided in the PR description. Use the existing tags in the repository as a reference for consistency and to avoid duplicates. Don't suggest words like: 'icon' and preferably use single words. Tags should always be in lowercase and should not contain spaces. The name of icon should not be included in the tags, as it is already specified.
+Provide tag suggestions based on the name of the icon and the use cases provided in the PR description. Use the existing tags in the repository as a reference for consistency and to avoid duplicates. Don't suggest words like: 'icon' and preferably use single words. Tags should always be in lowercase, and may also contain spaces (e.g. `magnifying glass`). The name of icon should not be included in the tags, as it is already specified.
 
 # Categories
 


### PR DESCRIPTION
## Description

Our Copilot metadata instructions currently note that tags may not contain spaces, which is just not true: a large portion of our tags contain spaces, both pertaining to use cases and as visual descriptors, these are perfectly legitimate tags, e.g.:
- “magnifying glass” for `search`
- “motion picture” for `video`
- “blood pressure” for `heart-pulse`
- “sign out” for `log-out` 
- amongst hundreds and hundreds of others

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
