### PR TITLE
feat(icons): add book-question-mark icon

### DIFF
--- a/icons/book-question-mark.json
+++ b/icons/book-question-mark.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "lazerg"
+  ],
+  "use-cases": [],
+  "tags": [
+    "reading",
+    "library",
+    "knowledge",
+    "help",
+    "question",
+    "unknown",
+    "not found",
+    "missing",
+    "search",
+    "faq"
+  ],
+  "categories": [
+    "text",
+    "development"
+  ]
+}

--- a/icons/book-question-mark.json
+++ b/icons/book-question-mark.json
@@ -1,9 +1,14 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "lazerg"
+    "jguddas"
   ],
-  "use-cases": [],
+  "use-cases": [
+    "empty state when a requested book or document cannot be found",
+    "flagging an unknown or unverified title in a catalogue or search result",
+    "indicating a missing reference or citation in documentation",
+    "linking to help, faq, or support articles about a publication"
+  ],
   "tags": [
     "reading",
     "library",
@@ -14,10 +19,19 @@
     "not found",
     "missing",
     "search",
-    "faq"
+    "faq",
+    "book",
+    "document",
+    "manual",
+    "reference",
+    "support",
+    "catalog",
+    "placeholder"
   ],
   "categories": [
     "text",
-    "development"
+    "development",
+    "files",
+    "communication"
   ]
 }

--- a/icons/book-question-mark.svg
+++ b/icons/book-question-mark.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 22H6.5a1 1 0 0 1 0-5h7.893" />
+  <path d="M18 15.27c.2-.4.5-.8.9-1a2.1 2.1 0 0 1 2.6.4c.3.4.5.8.5 1.3 0 1.3-2 2-2 2" />
+  <path d="M20 21.99h.01" />
+  <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v7.018" />
+</svg>


### PR DESCRIPTION
closes #4624

## Description

Adds the `book-question-mark` icon.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=2.16u2H6.5E10-5h7.893M18r5.27c.2-.4.5-.8.9-1a2.1u.1b12.6.4c.3.4.5.8.5r.3nr.3-o2-o2M2p21.99h.yM4r9.5v-15A2.5u.5b16.5uH19E11rv7.y8&name=book-question-mark&utm_source=lucide-studio&utm_medium=embed"><img alt="book-question-mark" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTYgMjJINi41YTEgMSAwIDAxMC01aDcuODkzIiAvPgogIDxwYXRoIGQ9Ik0xOCAxNS4yN2MuMi0uNC41LS44LjktMWEyLjEgMi4xIDAgMDEyLjYuNGMuMy40LjUuOC41IDEuMyAwIDEuMy0yIDItMiAyIiAvPgogIDxwYXRoIGQ9Ik0yMCAyMS45OWguMDEiIC8+CiAgPHBhdGggZD0iTTQgMTkuNXYtMTVBMi41IDIuNSAwIDAxNi41IDJIMTlhMSAxIDAgMDExIDF2Ny4wMTgiIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

It pairs the `book` shape with a corner question mark, matching how `file-question-mark` and `circle-question-mark` place the mark. The design comes straight from the version @jguddas generated in Lucide Studio on the request.

### Icon use case

- Empty state when a book, article or document cannot be found in a library or reading app.
- Marking an unknown or unrecognised title in a catalogue or search result.
- A help or FAQ entry inside documentation.

### Alternative icon designs

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] The icons were originally created in #4624 by @jguddas

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
