### PR TITLE
fix(scripts): removed toBeRemovedInVersion from all scripts and tools

### DIFF
--- a/icons/mic-signal.json
+++ b/icons/mic-signal.json
@@ -39,8 +39,7 @@
     {
       "name": "podcast",
       "deprecated": true,
-      "deprecationReason": "alias.name",
-      "toBeRemovedInVersion": "v1.0"
+      "deprecationReason": "alias.name"
     }
   ]
 }

--- a/scripts/rename/renameIcon.function.mts
+++ b/scripts/rename/renameIcon.function.mts
@@ -52,7 +52,6 @@ export async function renameIcon(ICONS_DIR: string, oldName: string, newName: st
         name: oldName,
         deprecated: true,
         deprecationReason: 'alias.name',
-        toBeRemovedInVersion: 'v1.0',
       },
     ];
     fs.writeFileSync(newJsonPath, JSON.stringify(jsonData, null, 2));

--- a/tools/build-icons/building/aliases/generateAliasesFiles.ts
+++ b/tools/build-icons/building/aliases/generateAliasesFiles.ts
@@ -110,7 +110,6 @@ export default async function generateAliasesFiles({
               ? deprecationReasonTemplate(alias.deprecationReason, {
                   componentName: toPascalCase(iconName),
                   iconName,
-                  toBeRemovedInVersion: alias.toBeRemovedInVersion,
                 })
               : '';
 

--- a/tools/build-icons/building/generateIconFiles.ts
+++ b/tools/build-icons/building/generateIconFiles.ts
@@ -48,10 +48,7 @@ function generateIconFiles({
     ]);
 
     const getSvg = () => readSvg(`${iconName}.svg`, iconsDir);
-    const {
-      deprecated = false,
-      aliases = [],
-    } = iconMetaData[iconName];
+    const { deprecated = false, aliases = [] } = iconMetaData[iconName];
     const deprecationReason = deprecated
       ? deprecationReasonTemplate(iconMetaData[iconName].deprecationReason ?? '', {
           componentName,

--- a/tools/build-icons/building/generateIconFiles.ts
+++ b/tools/build-icons/building/generateIconFiles.ts
@@ -50,14 +50,12 @@ function generateIconFiles({
     const getSvg = () => readSvg(`${iconName}.svg`, iconsDir);
     const {
       deprecated = false,
-      toBeRemovedInVersion = undefined,
       aliases = [],
     } = iconMetaData[iconName];
     const deprecationReason = deprecated
       ? deprecationReasonTemplate(iconMetaData[iconName].deprecationReason ?? '', {
           componentName,
           iconName,
-          toBeRemovedInVersion,
         })
       : '';
 

--- a/tools/build-icons/types.ts
+++ b/tools/build-icons/types.ts
@@ -32,13 +32,11 @@ export type AliasDeprecation = {
   name: string;
   deprecated: true;
   deprecationReason: AliasDeprecationReason;
-  toBeRemovedInVersion?: string;
 };
 
 export type IconDeprecationReason = 'icon.renamed' | '';
 
 export type IconMetadataBase = {
-  toBeRemovedInVersion?: string;
   categories: string[];
   aliases?: AliasDeprecation[];
   tags: string[];

--- a/tools/build-icons/utils/deprecationReasonTemplate.ts
+++ b/tools/build-icons/utils/deprecationReasonTemplate.ts
@@ -4,25 +4,20 @@ export default function deprecationReasonTemplate(
   deprecationReason: AliasDeprecationReason | IconDeprecationReason,
   {
     componentName,
-    toBeRemovedInVersion,
   }: {
     componentName: string;
     iconName: string;
-    toBeRemovedInVersion?: string;
   },
 ) {
   const resourceName = deprecationReason.startsWith('icon') ? 'icon' : 'alias';
-  const removalNotice = toBeRemovedInVersion
-    ? ` This ${resourceName} will be removed in ${toBeRemovedInVersion}`
-    : '';
 
   switch (deprecationReason) {
     case 'alias.typo':
-      return `Renamed because of typo, use {@link ${componentName}} instead.${removalNotice}`;
+      return `Renamed because of typo, use {@link ${componentName}} instead.`;
     case 'alias.duplicate':
-      return `The icon was combined with another icon that shares the same use case, use {@link ${componentName}} instead.${removalNotice}`;
+      return `The icon was combined with another icon that shares the same use case, use {@link ${componentName}} instead.`;
     case 'alias.name':
-      return `The name of this icon was changed because it didn't meet our guidelines anymore, use {@link ${componentName}} instead.${removalNotice}`;
+      return `The name of this icon was changed because it didn't meet our guidelines anymore, use {@link ${componentName}} instead.`;
     default:
       throw new Error(`Unknown deprecation reason: ${deprecationReason}`);
   }


### PR DESCRIPTION
We no longer use this prop, but some scripts & tools still add it / depend upon it.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
