### PR TITLE
feat(icons): added `hole` icon

### DIFF
--- a/icons/hole.json
+++ b/icons/hole.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "KesleyDavid",
+    "karsa-mistmere"
+  ],
+  "use-cases": [
+    "indicating a hole tool in 3D CAD or modeling software",
+    "warning about a hole or hazard on a path or street map",
+    "creating a hole in 3D terrain or landscape editing software",
+    "representing an opening or cavity in construction diagrams"
+  ],
+  "tags": [
+    "ellipse",
+    "opening",
+    "cavity",
+    "pit",
+    "void",
+    "tunnel",
+    "portal",
+    "3d",
+    "cad",
+    "terrain",
+    "hazard"
+  ],
+  "categories": [
+    "shapes",
+    "tools"
+  ]
+}

--- a/icons/hole.json
+++ b/icons/hole.json
@@ -8,7 +8,9 @@
     "indicating a hole tool in 3D CAD or modeling software",
     "warning about a hole or hazard on a path or street map",
     "creating a hole in 3D terrain or landscape editing software",
-    "representing an opening or cavity in construction diagrams"
+    "representing an opening or cavity in construction diagrams",
+    "representing a bore or drill operation in machining software",
+    "denoting a cutout or aperture in product design specifications"
   ],
   "tags": [
     "ellipse",
@@ -21,7 +23,11 @@
     "3d",
     "cad",
     "terrain",
-    "hazard"
+    "hazard",
+    "aperture",
+    "cutout",
+    "bore",
+    "well"
   ],
   "categories": [
     "shapes",

--- a/icons/hole.svg
+++ b/icons/hole.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2.57 14a10 6 0 0 1 18.86 0" />
+  <ellipse cx="12" cy="12" rx="10" ry="6" />
+</svg>


### PR DESCRIPTION
closes #3988

## Description

Adds the `hole` icon using the compliant ellipse design suggested by @karsa-mistmere on the request (full optical volume, no gap violation).

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMi41NyAxNGExMCA2IDAgMCAxIDE4Ljg2IDAiIC8+CiAgPGVsbGlwc2UgY3g9IjEyIiBjeT0iMTIiIHJ4PSIxMCIgcnk9IjYiIC8+Cjwvc3ZnPg%3D%3D&utm_source=lucide-studio&utm_medium=embed"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMi41NyAxNGExMCA2IDAgMCAxIDE4Ljg2IDAiIC8+CiAgPGVsbGlwc2UgY3g9IjEyIiBjeT0iMTIiIHJ4PSIxMCIgcnk9IjYiIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

Also updates `categories/emoji.json` (`smile` → `face-slightly-smiling`) so `checkIcons` passes after the emoji rename in #4606.

**AI note:** Geometry follows the maintainer Studio draft; packaging/metadata prepared with AI assistance (Grok) and checked against Lucide icon guidelines.

### Icon use case

- Indicating a hole tool in 3D CAD or modeling software.
- Warning about a hole or hazard on a path or street map.
- Creating a hole in 3D terrain or landscape editing software.
- Representing an opening or cavity in construction diagrams.

### Alternative icon designs

None attached; matches the compliant design posted by @karsa-mistmere on #3988.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons were originally created in #3988 by @karsa-mistmere
- [x] I've based them on the following Lucide icons: `ellipse` / circle optical volume conventions

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
