### PR TITLE
feat(icons): made `face-angry` even more angry

### DIFF
--- a/icons/face-angry.svg
+++ b/icons/face-angry.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M15 11V9.416" />
-  <path d="M17 9a5 5 0 00-3 1" />
-  <path d="M7 9a5 5 0 013 1" />
-  <path d="M9 11V9.416" />
-  <path d="M9 16a5 5 0 016.001 0" />
+  <path d="M15 12v-1.584" />
+  <path d="M17 10a5 5 0 00-3 1" />
+  <path d="M7 10a5 5 0 013 1" />
+  <path d="M9 12v-1.584" />
+  <path d="M9 17a5 5 0 016.001 0" />
   <circle cx="12" cy="12" r="10" />
 </svg>


### PR DESCRIPTION
## Description

Made `face-angry` even more angry than before by lowering the facial features by 1px, making it more in line with Unicode specifications for 😡

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.