### PR TITLE
feat(icons): add route-arrow-right

### DIFF
--- a/icons/route-arrow-right.json
+++ b/icons/route-arrow-right.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "samuelalake"
+  ],
+  "use-cases": [],
+  "tags": [
+    "route",
+    "path",
+    "arrow",
+    "direction",
+    "right",
+    "flow",
+    "journey",
+    "reroute",
+    "detour",
+    "navigate",
+    "forward",
+    "auto"
+  ],
+  "categories": [
+    "navigation",
+    "arrows"
+  ]
+}

--- a/icons/route-arrow-right.svg
+++ b/icons/route-arrow-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 5H17.5a3.5 3.5 0 0 1 0 7H6.5a3.5 3.5 0 0 0 0 7H21" />
+  <path d="m18 16 3 3-3 3" />
+</svg>


### PR DESCRIPTION
## Description

Adds `route-arrow-right`: a serpentine route that ends in an arrow, giving the path a direction of travel.

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Cpath%20d%3D%22M3%205H17.5a3.5%203.5%200%200%201%200%207H6.5a3.5%203.5%200%200%200%200%207H21%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22m18%2016%203%203-3%203%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=route-arrow-right"><img alt="route-arrow-right" width="170px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMyA1SDE3LjVhMy41IDMuNSAwIDAgMSAwIDdINi41YTMuNSAzLjUgMCAwIDAgMCA3SDIxIiAvPgogIDxwYXRoIGQ9Im0xOCAxNiAzIDMtMyAzIiAvPgo8L3N2Zz4K.svg"/><br/>Open lucide studio</a>

`route` depicts a path between two waypoints but shows no direction. This reuses `route`'s exact geometry — the 3.5-radius arcs at x6.5 and x17.5, rails at y5/y12/y19, and the same 2px margins — and replaces the waypoint circles with a directional arrow.

| `route-arrow-right` (new) | `route` |
| --- | --- |
| <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Cpath%20d%3D%22M3%205H17.5a3.5%203.5%200%200%201%200%207H6.5a3.5%203.5%200%200%200%200%207H21%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22m18%2016%203%203-3%203%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=route-arrow-right"><img alt="route-arrow-right" width="170px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMyA1SDE3LjVhMy41IDMuNSAwIDAgMSAwIDdINi41YTMuNSAzLjUgMCAwIDAgMCA3SDIxIiAvPgogIDxwYXRoIGQ9Im0xOCAxNiAzIDMtMyAzIiAvPgo8L3N2Zz4K.svg"/><br/>Open lucide studio</a> | <a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=%3Csvg%0A%20%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%0A%20%20width%3D%2224%22%0A%20%20height%3D%2224%22%0A%20%20viewBox%3D%220%200%2024%2024%22%0A%20%20fill%3D%22none%22%0A%20%20stroke%3D%22currentColor%22%0A%20%20stroke-width%3D%222%22%0A%20%20stroke-linecap%3D%22round%22%0A%20%20stroke-linejoin%3D%22round%22%0A%3E%0A%20%20%3Ccircle%20cx%3D%226%22%20cy%3D%2219%22%20r%3D%223%22%20%2F%3E%0A%20%20%3Cpath%20d%3D%22M9%2019h8.5a3.5%203.5%200%200%200%200-7h-11a3.5%203.5%200%200%201%200-7H15%22%20%2F%3E%0A%20%20%3Ccircle%20cx%3D%2218%22%20cy%3D%225%22%20r%3D%223%22%20%2F%3E%0A%3C%2Fsvg%3E%0A&name=route"><img alt="route" width="170px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8Y2lyY2xlIGN4PSI2IiBjeT0iMTkiIHI9IjMiIC8+CiAgPHBhdGggZD0iTTkgMTloOC41YTMuNSAzLjUgMCAwIDAgMC03aC0xMWEzLjUgMy41IDAgMCAxIDAtN0gxNSIgLz4KICA8Y2lyY2xlIGN4PSIxOCIgY3k9IjUiIHI9IjMiIC8+Cjwvc3ZnPgo=.svg"/><br/>Open lucide studio</a> |

The arrow follows Lucide's own convention: the shaft ends exactly at the chevron apex, as in `arrow-right` and `corner-down-right`.

**A note on naming.** I've gone with `route-arrow-right` since the arrow points right and it sets up a directional family, but I'm happy to switch to `route-arrow` if you'd rather not imply variants. If the direction is wanted, a `route-arrow-left` mirror and a both-arrows variant are natural follow-ups — I held them back rather than submit speculatively.

### Icon use case

- A directed route or path — showing which way it flows, not just that it exists.
- A reroute / detour control in a maps or navigation UI.
- Toggling automatic positioning or flow direction in a design or diagram tool.

### Alternative icon designs

None — the geometry is `route`'s own, reused rather than redrawn.

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] I've based them on the following Lucide icons: `route` for the serpentine, `arrow-right` for the arrowhead.

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
