### PR TITLE
fix(ci): limit certain github workflows to main repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       version: ${{ needs.create-release.outputs.VERSION }}
 
   dispatch-release:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.repository == 'lucide-icons/lucide' && github.event_name == 'workflow_dispatch'
     uses: './.github/workflows/release.yml'
     secrets: inherit
     with:

--- a/.github/workflows/close-issue-with-banned-phrases.yml
+++ b/.github/workflows/close-issue-with-banned-phrases.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   block_phrases:
+    if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/comment-icon-preview.yml
+++ b/.github/workflows/comment-icon-preview.yml
@@ -10,6 +10,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     if: >
+      github.repository == 'lucide-icons/lucide' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   triage:
+    if: github.repository == 'lucide-icons/lucide'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pull-request-icon-preview.yml
+++ b/.github/workflows/pull-request-icon-preview.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   generate-changed-icons-comment:
     name: Generate Changed Icons Comment
+    if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pull-request-metadata-suggestions.yml
+++ b/.github/workflows/pull-request-metadata-suggestions.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   pull-request-metadata-suggestions:
     name: Pull Request Metadata Suggestions
+    if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/repo-journal.yml
+++ b/.github/workflows/repo-journal.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
 jobs:
   weekly-summary:
+    if: github.repository == 'lucide-icons/lucide'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node.js environment

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   request-review:
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'lucide-icons/lucide' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Description

Got a few e-mails about workflow runs failing on my fork:
<img width="1168" height="954" alt="image" src="https://github.com/user-attachments/assets/bf874d7d-a2fb-407c-b101-18485d69b8f2" />

So I added an `if: github.repository == 'lucide-icons/lucide'` clause to a bunch of our github jobs, where running these on forked repositories didn't make sense.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
