### PR TITLE
feat(icons): add backslash icon

### DIFF
--- a/icons/backslash.json
+++ b/icons/backslash.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "juliansolimando"
+  ],
+  "use-cases": [
+    "Represent a backslash character",
+    "Represent path separators in developer and file-system interfaces"
+  ],
+  "tags": [
+    "separator",
+    "path",
+    "\\"
+  ],
+  "categories": [
+    "development"
+  ]
+}

--- a/icons/backslash.json
+++ b/icons/backslash.json
@@ -5,7 +5,10 @@
   ],
   "use-cases": [
     "Represent a backslash character",
-    "Represent path separators in developer and file-system interfaces"
+    "Represent path separators in developer and file-system interfaces",
+    "indicate escaping in code editors and regex tools",
+    "display Windows-style path separators in file manager UIs",
+    "denote path or escape sequences in terminal and CLI tools"
   ],
   "tags": [
     "separator",

--- a/icons/backslash.json
+++ b/icons/backslash.json
@@ -16,6 +16,8 @@
     "\\"
   ],
   "categories": [
-    "development"
+    "development",
+    "files",
+    "text"
   ]
 }

--- a/icons/backslash.json
+++ b/icons/backslash.json
@@ -13,7 +13,11 @@
   "tags": [
     "separator",
     "path",
-    "\\"
+    "\\",
+    "escape",
+    "windows",
+    "regex",
+    "filesystem"
   ],
   "categories": [
     "development",

--- a/icons/backslash.svg
+++ b/icons/backslash.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m2 2 20 20" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Adds a `backslash` icon as the mirrored counterpart to the existing `slash` icon.

<img width="380" height="379" alt="image" src="https://github.com/user-attachments/assets/21c31b27-927f-4579-98c3-c5e53728835a" />

### Icon use case <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->
- Representing Windows-style path separators in developer and file-system interfaces.
- Representing escaping or backslash syntax in code editors, regex tools, and other developer interfaces.

The geometry mirrors the existing `slash` icon to keep both symbols visually consistent.
### Alternative icon designs <!-- ONLY for new icons, remove this part if not icon PR -->
<!-- If you have any alternative icon designs, please attach them here. -->

## Icon Design Checklist <!-- ONLY for new icons, remove this part if not icon PR -->

### Concept <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
<!-- IMPORTANT! Please read our official statement on brand logos in Lucide: -->
<!-- https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md -->
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [x] I've based them on the following Lucide icons: `slash`<!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->


<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
