### PR TITLE
feat(icons): add user-round-clock icon

### DIFF
--- a/icons/user-round-clock.json
+++ b/icons/user-round-clock.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "jguddas"
+  ],
+  "use-cases": [
+    "showing the activity history of a user account",
+    "indicating recently active or recently seen members",
+    "displaying a login or session history for a profile",
+    "representing time tracking attached to a person",
+    "marking a pending or scheduled account action"
+  ],
+  "tags": [
+    "person",
+    "account",
+    "contact",
+    "history",
+    "log",
+    "clock",
+    "time",
+    "recent",
+    "activity",
+    "session",
+    "timestamp"
+  ],
+  "categories": [
+    "account",
+    "social",
+    "time"
+  ]
+}

--- a/icons/user-round-clock.json
+++ b/icons/user-round-clock.json
@@ -8,7 +8,11 @@
     "indicating recently active or recently seen members",
     "displaying a login or session history for a profile",
     "representing time tracking attached to a person",
-    "marking a pending or scheduled account action"
+    "marking a pending or scheduled account action",
+    "showing a user's scheduled appointments",
+    "indicating a reminder tied to a user account",
+    "representing user availability or office hours",
+    "displaying an audit or compliance timestamp for a user"
   ],
   "tags": [
     "person",
@@ -21,11 +25,19 @@
     "recent",
     "activity",
     "session",
-    "timestamp"
+    "timestamp",
+    "avatar",
+    "profile",
+    "badge",
+    "reminder",
+    "schedule",
+    "audit"
   ],
   "categories": [
     "account",
     "social",
-    "time"
+    "time",
+    "people",
+    "notifications"
   ]
 }

--- a/icons/user-round-clock.json
+++ b/icons/user-round-clock.json
@@ -1,6 +1,8 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
+    "karsa-mistmere",
+    "jamiemlaw",
     "jguddas"
   ],
   "use-cases": [

--- a/icons/user-round-clock.svg
+++ b/icons/user-round-clock.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 14v2.2l1.6 1" />
+  <path d="M6.212 13.954A8 8 0 0 0 2 21" />
+  <path d="M6.877 11.905a5 5 0 1 1 7.746-5.81" />
+  <circle cx="16" cy="16" r="6" />
+</svg>


### PR DESCRIPTION
closes #4566

## Description

Adds the `user-round-clock` icon.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=1.LIRgbABCAsBuBMA6eAbEjImGZJ5QGZEBOAVmgEEAOCGgBgjrv3ixyoHYOp1i7SAhqQjCGIEB0QdoYALSlEVEAG1lAIgDGASwBOGlAFM1AGgDemgB5qAXOGOaAnjbtqdNsAF8Aul6A&name=user-round-clock"><img alt="user-round-clock" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTYgMTR2Mi4ybDEuNiAxIiAvPgogIDxwYXRoIGQ9Ik02LjIxMiAxMy45NTRBOCA4IDAgMDAyIDIxIiAvPgogIDxwYXRoIGQ9Ik02Ljg3NyAxMS45MDVhNSA1IDAgMTE3Ljc0Ni01LjgxIiAvPgogIDxjaXJjbGUgY3g9IjE2IiBjeT0iMTYiIHI9IjYiIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

The request asked for a user history icon. There is no `history` icon in the set, so this uses the same clock badge as `file-clock`, `folder-clock` and `clipboard-clock` on a `user-round` body, which keeps it consistent with the rest of the clock family. The design is the one @jguddas drew in Lucide Studio on the request.

### Icon use case

- Showing the activity or login history of an account.
- Listing recently active members.
- Time tracking attached to a person.

### Alternative icon designs

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] The icons were originally created in #4566 by @jguddas
- [x] I've based them on the following Lucide icons: `user-round`, `file-clock`

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
