### PR TITLE
feat(icons): add number icon

### DIFF
--- a/icons/number.json
+++ b/icons/number.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "ishanbagra18"
+  ],
+  "use-cases": [
+    "To represent the data type of a field value (e.g. text vs date vs number).",
+    "Filtering properties by numeric data type in input forms or tables."
+  ],
+  "tags": [
+    "number",
+    "digit",
+    "numerical",
+    "field",
+    "type",
+    "value",
+    "filter",
+    "count",
+    "integer",
+    "123"
+  ],
+  "categories": [
+    "text",
+    "layout",
+    "development"
+  ]
+}

--- a/icons/number.svg
+++ b/icons/number.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 10l2-3v10" />
+  <path d="M4 17h4" />
+  <path d="M10 9a2.5 2.5 0 0 1 5 0c0 2.5-2.5 4.5-5 7h5" />
+  <path d="M17 7h4.5l-2 4.5a2.5 2.5 0 1 1-1.5 4.5" />
+</svg>

--- a/icons/shush.json
+++ b/icons/shush.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "ishanbagra18"
+  ],
+  "use-cases": [
+    "In chat/messaging apps as a 'please be quiet' reaction",
+    "In video-conferencing apps as a mute or 'quiet down' indicator",
+    "In classroom or library apps as a 'quiet mode' toggle",
+    "In podcasting/recording software as a 'quiet on set' status icon"
+  ],
+  "tags": [
+    "quiet",
+    "silence",
+    "mute",
+    "shh",
+    "hush",
+    "finger",
+    "lips",
+    "gesture"
+  ],
+  "categories": [
+    "communication",
+    "multimedia",
+    "emoji"
+  ]
+}

--- a/icons/shush.svg
+++ b/icons/shush.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 3v10" />
+  <path d="M10 3a2 2 0 0 1 4 0" />
+  <path d="M5 15c0-1.5 1-3 3.5-3.5" />
+  <path d="M19 15c0-1.5-1-3-3.5-3.5" />
+  <path d="M5 15c0 3 3.1 5 7 5s7-2 7-5" />
+  <path d="M8 18c1 1.5 2.4 2 4 2s3-0.5 4-2" />
+</svg>

--- a/icons/shush.svg
+++ b/icons/shush.svg
@@ -9,10 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M12 3v10" />
-  <path d="M10 3a2 2 0 0 1 4 0" />
-  <path d="M5 15c0-1.5 1-3 3.5-3.5" />
-  <path d="M19 15c0-1.5-1-3-3.5-3.5" />
-  <path d="M5 15c0 3 3.1 5 7 5s7-2 7-5" />
-  <path d="M8 18c1 1.5 2.4 2 4 2s3-0.5 4-2" />
+  <rect x="10.5" y="2" width="3" height="17" rx="1.5" />
+  <path d="M3 14Q7 10 12 12Q17 10 21 14" />
+  <path d="M3 14Q12 20 21 14" />
 </svg>


### PR DESCRIPTION
Resolves #4730

### Added Icon
- \
umber\

### Use Cases
- Represent the type of a field value (text vs date vs number).
- Useful when the type of a field is fixed, but not necessarily clear by its label.
- Help choosing a property to filter by from a list of labels or next to an input.

### Checklist
- [x] Icons follow the design guidelines
- [x] Icon metadata conforms to schema
- [x] Ran \
pm run checkIcons\ with clean output