### PR TITLE
feat(icons): add logic gate icons

### DIFF
--- a/icons/and-gate.json
+++ b/icons/and-gate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://lucide.dev/icons.schema.json",
+  "contributors": [
+    "Muhammad-Aqib-Bashir"
+  ],
+  "categories": [
+    "development",
+    "science"
+  ],
+  "tags": [
+    "and",
+    "boolean",
+    "circuit",
+    "digital",
+    "electronic",
+    "electronics",
+    "gate",
+    "logic"
+  ],
+  "use-cases": [
+    "digital circuit design",
+    "logic diagrams",
+    "Boolean logic",
+    "electronic circuits"
+  ]
+}

--- a/icons/and-gate.json
+++ b/icons/and-gate.json
@@ -5,7 +5,9 @@
   ],
   "categories": [
     "development",
-    "science"
+    "science",
+    "math",
+    "devices"
   ],
   "tags": [
     "and",

--- a/icons/and-gate.json
+++ b/icons/and-gate.json
@@ -15,7 +15,12 @@
     "electronic",
     "electronics",
     "gate",
-    "logic"
+    "logic",
+    "booleanalgebra",
+    "truthtable",
+    "digitallogic",
+    "hardware",
+    "microelectronics"
   ],
   "use-cases": [
     "digital circuit design",

--- a/icons/and-gate.svg
+++ b/icons/and-gate.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 12h-3" />
+  <path d="M5 15H2" />
+  <path d="M6 18h6a6 6 0 000-12H6z" />
+  <path d="M6 9H2" />
+</svg>

--- a/icons/buffer-gate.json
+++ b/icons/buffer-gate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://lucide.dev/icons.schema.json",
+  "contributors": [
+    "Muhammad-Aqib-Bashir"
+  ],
+  "categories": [
+    "development",
+    "science"
+  ],
+  "tags": [
+    "buffer",
+    "boolean",
+    "circuit",
+    "digital",
+    "electronic",
+    "electronics",
+    "gate",
+    "logic"
+  ],
+  "use-cases": [
+    "digital circuit design",
+    "logic diagrams",
+    "Boolean logic",
+    "electronic circuits"
+  ]
+}

--- a/icons/buffer-gate.svg
+++ b/icons/buffer-gate.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 12h-3l-9 5V7l9 5" />
+  <path d="M8 12H4" />
+</svg>

--- a/icons/nand-gate.json
+++ b/icons/nand-gate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://lucide.dev/icons.schema.json",
+  "contributors": [
+    "Muhammad-Aqib-Bashir"
+  ],
+  "categories": [
+    "development",
+    "science"
+  ],
+  "tags": [
+    "nand",
+    "and",
+    "not",
+    "boolean",
+    "circuit",
+    "digital",
+    "electronic",
+    "electronics",
+    "gate",
+    "logic"
+  ],
+  "use-cases": [
+    "digital circuit design",
+    "logic diagrams",
+    "Boolean logic",
+    "electronic circuits"
+  ]
+}

--- a/icons/nand-gate.svg
+++ b/icons/nand-gate.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 18H5V6h5" />
+  <path d="M21 12h1" />
+  <path d="M4.5 15H2" />
+  <path d="M5 9H2" />
+  <path d="M9.5 18a6 6 0 000-12" />
+  <circle cx="18.5" cy="12" r="2" />
+</svg>

--- a/icons/nor-gate.json
+++ b/icons/nor-gate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://lucide.dev/icons.schema.json",
+  "contributors": [
+    "Muhammad-Aqib-Bashir"
+  ],
+  "categories": [
+    "development",
+    "science"
+  ],
+  "tags": [
+    "nor",
+    "or",
+    "not",
+    "boolean",
+    "circuit",
+    "digital",
+    "electronic",
+    "electronics",
+    "gate",
+    "logic"
+  ],
+  "use-cases": [
+    "digital circuit design",
+    "logic diagrams",
+    "Boolean logic",
+    "electronic circuits"
+  ]
+}

--- a/icons/nor-gate.svg
+++ b/icons/nor-gate.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 11.848s-1.135 2.62-5.136 4.623C6.862 18.473 4 17.85 4 17.85" />
+  <path d="M16 12.095s-1.135-2.621-5.136-4.623S4 6.091 4 6.091" />
+  <path d="M2 15h3" />
+  <path d="M2 9h3" />
+  <path d="m21 12 1-.03" />
+  <path d="M4 6.353S5.838 8.235 5.838 12 4 17.647 4 17.647" />
+  <circle cx="18" cy="12" r="2" />
+</svg>

--- a/icons/not-gate.json
+++ b/icons/not-gate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://lucide.dev/icons.schema.json",
+  "contributors": [
+    "Muhammad-Aqib-Bashir"
+  ],
+  "categories": [
+    "development",
+    "science"
+  ],
+  "tags": [
+    "not",
+    "inverter",
+    "inversion",
+    "boolean",
+    "circuit",
+    "digital",
+    "electronic",
+    "electronics",
+    "gate",
+    "logic"
+  ],
+  "use-cases": [
+    "digital circuit design",
+    "logic diagrams",
+    "Boolean logic",
+    "electronic circuits"
+  ]
+}

--- a/icons/not-gate.svg
+++ b/icons/not-gate.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 12h-2" />
+  <path d="M6 12H3" />
+  <path d="m6 17 9-5-9-5z" />
+  <circle cx="17" cy="12" r="2" />
+</svg>

--- a/icons/or-gate.json
+++ b/icons/or-gate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://lucide.dev/icons.schema.json",
+  "contributors": [
+    "Muhammad-Aqib-Bashir"
+  ],
+  "categories": [
+    "development",
+    "science"
+  ],
+  "tags": [
+    "or",
+    "boolean",
+    "circuit",
+    "digital",
+    "electronic",
+    "electronics",
+    "gate",
+    "logic"
+  ],
+  "use-cases": [
+    "digital circuit design",
+    "logic diagrams",
+    "Boolean logic",
+    "electronic circuits"
+  ]
+}

--- a/icons/or-gate.svg
+++ b/icons/or-gate.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 11.97h4" />
+  <path d="M18.06 11.848s-1.235 2.62-5.59 4.623C8.115 18.473 5 17.85 5 17.85" />
+  <path d="M18.06 12.094s-1.235-2.621-5.59-4.623S5 6.09 5 6.09" />
+  <path d="m2 15 4.5-.03" />
+  <path d="M2 9h4" />
+  <path d="M5 6.353S7 8.235 7 12s-2 5.647-2 5.647" />
+</svg>

--- a/icons/xnor-gate.json
+++ b/icons/xnor-gate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://lucide.dev/icons.schema.json",
+  "contributors": [
+    "karsa-mistmere",
+    "Muhammad-Aqib-Bashir"
+  ],
+  "categories": [
+    "development",
+    "science"
+  ],
+  "tags": [
+    "xnor",
+    "exclusive nor",
+    "exclusive-nor",
+    "xor",
+    "not",
+    "boolean",
+    "circuit",
+    "digital",
+    "electronic",
+    "electronics",
+    "gate",
+    "logic"
+  ],
+  "use-cases": [
+    "digital circuit design",
+    "logic diagrams",
+    "Boolean logic",
+    "electronic circuits"
+  ]
+}

--- a/icons/xnor-gate.svg
+++ b/icons/xnor-gate.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 9h6" />
+  <path d="M21 12h1" />
+  <path d="M3 6s2 2 2 6-2 6-2 6" />
+  <path
+    d="M7.658 6.741a.497.497 0 01.47-.739c3.955.352 7.224 2.702 8.44 5.863a.38.38 0 010 .27c-1.216 3.161-4.485 5.51-8.44 5.863a.496.496 0 01-.47-.738C8.22 16.33 9 14.578 9 12s-.78-4.332-1.342-5.259" />
+  <path d="M8.105 15H2" />
+  <circle cx="19" cy="12" r="2" />
+</svg>

--- a/icons/xor-gate.json
+++ b/icons/xor-gate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://lucide.dev/icons.schema.json",
+  "contributors": [
+    "karsa-mistmere",
+    "Muhammad-Aqib-Bashir"
+  ],
+  "categories": [
+    "development",
+    "science"
+  ],
+  "tags": [
+    "xor",
+    "exclusive or",
+    "exclusive-or",
+    "boolean",
+    "circuit",
+    "digital",
+    "electronic",
+    "electronics",
+    "gate",
+    "logic"
+  ],
+  "use-cases": [
+    "digital circuit design",
+    "logic diagrams",
+    "Boolean logic",
+    "electronic circuits"
+  ]
+}

--- a/icons/xor-gate.svg
+++ b/icons/xor-gate.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 15H2" />
+  <path d="M19 12h3" />
+  <path d="M2 9h8" />
+  <path d="M4 6s2 2 2 6-2 6-2 6" />
+  <path
+    d="M9.074 6.741c-.217-.324.074-.775.523-.739 4.393.352 8.025 2.702 9.375 5.863a.34.34 0 010 .27c-1.35 3.161-4.982 5.51-9.375 5.863-.45.036-.741-.415-.523-.738.624-.93 1.49-2.682 1.49-5.26s-.866-4.332-1.49-5.259" />
+</svg>


### PR DESCRIPTION
closes: #3608

## Description

This PR adds a set of logic-gate icons with their corresponding metadata:

* AND gate
* OR gate
* NAND gate
* NOR gate
* Buffer gate
* NOT gate
* XNOR gate
* XOR gate

The icons follow the existing Lucide icon design conventions and include the required metadata files.

### Icon use case

* **AND gate:** Used in digital logic diagrams to represent a logical AND operation, such as requiring multiple conditions to be true.
* **OR gate:** Used to represent alternative conditions where any one of multiple inputs can produce an active output.
* **NAND gate:** Used in digital circuit design and logic diagrams for inverted AND operations.
* **NOR gate:** Used for representing inverted OR operations in digital logic circuits.
* **Buffer gate:** Used to represent signal buffering and isolation while preserving the input signal.
* **NOT gate:** Used to represent logical inversion in digital circuits and Boolean logic.
* **XNOR gate:** Used when the output should be true when two inputs have the same logical value.
* **XOR gate:** Used when the output should be true when two inputs have different logical values.


## Before Submitting

* [x] I've read the Contribution Guidelines.
* [x] I've checked if there was an existing PR that solves the same issue.
