### PR TITLE
feat(docs): add list view with icon names to the icons page

### DIFF
--- a/docs/.vitepress/theme/components/icons/IconList.vue
+++ b/docs/.vitepress/theme/components/icons/IconList.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import type { IconEntity } from '../../types';
+import IconListItem from './IconListItem.vue';
+
+const emit = defineEmits(['setActiveIcon']);
+
+defineProps<{
+  icons: IconEntity[];
+  activeIcon?: string;
+  overlayMode?: boolean;
+}>();
+
+function setActiveIcon(name: string) {
+  emit('setActiveIcon', name);
+}
+</script>
+
+<template>
+  <div class="icon-list">
+    <div
+      class="icon-list-row"
+      v-for="icon in icons"
+      :key="icon.name"
+    >
+      <IconListItem
+        :iconNode="icon.iconNode"
+        :name="icon.name"
+        :aliases="icon.aliases"
+        :deprecated="icon.deprecated"
+        :externalLibrary="icon.externalLibrary"
+        :active="activeIcon === icon.name"
+        :overlayMode="overlayMode"
+        @setActiveIcon="setActiveIcon"
+      />
+    </div>
+  </div>
+</template>
+
+<style>
+.icon-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.icon-list-row {
+  height: 48px;
+  position: relative;
+}
+</style>

--- a/docs/.vitepress/theme/components/icons/IconList.vue
+++ b/docs/.vitepress/theme/components/icons/IconList.vue
@@ -10,6 +10,10 @@ defineProps<{
   overlayMode?: boolean;
 }>();
 
+function iconId(icon: IconEntity) {
+  return icon.externalLibrary ? `${icon.externalLibrary}:${icon.name}` : icon.name;
+}
+
 function setActiveIcon(name: string) {
   emit('setActiveIcon', name);
 }
@@ -20,7 +24,7 @@ function setActiveIcon(name: string) {
     <div
       class="icon-list-row"
       v-for="icon in icons"
-      :key="icon.name"
+      :key="iconId(icon)"
     >
       <IconListItem
         :iconNode="icon.iconNode"
@@ -28,7 +32,7 @@ function setActiveIcon(name: string) {
         :aliases="icon.aliases"
         :deprecated="icon.deprecated"
         :externalLibrary="icon.externalLibrary"
-        :active="activeIcon === icon.name"
+        :active="activeIcon === iconId(icon)"
         :overlayMode="overlayMode"
         @setActiveIcon="setActiveIcon"
       />

--- a/docs/.vitepress/theme/components/icons/IconListItem.vue
+++ b/docs/.vitepress/theme/components/icons/IconListItem.vue
@@ -57,7 +57,6 @@ function navigateToIcon(event: MouseEvent) {
     class="icon-list-item vp-raw"
     :class="{ active }"
     :href="href"
-    :aria-label="name"
     @click="navigateToIcon"
   >
     <span class="icon-preview">

--- a/docs/.vitepress/theme/components/icons/IconListItem.vue
+++ b/docs/.vitepress/theme/components/icons/IconListItem.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import createLucideIcon from '@lucide/vue/src/createLucideIcon';
+import Icon from '@lucide/vue/src/Icon';
+import { useMediaQuery } from '@vueuse/core';
+import { useRouter } from 'vitepress';
+import { diamond } from '../../../data/iconNodes';
+
+export type IconNode = [elementName: string, attrs: Record<string, string>][];
+
+const props = defineProps<{
+  name: string;
+  iconNode: IconNode;
+  active: boolean;
+  aliases?: string[];
+  deprecated?: boolean;
+  externalLibrary?: string;
+  overlayMode?: boolean;
+}>();
+
+const emit = defineEmits(['setActiveIcon']);
+
+const { go } = useRouter();
+const showOverlay = useMediaQuery('(min-width: 860px)');
+
+const icon = computed(() => {
+  if (!props.name || !props.iconNode) return null;
+  return createLucideIcon(props.name, props.iconNode);
+});
+
+const href = computed(() =>
+  props.externalLibrary ? `/icons/${props.externalLibrary}/${props.name}` : `/icons/${props.name}`,
+);
+
+function navigateToIcon(event: MouseEvent) {
+  event.preventDefault();
+
+  if (props.overlayMode && showOverlay.value) {
+    window.history.pushState({}, '', href.value);
+    emit(
+      'setActiveIcon',
+      props.externalLibrary ? `${props.externalLibrary}:${props.name}` : props.name,
+    );
+    return;
+  }
+
+  go(href.value);
+}
+</script>
+
+<template>
+  <a
+    class="icon-list-item vp-raw"
+    :class="{ active }"
+    :href="href"
+    :aria-label="name"
+    @click="navigateToIcon"
+  >
+    <span class="icon-preview">
+      <component
+        :is="icon"
+        class="lucide-icon customizable"
+      />
+      <span
+        v-if="externalLibrary"
+        class="floating-diamond"
+        aria-hidden="true"
+      >
+        <Icon
+          :iconNode="diamond"
+          fill="currentColor"
+          :size="8"
+        />
+      </span>
+    </span>
+
+    <span class="icon-name">{{ name }}</span>
+
+    <span
+      v-if="deprecated"
+      class="icon-flag deprecated"
+      >deprecated</span
+    >
+
+    <span
+      v-if="aliases?.length"
+      class="icon-aliases"
+      >{{ aliases.join(', ') }}</span
+    >
+  </a>
+</template>
+
+<style scoped>
+.icon-list-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  height: 100%;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background-color: var(--vp-c-bg-alt);
+  color: var(--vp-c-text-1);
+  font-weight: 500;
+  text-decoration: none;
+  transition:
+    color 0.25s,
+    border-color 0.25s,
+    background-color 0.25s;
+}
+
+.icon-list-item:hover {
+  border-color: var(--vp-button-alt-hover-border);
+  color: var(--vp-button-alt-hover-text);
+  background-color: var(--vp-button-alt-hover-bg);
+}
+
+.icon-list-item.active {
+  border-color: var(--vp-c-brand);
+}
+
+.icon-preview {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+.floating-diamond {
+  position: absolute;
+  top: 0;
+  right: 0;
+  color: var(--vp-c-brand);
+}
+
+.icon-name {
+  flex-shrink: 0;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.icon-aliases {
+  overflow: hidden;
+  color: var(--vp-c-text-3);
+  font-size: 12px;
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.icon-flag {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.icon-flag.deprecated {
+  background-color: var(--vp-c-warning-soft, var(--vp-c-bg-elv));
+  color: var(--vp-c-warning-1, var(--vp-c-text-2));
+}
+
+.lucide-icon {
+  pointer-events: none;
+}
+
+.lucide-icon.customizable {
+  width: 24px;
+  height: 24px;
+  color: var(--customize-color, currentColor);
+  stroke-width: var(--customize-strokeWidth, 2);
+}
+
+html.absolute-stroke-width .lucide-icon.customizable {
+  stroke-width: calc(var(--customize-strokeWidth, 2) * 24 / var(--customize-size, 24));
+}
+</style>

--- a/docs/.vitepress/theme/components/icons/IconListItem.vue
+++ b/docs/.vitepress/theme/components/icons/IconListItem.vue
@@ -33,6 +33,10 @@ const href = computed(() =>
 );
 
 function navigateToIcon(event: MouseEvent) {
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+    return;
+  }
+
   event.preventDefault();
 
   if (props.overlayMode && showOverlay.value) {

--- a/docs/.vitepress/theme/components/icons/IconsOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsOverview.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { ref, computed, defineAsyncComponent, onMounted, watch } from 'vue';
 import type { IconEntity } from '../../types';
-import { useElementSize, useEventListener, useVirtualList } from '@vueuse/core';
+import { useElementSize, useEventListener, useStorage, useVirtualList } from '@vueuse/core';
 import { useRoute } from 'vitepress';
 import IconGrid from './IconGrid.vue';
+import IconList from './IconList.vue';
 import Select from '../base/Select.vue';
 import InputSearch from '../base/InputSearch.vue';
 import useSearch from '../../composables/useSearch';
@@ -16,10 +17,30 @@ import chunkArray from '../../utils/chunkArray';
 import CarbonAdOverlay from './CarbonAdOverlay.vue';
 import useSearchPlaceholder from '../../utils/useSearchPlaceholder.ts';
 import Icon from '@lucide/vue/src/Icon';
-import { listSortDescending } from '~/.vitepress/data/iconNodes';
+import {
+  listSortDescending,
+  layoutGrid,
+  list as listIcon,
+  copy,
+  check,
+} from '~/.vitepress/data/iconNodes';
+import IconButton from '../base/IconButton.vue';
+import Tooltip from '../base/Tooltip.vue';
 
 const ICON_SIZE = 56;
 const ICON_GRID_GAP = 8;
+const LIST_ITEM_SIZE = 48;
+const VIEW_STORAGE_KEY = 'lucide-icons-view';
+const VIEWS = [
+  {
+    name: 'Grid',
+    value: 'grid',
+  },
+  {
+    name: 'List',
+    value: 'list',
+  },
+];
 const SORTING = [
   {
     name: 'Popularity',
@@ -51,6 +72,14 @@ const props = defineProps<{
 
 const activeIconName = ref(null);
 const selectedSort = ref(SORTING[0])
+const selectedView = useStorage(VIEW_STORAGE_KEY, VIEWS[0], undefined, {
+  serializer: {
+    read: (value) => VIEWS.find((view) => view.value === value) ?? VIEWS[0],
+    write: (view) => view.value,
+  },
+});
+const isListView = computed(() => selectedView.value.value === 'list');
+const justCopied = ref(false);
 
 const { execute: fetchTags, data: tags, isFetching: isFetchingTags } = useFetchTags();
 const {
@@ -119,13 +148,20 @@ const isSearchMetadataLoading = computed(
 );
 
 const chunkedIcons = computed(() => {
-  return chunkArray(searchResults.value, columnSize.value);
+  return chunkArray(searchResults.value, isListView.value ? 1 : columnSize.value);
 });
 
 const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(chunkedIcons, {
-  itemHeight: ICON_SIZE + ICON_GRID_GAP,
+  itemHeight: () => (isListView.value ? LIST_ITEM_SIZE : ICON_SIZE) + ICON_GRID_GAP,
   overscan: 10,
 });
+
+async function copyIconNames() {
+  await navigator.clipboard.writeText(searchResults.value.map((icon) => icon.name).join('\n'));
+
+  justCopied.value = true;
+  setTimeout(() => (justCopied.value = false), 2000);
+}
 
 onMounted(() => {
   containerProps.ref.value = document.documentElement;
@@ -208,6 +244,34 @@ function handleCloseDrawer() {
           />
         </template>
       </Select>
+
+      <Select
+        id="view-select"
+        :items="VIEWS"
+        v-model="selectedView"
+      >
+        <template #start-icon>
+          <Icon
+            :iconNode="isListView ? listIcon : layoutGrid"
+            class="chevron-icon"
+            aria-hidden="true"
+          />
+        </template>
+      </Select>
+
+      <Tooltip :title="`Copy ${searchResults.length} icon names`">
+        <IconButton
+          class="copy-names-button"
+          :aria-label="`Copy ${searchResults.length} icon names`"
+          @click="copyIconNames"
+        >
+          <Icon
+            :iconNode="justCopied ? check : copy"
+            :size="20"
+            aria-hidden="true"
+          />
+        </IconButton>
+      </Tooltip>
     </StickyBar>
     <NoResults
       v-if="searchPlaceholder.isNoResults && !isSearchMetadataLoading"
@@ -215,7 +279,8 @@ function handleCloseDrawer() {
       :isBrandSearch="searchPlaceholder.isBrand"
       @clear="searchQuery = ''"
     />
-    <IconGrid
+    <component
+      :is="isListView ? IconList : IconGrid"
       v-else-if="list.length === 0"
       overlayMode
       :icons="searchResults.slice(0, initialGridItems)"
@@ -227,7 +292,8 @@ function handleCloseDrawer() {
       class="icon"
       v-else
     >
-      <IconGrid
+      <component
+        :is="isListView ? IconList : IconGrid"
         v-for="{ index, data: icons } in list"
         :key="index"
         overlayMode
@@ -255,8 +321,24 @@ function handleCloseDrawer() {
   aspect-ratio: 1/1;
 }
 
+.search-bar .reference {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.copy-names-button {
+  display: flex;
+  width: 48px;
+  align-items: center;
+  justify-content: center;
+  padding: 11px;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+}
+
 .input-wrapper {
   width: 100%;
+  min-width: 0;
   /* view-transition-name: icons-search-box; */
 }
 </style>

--- a/docs/.vitepress/theme/components/icons/IconsOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsOverview.vue
@@ -80,6 +80,7 @@ const selectedView = useStorage(VIEW_STORAGE_KEY, VIEWS[0], undefined, {
 });
 const isListView = computed(() => selectedView.value.value === 'list');
 const justCopied = ref(false);
+let copyResetTimeout: ReturnType<typeof setTimeout>;
 
 const { execute: fetchTags, data: tags, isFetching: isFetchingTags } = useFetchTags();
 const {
@@ -167,8 +168,9 @@ async function copyIconNames() {
     return;
   }
 
+  clearTimeout(copyResetTimeout);
   justCopied.value = true;
-  setTimeout(() => (justCopied.value = false), 2000);
+  copyResetTimeout = setTimeout(() => (justCopied.value = false), 2000);
 }
 
 onMounted(() => {

--- a/docs/.vitepress/theme/components/icons/IconsOverview.vue
+++ b/docs/.vitepress/theme/components/icons/IconsOverview.vue
@@ -157,7 +157,15 @@ const { list, containerProps, wrapperProps, scrollTo } = useVirtualList(chunkedI
 });
 
 async function copyIconNames() {
-  await navigator.clipboard.writeText(searchResults.value.map((icon) => icon.name).join('\n'));
+  if (!navigator.clipboard?.writeText) {
+    return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(searchResults.value.map((icon) => icon.name).join('\n'));
+  } catch {
+    return;
+  }
 
   justCopied.value = true;
   setTimeout(() => (justCopied.value = false), 2000);


### PR DESCRIPTION
## Description

The icons page only renders a grid of glyphs. Icon names are visible one at a time, on hover or in the detail drawer, and aliases are not visible at all, two names for the same icon look like two unrelated results.

This adds a **Grid / List** toggle to the sticky bar, next to the sort select. In list view each row shows the icon, its canonical name, its aliases, and a marker for deprecated icons. The chosen view is persisted in `localStorage`.

It also adds a button that **copies the names of the current result set** to the clipboard, respecting the active search and sorting.

**Why this helps**

- Aliases become visible at a glance. `help-circle` / `circle-help`, `alert-circle` / `circle-alert` and `alert-triangle` / `triangle-alert` are the same icons under two names, and a codebase can accumulate both spellings for a long time without anyone noticing.
- Auditing which icons a project uses currently means reading names one by one.
- Getting names into other tools, such as an allowlist, a design doc, or a framework registration array, currently means manual transcription. Angular, for example, requires importing and registering each icon explicitly.

**Implementation notes**

- `IconList.vue` and `IconListItem.vue` are new and mirror the props of `IconGrid` / `IconItem`, so the overview switches between them with `<component :is>`.
- `useVirtualList` now receives `itemHeight` as a function instead of a fixed number, and the chunk size follows the active view. Both `totalHeight` and `offsetTop` are computed from that function, so switching views recalculates the scroll geometry. With the previous fixed number, list rows would have been measured with the grid's row height.
- Grid view is untouched and remains the default.

## Screenshots

<img width="363" height="166" alt="1" src="https://github.com/user-attachments/assets/af982de8-2c96-487f-8953-7be570a476d2" />

<img width="1907" height="994" alt="3" src="https://github.com/user-attachments/assets/2515a36b-fbce-4825-aeb4-83aca0643ada" />

<img width="394" height="131" alt="2" src="https://github.com/user-attachments/assets/5b772d19-fa92-4f17-a610-ad9a23dfad9a" />

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
