### PR TITLE
feat(icons): added `mail-badge` icon

### DIFF
--- a/icons/mail-badge.json
+++ b/icons/mail-badge.json
@@ -3,7 +3,12 @@
   "contributors": [
     "rrod497"
   ],
-  "use-cases": [],
+  "use-cases": [
+    "indicating certified or registered email",
+    "marking messages with proof of delivery",
+    "marking a message as signed or sealed",
+    "labeling official or legal correspondence"
+  ],
   "tags": [
     "email",
     "message",
@@ -12,9 +17,17 @@
     "registered",
     "seal",
     "stamp",
-    "verified"
+    "verified",
+    "envelope",
+    "badge",
+    "rosette",
+    "signed",
+    "official",
+    "delivery"
   ],
   "categories": [
-    "mail"
+    "mail",
+    "communication",
+    "security"
   ]
 }

--- a/icons/mail-badge.json
+++ b/icons/mail-badge.json
@@ -19,7 +19,6 @@
     "stamp",
     "verified",
     "envelope",
-    "badge",
     "rosette",
     "signed",
     "official",

--- a/icons/mail-badge.json
+++ b/icons/mail-badge.json
@@ -1,7 +1,12 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "rrod497"
+    "rrod497",
+    "colebemis",
+    "karsa-mistmere",
+    "ericfennis",
+    "jguddas",
+    "danielbayley"
   ],
   "use-cases": [
     "indicating certified or registered email",

--- a/icons/mail-badge.json
+++ b/icons/mail-badge.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "rrod497"
+  ],
+  "use-cases": [],
+  "tags": [
+    "email",
+    "message",
+    "letter",
+    "certified",
+    "registered",
+    "seal",
+    "stamp",
+    "verified"
+  ],
+  "categories": [
+    "mail"
+  ]
+}

--- a/icons/mail-badge.svg
+++ b/icons/mail-badge.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 7.7V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8.25" />
+  <path d="M12 12.996a1.94 1.94 0 0 1-1.03-.296L2 7" />
+  <path d="m20.69 16.479 1.29 4.88a.5.5 0 0 1-.698.591l-1.843-.849a1 1 0 0 0-.879.001l-1.846.85a.5.5 0 0 1-.692-.593l1.29-4.88" />
+  <circle cx="19" cy="14" r="3" />
+</svg>


### PR DESCRIPTION
closes #4525

## Description

Adds the `mail-badge` icon.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=1.LIRgTABOB0CcsDYCGI4BYrogBhyAtKtgMz7RiIAykA7ALZjbQKxQLRo2uoURrQAOAUmgBWMTjxkWAsbBAAbQoLSkVsFFEnZsZAV2g7FygWnYDRI8aO0FmsMGVGxiCnrHz8hwMLWg0ANWRISFwdfEcwAAk0JBDtXRCAN3A4iFCcbBCAC1kwUQBtAoAiAGMASwAnUoUAU2KAGgBvMoAPYoAuEFgGsoBPTpA0XsrO4gBfAF1JoA&name=mail-badge"><img alt="mail-badge" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMjIgNy43VjZhMiAyIDAgMCAwLTItMkg0YTIgMiAwIDAgMC0yIDJ2MTJhMiAyIDAgMCAwIDIgMmg4LjI1IiAvPgogIDxwYXRoIGQ9Ik0xMiAxMi45OTZhMS45NCAxLjk0IDAgMCAxLTEuMDMtLjI5NkwyIDciIC8+CiAgPHBhdGggZD0ibTIwLjY5IDE2LjQ3OSAxLjI5IDQuODhhLjUuNSAwIDAgMS0uNjk4LjU5MWwtMS44NDMtLjg0OWExIDEgMCAwIDAtLjg3OS4wMDFsLTEuODQ2Ljg1YS41LjUgMCAwIDEtLjY5Mi0uNTkzbDEuMjktNC44OCIgLz4KICA8Y2lyY2xlIGN4PSIxOSIgY3k9IjE0IiByPSIzIiAvPgo8L3N2Zz4K.svg"/><br/>Open lucide studio</a>

The request asked for an envelope with a seal, used for certified mail. This is the design @rrod497 drew in Lucide Studio on the request: the `mail` envelope with the same rosette as `file-badge`, which is why it is named `mail-badge`. The right half of the flap is cut away because the badge would otherwise sit on top of it.

### Icon use case

- Certified email such as PEC in Italy or De-Mail in Germany.
- Registered post and other mail that carries proof of delivery.
- Marking a message as signed or sealed.

### Alternative icon designs

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] The icons were originally created in #4525 by @rrod497
- [x] I've based them on the following Lucide icons: `mail`, `file-badge`

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
