### PR TITLE
feat(icons): add list-clock icon

### DIFF
--- a/icons/list-clock.json
+++ b/icons/list-clock.json
@@ -24,7 +24,6 @@
     "list"
   ],
   "categories": [
-  "categories": [
     "text",
     "time",
     "notifications"

--- a/icons/list-clock.json
+++ b/icons/list-clock.json
@@ -3,15 +3,29 @@
   "contributors": [
     "kemie"
   ],
-  "use-cases": [],
+  "use-cases": [
+    "showing the edit or revision history of a list item",
+    "indicating recently viewed list entries",
+    "displaying a list of recently changed tasks",
+    "representing an activity or audit log for list-based content",
+    "marking last-updated or timestamped list rows"
+  ],
   "tags": [
     "history",
     "log",
     "clock",
-    "time"
+    "time",
+    "recent",
+    "updated",
+    "revision",
+    "activity",
+    "timestamp",
+    "audit",
+    "list"
   ],
   "categories": [
     "text",
-    "time"
+    "time",
+    "notifications"
   ]
 }

--- a/icons/list-clock.json
+++ b/icons/list-clock.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "kemie"
+  ],
+  "use-cases": [],
+  "tags": [
+    "history",
+    "log",
+    "clock",
+    "time"
+  ],
+  "categories": [
+    "text",
+    "time"
+  ]
+}

--- a/icons/list-clock.json
+++ b/icons/list-clock.json
@@ -1,6 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
+    "karsa-mistmere",
+    "jamiemlaw",
     "kemie"
   ],
   "use-cases": [

--- a/icons/list-clock.json
+++ b/icons/list-clock.json
@@ -17,13 +17,6 @@
     "time",
     "recent",
     "updated",
-  "tags": [
-    "history",
-    "log",
-    "clock",
-    "time",
-    "recent",
-    "updated",
     "revision",
     "activity",
     "timestamp",

--- a/icons/list-clock.json
+++ b/icons/list-clock.json
@@ -17,6 +17,13 @@
     "time",
     "recent",
     "updated",
+  "tags": [
+    "history",
+    "log",
+    "clock",
+    "time",
+    "recent",
+    "updated",
     "revision",
     "activity",
     "timestamp",

--- a/icons/list-clock.json
+++ b/icons/list-clock.json
@@ -31,6 +31,7 @@
     "list"
   ],
   "categories": [
+  "categories": [
     "text",
     "time",
     "notifications"

--- a/icons/list-clock.svg
+++ b/icons/list-clock.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M16 14v2.2l1.6 1" />
-  <path d="M16 5H3" />
-  <path d="M7 12H3" />
-  <path d="M7 19H3" />
-  <circle cx="16" cy="16" r="6" />
+  <path d="M16 13v2.2l1.6 1" />
+  <path d="M3 12h3.458" />
+  <path d="M3 19h3.832" />
+  <path d="M3 5h18" />
+  <circle cx="16" cy="15" r="6" />
 </svg>

--- a/icons/list-clock.svg
+++ b/icons/list-clock.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 14v2.2l1.6 1" />
+  <path d="M16 5H3" />
+  <path d="M7 12H3" />
+  <path d="M7 19H3" />
+  <circle cx="16" cy="16" r="6" />
+</svg>


### PR DESCRIPTION
closes #4600

## Description

Adds the `list-clock` icon.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=1.LIRgbABCAsBuBMA6eAbEjIlJArACQGZgB2KeQkqATkIG1aAiAYwEsAnJlAUwYBoBvZgA8GALnC9mATzESGbMWAC%2BAXRVA&name=list-clock&utm_source=lucide-studio&utm_medium=embed"><img alt="list-clock" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTYgMTR2Mi4ybDEuNiAxIiAvPgogIDxwYXRoIGQ9Ik0xNiA1SDMiIC8+CiAgPHBhdGggZD0iTTcgMTJIMyIgLz4KICA8cGF0aCBkPSJNNyAxOUgzIiAvPgogIDxjaXJjbGUgY3g9IjE2IiBjeT0iMTYiIHI9IjYiIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

It sets the clock motif from `file-clock` and `clipboard-clock` next to a shortened list, so the rows read as list or text history. The design comes from the version @kemie drew in Lucide Studio on the request.

### Icon use case

- Showing the edit or revision history of a list or text item.
- A recently viewed or recently changed entries view.
- An activity log built from list rows.

### Alternative icon designs

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] The icons were originally created in #4600 by @kemie

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
