### PR TITLE
feat(icons): added `asterism` icon

### DIFF
--- a/icons/asterism.json
+++ b/icons/asterism.json
@@ -8,7 +8,9 @@
     "marking fediverse or ActivityPub profile links that are interoperable across platforms",
     "representing the asterism typographic symbol (⁂) in text or publishing tools",
     "indicating decentralized social network handles in blogs and about pages",
-    "labeling federation or multi-platform follow actions in social clients"
+    "labeling federation or multi-platform follow actions in social clients",
+    "decorative divider between sections in articles or posts",
+    "marking typographic ornaments or footnote groups in publishing templates"
   ],
   "tags": [
     "asterisk",
@@ -20,10 +22,14 @@
     "decentralized",
     "federation",
     "stars",
-    "three"
+    "three",
+    "ornament",
+    "punctuation",
+    "divider"
   ],
   "categories": [
     "text",
-    "social"
+    "social",
+    "design"
   ]
 }

--- a/icons/asterism.json
+++ b/icons/asterism.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "KesleyDavid",
+    "karsa-mistmere"
+  ],
+  "use-cases": [
+    "marking fediverse or ActivityPub profile links that are interoperable across platforms",
+    "representing the asterism typographic symbol (⁂) in text or publishing tools",
+    "indicating decentralized social network handles in blogs and about pages",
+    "labeling federation or multi-platform follow actions in social clients"
+  ],
+  "tags": [
+    "asterisk",
+    "fediverse",
+    "activitypub",
+    "symbol",
+    "typography",
+    "social",
+    "decentralized",
+    "federation",
+    "stars",
+    "three"
+  ],
+  "categories": [
+    "text",
+    "social"
+  ]
+}

--- a/icons/asterism.svg
+++ b/icons/asterism.svg
@@ -1,0 +1,21 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 2v8" />
+  <path d="m14.5 15 7 4" />
+  <path d="m14.5 19 7-4" />
+  <path d="M18 13v8" />
+  <path d="m2.5 15 7 4" />
+  <path d="m2.5 19 7-4" />
+  <path d="M6 13v8" />
+  <path d="m8.5 4 7 4" />
+  <path d="m8.5 8 7-4" />
+</svg>


### PR DESCRIPTION
closes #4077

## Description

Adds the `asterism` icon (⁂) using the three-asterisk composition proposed by @karsa-mistmere, built from the asterisk geometry of `square-asterisk`.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTIgMnY4IiAvPgogIDxwYXRoIGQ9Im0xNC41IDE1IDcgNCIgLz4KICA8cGF0aCBkPSJtMTQuNSAxOSA3LTQiIC8+CiAgPHBhdGggZD0iTTE4IDEzdjgiIC8+CiAgPHBhdGggZD0ibTIuNSAxNSA3IDQiIC8+CiAgPHBhdGggZD0ibTIuNSAxOSA3LTQiIC8+CiAgPHBhdGggZD0iTTYgMTN2OCIgLz4KICA8cGF0aCBkPSJtOC41IDQgNyA0IiAvPgogIDxwYXRoIGQ9Im04LjUgOCA3LTQiIC8+Cjwvc3ZnPg%3D&utm_source=lucide-studio&utm_medium=embed"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTIgMnY4IiAvPgogIDxwYXRoIGQ9Im0xNC41IDE1IDcgNCIgLz4KICA8cGF0aCBkPSJtMTQuNSAxOSA3LTQiIC8+CiAgPHBhdGggZD0iTTE4IDEzdjgiIC8+CiAgPHBhdGggZD0ibTIuNSAxNSA3IDQiIC8+CiAgPHBhdGggZD0ibTIuNSAxOSA3LTQiIC8+CiAgPHBhdGggZD0iTTYgMTN2OCIgLz4KICA8cGF0aCBkPSJtOC41IDQgNyA0IiAvPgogIDxwYXRoIGQ9Im04LjUgOCA3LTQiIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

Also updates `categories/emoji.json` (`smile` → `face-slightly-smiling`) so `checkIcons` passes after the emoji rename in #4606.

**AI note:** Geometry follows the maintainer Studio draft; packaging/metadata prepared with AI assistance (Grok) and checked against Lucide icon guidelines.

### Icon use case

- Marking fediverse or ActivityPub profile links that are interoperable across platforms.
- Representing the asterism typographic symbol (⁂) in text or publishing tools.
- Indicating decentralized social network handles in blogs and about pages.
- Labeling federation or multi-platform follow actions in social clients.

### Alternative icon designs

None attached; matches the design posted by @karsa-mistmere on #4077.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons were originally created in #4077 by @karsa-mistmere
- [x] I've based them on the following Lucide icons: `square-asterisk`, `asterisk`

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
