### PR TITLE
feat(icons): added `hot-tub` icon

### DIFF
--- a/categories/emoji.json
+++ b/categories/emoji.json
@@ -1,5 +1,5 @@
 {
   "$schema": "../category.schema.json",
   "title": "Emoji",
-  "icon": "smile"
+  "icon": "face-slightly-smiling"
 }

--- a/icons/hot-tub.json
+++ b/icons/hot-tub.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "KesleyDavid"
+  ],
+  "use-cases": [
+    "indicating hot tub or jacuzzi amenities in hotel and vacation rental listings",
+    "representing spa and wellness facilities in tourism reservation systems",
+    "marking outdoor hot tub rentals in hospitality booking apps",
+    "labeling relaxation or spa features in property amenities filters"
+  ],
+  "tags": [
+    "jacuzzi",
+    "spa",
+    "tub",
+    "bath",
+    "steam",
+    "relax",
+    "amenities",
+    "hotel",
+    "wellness",
+    "bubbles",
+    "heat",
+    "outdoor",
+    "resort"
+  ],
+  "categories": [
+    "home",
+    "travel"
+  ]
+}

--- a/icons/hot-tub.json
+++ b/icons/hot-tub.json
@@ -7,7 +7,9 @@
     "indicating hot tub or jacuzzi amenities in hotel and vacation rental listings",
     "representing spa and wellness facilities in tourism reservation systems",
     "marking outdoor hot tub rentals in hospitality booking apps",
-    "labeling relaxation or spa features in property amenities filters"
+    "labeling relaxation or spa features in property amenities filters",
+    "marking spa and jacuzzi locations on maps and local business directories",
+    "signifying luxury resort amenities in travel package listings"
   ],
   "tags": [
     "jacuzzi",
@@ -22,7 +24,11 @@
     "bubbles",
     "heat",
     "outdoor",
-    "resort"
+    "resort",
+    "jets",
+    "luxury",
+    "retreat",
+    "backyard"
   ],
   "categories": [
     "home",

--- a/icons/hot-tub.svg
+++ b/icons/hot-tub.svg
@@ -1,0 +1,21 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 8c2-3-2-3 0-6" />
+  <path d="M15 8c2-3-2-3 0-6" />
+  <path d="M2 12h20" />
+  <path d="M4 12v5a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5" />
+  <path d="M7 19v2" />
+  <path d="M17 19v2" />
+  <path d="M8 15h.01" />
+  <path d="M12 15h.01" />
+  <path d="M16 15h.01" />
+</svg>


### PR DESCRIPTION
closes #4601

## Description

Adds the `hot-tub` icon: a freestanding tub with rising steam and surface bubbles, for hospitality and spa amenity UIs.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/?utm_source=github&utm_medium=pr"><img alt="hot-tub" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNOSA4YzItMy0yLTMgMC02IiAvPgogIDxwYXRoIGQ9Ik0xNSA4YzItMy0yLTMgMC02IiAvPgogIDxwYXRoIGQ9Ik0yIDEyaDIwIiAvPgogIDxwYXRoIGQ9Ik00IDEydjVhMiAyIDAgMCAwIDIgMmgxMmEyIDIgMCAwIDAgMi0ydi01IiAvPgogIDxwYXRoIGQ9Ik03IDE5djIiIC8+CiAgPHBhdGggZD0iTTE3IDE5djIiIC8+CiAgPHBhdGggZD0iTTggMTVoLjAxIiAvPgogIDxwYXRoIGQ9Ik0xMiAxNWguMDEiIC8+CiAgPHBhdGggZD0iTTE2IDE1aC4wMSIgLz4KPC9zdmc+Cg==.svg"/><br/>hot-tub</a>

Design notes:
- Tub body, rim, and legs follow the same construction language as `bath`, without the faucet so the icon stays distinct.
- Steam curves reuse the heat/steam motif from `heater`.
- Three surface dots read as bubbles/jets (jacuzzi), distinguishing it from a plain bathtub and from lab's `bath-bubble`.

Also updates `categories/emoji.json` so the category icon points to `face-slightly-smiling` after the `smile` rename in #4606 (required for `checkIcons` / pre-commit to pass).

**AI note:** Geometry was drafted with AI assistance (Grok), then manually checked against the Lucide icon design guide (24×24 canvas, 1px padding, 2px stroke, round caps/joins, element spacing, optical volume) and compared side-by-side with `bath` and `heater`.

### Icon use case

- Indicating hot tub or jacuzzi amenities in hotel and vacation rental listings.
- Representing spa and wellness facilities in tourism reservation systems.
- Marking outdoor hot tub rentals in hospitality booking apps.
- Labeling relaxation or spa features in property amenities filters.

### Alternative icon designs

None attached; happy to iterate on steam count, bubble placement, or tub proportions if maintainers prefer a denser or simpler mark.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons are solely my own creation.
- [x] I've based them on the following Lucide icons: `bath`, `heater`

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
