### PR TITLE
fix(vue): allow empty IconProps

### DIFF
--- a/packages/vue/src/Icon.ts
+++ b/packages/vue/src/Icon.ts
@@ -4,9 +4,10 @@ import defaultAttributes from './defaultAttributes';
 import { IconNode, LucideProps } from './types';
 import { useLucideProps } from './context';
 
-type IconProps = { name: string } & (
+type IconProps = { name?: string } & (
   | { iconNode: IconNode; 'icon-node'?: never }
   | { 'icon-node': IconNode; iconNode?: never }
+  | {}
 );
 
 const Icon: FunctionalComponent<LucideProps & IconProps> = (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!--
PR Title Guidelines:

Please use the format: <type>(<scope>): <short description>

Example: feat(icons): added `camera` icon

Available types: fix, feat, perf, docs, style, refactor, test, chore, ci, build
Common scopes: icons, docs, studio, site, dev
-->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description
<!-- Please insert your description here and provide info about the "what" this PR is contribution -->
Fix `IconProps` type to allow both undefined `name` and `iconNode`/`icon-node`.  In the #4512 empty values were effectively allowed but restricted on the type level. While the original motivation might still stand, there are reasons to allow empty values "officially":
1. It just works with the empty values, rendering empty icon.
2. It is quite convenient to use `Icon` component as a "blank" icon when [combining icons](https://lucide.dev/guide/vue/advanced/combining-icons) in the case when neither icon should be the "main" one, e.g.:
    ```vue
    <script setup>
    import { Icon, Check, X } from "@lucide/vue";
    </script>
    
    <template>
      <div class="app">
        <Icon :size="48">
          <Check :x="-1" :y="-3" :size="21" absoluteStrokeWidth/>
          <X :x="7" :y="7" :size="21" absoluteStrokeWidth/>
        </Icon>
      </div>
    </template>
    ```

So, the change just eliminates type error for the already supported case.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
