### PR TITLE
feat: add square-puzzle icon

### DIFF
--- a/icons/square-puzzle.json
+++ b/icons/square-puzzle.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "Mirazstudio-offical"
+  ],
+  "use-cases": [],
+  "tags": [
+    "puzzle",
+    "game",
+    "piece",
+    "square",
+    "jigsaw",
+    "board game",
+    "logic",
+    "brain teaser"
+  ],
+  "categories": [
+    "gaming",
+    "shapes"
+  ]
+}

--- a/icons/square-puzzle.json
+++ b/icons/square-puzzle.json
@@ -3,7 +3,13 @@
   "contributors": [
     "Mirazstudio-offical"
   ],
-  "use-cases": [],
+  "use-cases": [
+    "show a puzzle challenge in a level selector",
+    "badge for puzzle-related achievements in profiles",
+    "represent modular plugins or extensions in settings",
+    "use as a draggable tile in puzzle or layout editors",
+    "visualize problem-solving modules in learning platforms"
+  ],
   "tags": [
     "puzzle",
     "game",
@@ -12,10 +18,17 @@
     "jigsaw",
     "board game",
     "logic",
-    "brain teaser"
+    "brain teaser",
+    "gamification",
+    "tile",
+    "modular",
+    "component",
+    "challenge",
+    "educational"
   ],
   "categories": [
     "gaming",
-    "shapes"
+    "shapes",
+    "design"
   ]
 }

--- a/icons/square-puzzle.svg
+++ b/icons/square-puzzle.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7 6h3a2.5 2.5 0 1 1 4 0h3a2 2 0 0 1 2 2v3a2.5 2.5 0 1 0 0 4v3a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2Z" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

feat(icons): added `square-puzzle` icon

## Description
Added a new square puzzle icon representing a single puzzle piece in a square form, commonly used in gaming interfaces, logic puzzles, and gamification elements.

### Icon use case
1. Board game apps — as a button to start a puzzle mode or indicate puzzle piece inventory
2. Gamification platforms — to represent achievement categories related to logic/brain teasers
3. Educational software — as an icon for problem-solving or critical thinking sections

### Alternative icon designs
None.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons are solely my own creation.

### Naming
- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->

- [ ] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icon-design-guide)
- [ ] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [ ] I've made sure that the icons look sharp on low DPI displays.
- [ ] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [ ] I've made sure that the icons are visually centered.
- [ ] I've correctly optimized all icons to three points of precision.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [ ] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [ ] I've checked if there was an existing PR that solves the same issue.
<img width="126" height="122" alt="image" src="https://github.com/user-attachments/assets/e136519f-2f91-46d6-9009-36e52f35098f" />
