### PR TITLE
feat(icons): added `lightbulb-on` icon

### DIFF
--- a/categories/emoji.json
+++ b/categories/emoji.json
@@ -1,5 +1,5 @@
 {
   "$schema": "../category.schema.json",
   "title": "Emoji",
-  "icon": "smile"
+  "icon": "face-slightly-smiling"
 }

--- a/icons/lightbulb-on.json
+++ b/icons/lightbulb-on.json
@@ -8,7 +8,9 @@
     "indicating an active idea, inspiration, or aha moment in creative tools",
     "toggling a light or smart-bulb on state next to lightbulb-off",
     "highlighting tips, hints, or learning moments in product onboarding",
-    "showing that a feature or insight is currently active or illuminated"
+    "showing that a feature or insight is currently active or illuminated",
+    "indicating a device power or operational status in smart-home dashboards",
+    "signifying recommended settings or suggested improvements in tools"
   ],
   "tags": [
     "idea",
@@ -20,10 +22,16 @@
     "aha",
     "energy",
     "shine",
-    "radiate"
+    "radiate",
+    "bulb",
+    "illumination",
+    "spark",
+    "innovation",
+    "smarthome"
   ],
   "categories": [
     "photography",
-    "devices"
+    "devices",
+    "home"
   ]
 }

--- a/icons/lightbulb-on.json
+++ b/icons/lightbulb-on.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "KesleyDavid",
+    "jguddas"
+  ],
+  "use-cases": [
+    "indicating an active idea, inspiration, or aha moment in creative tools",
+    "toggling a light or smart-bulb on state next to lightbulb-off",
+    "highlighting tips, hints, or learning moments in product onboarding",
+    "showing that a feature or insight is currently active or illuminated"
+  ],
+  "tags": [
+    "idea",
+    "bright",
+    "lights",
+    "on",
+    "lit",
+    "inspiration",
+    "aha",
+    "energy",
+    "shine",
+    "radiate"
+  ],
+  "categories": [
+    "photography",
+    "devices"
+  ]
+}

--- a/icons/lightbulb-on.svg
+++ b/icons/lightbulb-on.svg
@@ -1,0 +1,21 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 22h4" />
+  <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5" />
+  <path d="m2 12 .855-.342" />
+  <path d="M2 7.5h.01" />
+  <path d="m2.5 2.5.863.5" />
+  <path d="m21 2-.697.465" />
+  <path d="M21.21 11.684 22 12" />
+  <path d="M22 7h.01" />
+  <path d="M9 18h6" />
+</svg>


### PR DESCRIPTION
closes #4054

## Description

Adds the `lightbulb-on` icon: the existing `lightbulb` body with radiating rays (spark/shine ticks) as drafted by @jguddas on the request, for inspiration and "lit" states.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTAgMjJoNCIgLz4KICA8cGF0aCBkPSJNMTUgMTRjLjItMSAuNy0xLjcgMS41LTIuNSAxLS45IDEuNS0yLjIgMS41LTMuNUE2IDYgMCAwIDAgNiA4YzAgMSAuMiAyLjIgMS41IDMuNS43LjcgMS4zIDEuNSAxLjUgMi41IiAvPgogIDxwYXRoIGQ9Im0yIDEyIC44NTUtLjM0MiIgLz4KICA8cGF0aCBkPSJNMiA3LjVoLjAxIiAvPgogIDxwYXRoIGQ9Im0yLjUgMi41Ljg2My41IiAvPgogIDxwYXRoIGQ9Im0yMSAyLS42OTcuNDY1IiAvPgogIDxwYXRoIGQ9Ik0yMS4yMSAxMS42ODQgMjIgMTIiIC8+CiAgPHBhdGggZD0iTTIyIDdoLjAxIiAvPgogIDxwYXRoIGQ9Ik05IDE4aDYiIC8+Cjwvc3ZnPg%3D%3D&name=lightbulb-on&utm_source=lucide-studio&utm_medium=embed"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTAgMjJoNCIgLz4KICA8cGF0aCBkPSJNMTUgMTRjLjItMSAuNy0xLjcgMS41LTIuNSAxLS45IDEuNS0yLjIgMS41LTMuNUE2IDYgMCAwIDAgNiA4YzAgMSAuMiAyLjIgMS41IDMuNS43LjcgMS4zIDEuNSAxLjUgMi41IiAvPgogIDxwYXRoIGQ9Im0yIDEyIC44NTUtLjM0MiIgLz4KICA8cGF0aCBkPSJNMiA3LjVoLjAxIiAvPgogIDxwYXRoIGQ9Im0yLjUgMi41Ljg2My41IiAvPgogIDxwYXRoIGQ9Im0yMSAyLS42OTcuNDY1IiAvPgogIDxwYXRoIGQ9Ik0yMS4yMSAxMS42ODQgMjIgMTIiIC8+CiAgPHBhdGggZD0iTTIyIDdoLjAxIiAvPgogIDxwYXRoIGQ9Ik05IDE4aDYiIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

Also updates `categories/emoji.json` (`smile` → `face-slightly-smiling`) so `checkIcons` passes after the emoji rename in #4606.

**AI note:** Geometry follows the maintainer Studio draft; packaging/metadata prepared with AI assistance (Grok) and checked against Lucide icon guidelines.

### Icon use case

- Indicating an active idea, inspiration, or aha moment in creative tools.
- Toggling a light or smart-bulb on state next to `lightbulb-off`.
- Highlighting tips, hints, or learning moments in product onboarding.
- Showing that a feature or insight is currently active or illuminated.

### Alternative icon designs

Happy to swap ray style (sun-like longer rays vs short spark ticks) if maintainers prefer.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons were originally created in #4054 by @jguddas
- [x] I've based them on the following Lucide icons: `lightbulb`, `siren` (radiating motif)

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
