### PR TITLE
feat(icons): added `square-kanban-plus` icon

### DIFF
--- a/icons/square-kanban-plus.json
+++ b/icons/square-kanban-plus.json
@@ -7,7 +7,9 @@
     "adding a new kanban board in project management apps",
     "creating a new board from an empty state or dashboard",
     "toolbar action to open a new agile board or sprint view",
-    "indicating add-column or add-board affordances next to kanban views"
+    "indicating add-column or add-board affordances next to kanban views",
+    "empty-state call-to-action to set up a kanban board",
+    "onboarding step to prompt creation of a first project board"
   ],
   "tags": [
     "board",
@@ -19,11 +21,18 @@
     "tickets",
     "issues",
     "productivity",
-    "columns"
+    "columns",
+    "workflow",
+    "planning",
+    "dashboard",
+    "workspace",
+    "collaboration",
+    "cards"
   ],
   "categories": [
     "charts",
     "development",
-    "design"
+    "design",
+    "layout"
   ]
 }

--- a/icons/square-kanban-plus.json
+++ b/icons/square-kanban-plus.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "KesleyDavid"
+  ],
+  "use-cases": [
+    "adding a new kanban board in project management apps",
+    "creating a new board from an empty state or dashboard",
+    "toolbar action to open a new agile board or sprint view",
+    "indicating add-column or add-board affordances next to kanban views"
+  ],
+  "tags": [
+    "board",
+    "project",
+    "add",
+    "create",
+    "plus",
+    "agile",
+    "tickets",
+    "issues",
+    "productivity",
+    "columns"
+  ],
+  "categories": [
+    "charts",
+    "development",
+    "design"
+  ]
+}

--- a/icons/square-kanban-plus.svg
+++ b/icons/square-kanban-plus.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 19h6" />
+  <path d="M19 22v-6" />
+  <path d="M8 7v7" />
+  <path d="M12 7v4" />
+  <path d="M16 7v5" />
+  <path d="M21 13V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8" />
+</svg>


### PR DESCRIPTION
closes #4416

## Description

Adds the `square-kanban-plus` icon for creating a new kanban board. Combines `square-kanban` bars with the corner-plus treatment used by siblings such as `calendar-plus` and `grid-2x2-plus`.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=2.1o7v4M16r9h6M16_7v5M19u2v-6M21r2.536V5B0-2-2H5B0-o2v14B0o2h7.536M8_7v7&name=square-canban-plus&utm_source=lucide-studio&utm_medium=embed"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTIgN3Y0IiAvPgogIDxwYXRoIGQ9Ik0xNiAxOWg2IiAvPgogIDxwYXRoIGQ9Ik0xNiA3djUiIC8+CiAgPHBhdGggZD0iTTE5IDIydi02IiAvPgogIDxwYXRoIGQ9Ik0yMSAxMi41MzZWNWEyIDIgMCAwMC0yLTJINWEyIDIgMCAwMC0yIDJ2MTRhMiAyIDAgMDAyIDJoNy41MzYiIC8+CiAgPHBhdGggZD0iTTggN3Y3IiAvPgo8L3N2Zz4=.svg"/><br/>Open lucide studio</a>

Also updates `categories/emoji.json` (`smile` → `face-slightly-smiling`) so `checkIcons` passes after the emoji rename in #4606.

**AI note:** Icon composition drafted with AI assistance (Grok), aligned to existing `square-kanban` and Lucide plus-variant patterns, then checked against the icon design guide.

### Icon use case

- Adding a new kanban board in project management apps.
- Creating a new board from an empty state or dashboard.
- Toolbar action to open a new agile board or sprint view.
- Indicating add-board affordances next to kanban views.

### Alternative icon designs

Could also ship as bare `kanban-plus` (bars only + plus). Named `square-kanban-plus` to stay in the `square-kanban` family requested as "kanban square plus".

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons are solely my own creation.
- [x] I've based them on the following Lucide icons: `square-kanban`, `calendar-plus`, `grid-2x2-plus`

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
