### PR TITLE
feat: add shush icon

### DIFF
--- a/icons/shush.json
+++ b/icons/shush.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "ishanbagra18"
+  ],
+  "use-cases": [
+    "In chat/messaging apps as a 'please be quiet' reaction",
+    "In video-conferencing apps as a mute or 'quiet down' indicator",
+    "In classroom or library apps as a 'quiet mode' toggle",
+    "In podcasting/recording software as a 'quiet on set' status icon"
+  ],
+  "tags": [
+    "quiet",
+    "silence",
+    "mute",
+    "shh",
+    "hush",
+    "finger",
+    "lips",
+    "gesture"
+  ],
+  "categories": [
+    "communication",
+    "multimedia",
+    "emoji"
+  ]
+}

--- a/icons/shush.svg
+++ b/icons/shush.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 3v10" />
+  <path d="M10 3a2 2 0 0 1 4 0" />
+  <path d="M5 15c0-1.5 1-3 3.5-3.5" />
+  <path d="M19 15c0-1.5-1-3-3.5-3.5" />
+  <path d="M5 15c0 3 3.1 5 7 5s7-2 7-5" />
+  <path d="M8 18c1 1.5 2.4 2 4 2s3-0.5 4-2" />
+</svg>


### PR DESCRIPTION
Closes https://github.com/lucide-icons/lucide/issues/4727

## What
Adds a new `shush` icon depicting the classic 'shh' gesture - lips with an index finger held vertically in front of them.

## Design
- Minimalist stroke-based design following Lucide's 24x24 grid
- Shows a vertical index finger (with rounded fingertip) positioned over slightly parted lips
- Clean, abstract style consistent with existing Lucide icons
- Uses standard stroke-width='2', stroke-linecap='round', stroke-linejoin='round'

## Use Cases
- Chat/messaging apps (Slack, Discord) - 'please be quiet' reaction
- Video-conferencing - mute/quiet indicator
- Classroom/library apps - 'quiet mode' toggle
- Podcasting/recording - 'quiet on set' status

## Categories
- communication
- multimedia
- emoji

## Tags
quiet, silence, mute, shh, hush, finger, lips, gesture