### PR TITLE
ci(workflows): add plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,35 @@
+name: Plumber
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: getplumber/plumber@40bd6b5bb8ff4f0944feacaeb41dea6bce08d62d # v0.4.28
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,17 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the actions this repo
+      # already relies on for releases, PR title linting and
+      # changed-file detection on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - amannn/action-semantic-pull-request
+        - softprops/action-gh-release
+        - tj-actions/changed-files

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/lucide-icons/lucide/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-ISC-green" alt="license"></a>
   <a href="https://www.figma.com/community/plugin/939567362549682242/Lucide-Icons"><img src="https://img.shields.io/badge/Figma-F24E1E?logo=figma&logoColor=white" alt="figma installs"></a>
   <a href="https://github.com/lucide-icons/lucide/actions/workflows/ci.yml"><img src="https://github.com/lucide-icons/lucide/actions/workflows/ci.yml/badge.svg" alt="build status"></a>
+  <a href="https://score.getplumber.io/github.com/lucide-icons/lucide"><img src="https://score.getplumber.io/github.com/lucide-icons/lucide.svg" alt="plumber score"></a>
   <a href="https://discord.gg/EH6nSts"><img src="https://img.shields.io/discord/723074157486800936?label=chat&logo=discord&logoColor=%23ffffff&colorB=%237289DA" alt="discord chat"></a>
 </p>
 <p align="center">


### PR DESCRIPTION
## Description

Companion to https://github.com/lucide-icons/lucide/pull/4640, merge that one first: the check added here flags the CVE-affected action, the unpinned refs, the inherited secrets and the missing permission scopes until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to main and on each PR, and fails when something regresses: an unpinned or known-vulnerable action, a job without a permissions block, a secret handed to a workflow that does not need it, that kind of thing. The gate passes at 85 of 100 points, so one small finding does not block your PRs.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the Security tab as SARIF (skipped on PRs from forks, the report stays as a workflow artifact there).
- `.plumber.yaml`: a small overlay that inherits the tool's built-in baseline; the only thing written is what differs for this repo, the release, PR title lint and changed-file actions already in use are trusted on top of the curated default source list. Everything else, including new controls in future releases, follows the defaults automatically.
- `README.md`: one line, the score badge next to the build status one.

## Score badge

I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of main. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README line and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I close this PR, the hardening PR stands on its own.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.