### PR TITLE
chore(scripts): Potential fix for code scanning alert no. 31: Inefficient regular expression

### DIFF
--- a/scripts/updateGuidelineIcons.mts
+++ b/scripts/updateGuidelineIcons.mts
@@ -14,7 +14,7 @@ for (const file of readdirSync(path.join(import.meta.dirname, '../docs/images'))
           [
             groupOpeningTag,
             ...readFileSync(path.join(import.meta.dirname, `../icons/${iconName}.svg`), 'utf8')
-              .replace(/(<svg)([^>]|\n)*>|<\/svg>/g, '')
+              .replace(/(<svg)[^>]*>|<\/svg>/g, '')
               .split('\n'),
           ]
             .map((val) => val.trimEnd())


### PR DESCRIPTION
Potential fix for [https://github.com/lucide-icons/lucide/security/code-scanning/31](https://github.com/lucide-icons/lucide/security/code-scanning/31)

The best fix is to remove the ambiguous alternation from the opening-tag pattern.  
Current: `(<svg)([^>]|\n)*>|<\/svg>`  
Safe equivalent: `(<svg)[^>]*>|<\/svg>`

Why this works:
- `[^>]` already matches newlines, so `|\n` is redundant and creates ambiguity.
- `[^>]*` consumes everything up to the closing `>` linearly, including multiline attributes.
- This preserves existing functionality (remove opening `<svg ...>` and closing `</svg>`).

Change only the regex on line 17 in `scripts/updateGuidelineIcons.mts`; no imports or new methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
