### PR TITLE
feat(icons): added `heart-full` icon

### DIFF
--- a/icons/heart-full.json
+++ b/icons/heart-full.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "firedev"
+  ],
+  "tags": [
+    "like",
+    "love",
+    "favorite",
+    "saved",
+    "wishlist",
+    "emotion"
+  ],
+  "categories": [
+    "social",
+    "multimedia",
+    "emoji",
+    "shapes"
+  ],
+  "use-cases": [
+    "Saved or favorited state of a listing, product, or post (pair with outline `heart` for not saved)",
+    "Liked state on social content versus the unused outline heart"
+  ]
+}

--- a/icons/heart-full.svg
+++ b/icons/heart-full.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5" />
+</svg>


### PR DESCRIPTION
## Description

Adds `heart-full` as the named sibling of `heart` for saved/favorited UI.

The path is the existing `heart` geometry. Lucide’s [filled icons](https://lucide.dev/guide/lucide/advanced/filled-icons) guide already allows `fill` on closed shapes; this gives icon APIs that pick glyphs by name (and not by SVG `fill`) a `heart` / `heart-full` pair instead of restyling one icon.

Related: #2843 (closed as not planned, see also #458). Opening this so the name `heart-full` is on the table as the element-modifier form of that request.

### Icon use case

- Saved/favorited state of a listing, product, or post. Outline `heart` = not saved; `heart-full` = saved.
- Liked state on social content versus the unused outline heart.

### Alternative icon designs

Same path as `heart`. Applying `fill="currentColor"` (stroke can stay) is the filled look. A separate stroked-only silhouette would be a duplicate outline.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: `heart`
- [ ] I've based them on the following design:

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.