### PR TITLE
feat(icons): add monitor-activity icon

### DIFF
--- a/icons/monitor-activity.json
+++ b/icons/monitor-activity.json
@@ -5,12 +5,19 @@
     "karsa-mistmere",
     "mmaxence"
   ],
-  "use-cases": [],
+  "use-cases": [
+    "Representing system monitoring sections in a dashboard",
+    "Showing uptime or service health on a status page",
+    "Indicating live performance metrics for a server or workstation",
+    "Denoting observability and diagnostics tools in developer software"
+  ],
   "tags": [
     "tv",
+    "computer",
     "screen",
     "display",
     "desktop",
+    "external display",
     "pulse",
     "activity",
     "monitoring",

--- a/icons/monitor-activity.json
+++ b/icons/monitor-activity.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "jguddas",
+    "karsa-mistmere",
+    "mmaxence"
+  ],
+  "use-cases": [],
+  "tags": [
+    "tv",
+    "screen",
+    "display",
+    "desktop",
+    "pulse",
+    "activity",
+    "monitoring",
+    "performance",
+    "health",
+    "uptime",
+    "vitals",
+    "heartbeat",
+    "system",
+    "dashboard",
+    "virtual machine",
+    "vm"
+  ],
+  "categories": [
+    "connectivity",
+    "devices"
+  ]
+}

--- a/icons/monitor-activity.svg
+++ b/icons/monitor-activity.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 17v4" />
+  <path d="M17 10h-1.315a1 1 0 0 0-.932.64l-.787 2.034a.5.5 0 0 1-.932 0l-2.068-5.348a.5.5 0 0 0-.932 0l-.787 2.035a1 1 0 0 1-.932.639H7" />
+  <path d="M8 21h8" />
+  <rect width="20" height="14" x="2" y="3" rx="2" />
+</svg>


### PR DESCRIPTION
Adds the `monitor-activity` icon requested in #4714: a monitor with an activity pulse line, composing the existing `monitor` and `activity` icons. Uses the up-first geometry from the design direction in the issue, consistent with the other `-activity` icons.

Closes #4714