### PR TITLE
feat(icons): added `chair` icon

### DIFF
--- a/categories/emoji.json
+++ b/categories/emoji.json
@@ -1,5 +1,5 @@
 {
   "$schema": "../category.schema.json",
   "title": "Emoji",
-  "icon": "smile"
+  "icon": "face-slightly-smiling"
 }

--- a/icons/chair.json
+++ b/icons/chair.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "KesleyDavid",
+    "jamiemlaw"
+  ],
+  "use-cases": [
+    "indicating available seating or table type in restaurant reservation UIs",
+    "representing the chair product category in furniture e-commerce filters",
+    "marking selectable seats in venue maps or event booking flows",
+    "showing seating locations on simple floor plans and wayfinding diagrams"
+  ],
+  "tags": [
+    "seat",
+    "furniture",
+    "dining",
+    "sit",
+    "seating",
+    "restaurant",
+    "table",
+    "wood",
+    "home"
+  ],
+  "categories": [
+    "home"
+  ]
+}

--- a/icons/chair.json
+++ b/icons/chair.json
@@ -8,7 +8,9 @@
     "indicating available seating or table type in restaurant reservation UIs",
     "representing the chair product category in furniture e-commerce filters",
     "marking selectable seats in venue maps or event booking flows",
-    "showing seating locations on simple floor plans and wayfinding diagrams"
+    "showing seating locations on simple floor plans and wayfinding diagrams",
+    "representing furniture items in interior design or room-planning apps",
+    "used as a toolbar control to add or place chairs in room-layout or floor-plan editors"
   ],
   "tags": [
     "seat",
@@ -19,9 +21,14 @@
     "restaurant",
     "table",
     "wood",
-    "home"
+    "home",
+    "interior",
+    "floorplan",
+    "seatmap",
+    "venue"
   ],
   "categories": [
-    "home"
+    "home",
+    "shopping"
   ]
 }

--- a/icons/chair.svg
+++ b/icons/chair.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 3a2 2 0 0 1 2 2v3a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V5a2 2 0 0 1 2-2z" />
+  <path d="M16 9v4" />
+  <path d="M18 13a2 2 0 0 1 2 2v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1a2 2 0 0 1 2-2z" />
+  <path d="M18 17v4" />
+  <path d="M7 17v4" />
+  <path d="M8 9v4" />
+</svg>


### PR DESCRIPTION
closes #4282

## Description

Adds a generic `chair` icon using the frontal dining-chair silhouette proposed by @jamiemlaw on the request (backrest, seat, two legs, uprights), distinct from existing `armchair` / `sofa`.

<a title="chair" target="_blank" href="https://studio.lucide.dev/"><img alt="chair" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTYgM2EyIDIgMCAwIDEgMiAydjNhMSAxIDAgMCAxLTEgMUg3YTEgMSAwIDAgMS0xLTFWNWEyIDIgMCAwIDEgMi0yeiIgLz4KICA8cGF0aCBkPSJNMTYgOXY0IiAvPgogIDxwYXRoIGQ9Ik0xOCAxM2EyIDIgMCAwIDEgMiAydjFhMSAxIDAgMCAxLTEgMUg1YTEgMSAwIDAgMS0xLTF2LTFhMiAyIDAgMCAxIDItMnoiIC8+CiAgPHBhdGggZD0iTTE4IDE3djQiIC8+CiAgPHBhdGggZD0iTTcgMTd2NCIgLz4KICA8cGF0aCBkPSJNOCA5djQiIC8+Cjwvc3ZnPg==.svg"/><br/>chair</a>

Also updates `categories/emoji.json` (`smile` → `face-slightly-smiling`) so `checkIcons` passes after the emoji rename in #4606.

**AI note:** Geometry follows the contributor Studio draft; packaging/metadata prepared with AI assistance (Grok) and checked against Lucide icon guidelines.

### Icon use case

- Indicating available seating or table type in restaurant reservation UIs.
- Representing the chair product category in furniture e-commerce filters.
- Marking selectable seats in venue maps or event booking flows.
- Showing seating locations on simple floor plans and wayfinding diagrams.

### Alternative icon designs

@jamiemlaw also shared `chair-office`, `stool`, and `seat` variants on #4282 — this PR ships only the generic `chair` as requested.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons were originally created in #4282 by @jamiemlaw
- [x] I've based them on the following Lucide icons: `armchair` (furniture family context)

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
