### PR TITLE
fix(ci): download the font artifact into its own directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
+        with:
+          name: lucide-font
+          path: lucide-font
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7.0.0
         with:
@@ -155,6 +158,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
+        with:
+          name: lucide-font
+          path: lucide-font
       - name: Zip font and icons
         run: |
           zip -r lucide-font-${{ needs.prepare.outputs.VERSION }}.zip lucide-font


### PR DESCRIPTION
closes #4677

`actions/download-artifact` went from v4 to v8 in #4668. Since v5 it no longer unpacks a lone artifact into a directory named after it when no `name` is given, so the font files land loose in the workspace root instead of in `lucide-font/`.

That broke two jobs in the [1.29.0 run](https://github.com/lucide-icons/lucide/actions/runs/31098294770): `post-release` had nothing called `lucide-font` to zip, which is why the release has no font/icon archives, and `lucide-static` ended up with untracked font files in the tree, so `pnpm version` bailed out with `ERR_PNPM_UNCLEAN_WORKING_TREE`.

Passing `name` and `path` explicitly puts the font back where both jobs look for it.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.