### PR TITLE
feat(icons): changed `lab/bottle-toothbrush-comb` icon

### DIFF
--- a/lab/bottle-toothbrush-comb.svg
+++ b/lab/bottle-toothbrush-comb.svg
@@ -9,13 +9,13 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <rect width="4" height="4" x="2" y="3" />
-  <path d="M6 7v2c0 .6.1 1.4.2 2L8 20.8v.2c0 .6-.4 1-1 1H3c-.6 0-1-.4-1-1V7" />
-  <path d="M14 2v7l-2 5v8" />
-  <rect width="4" height="6" x="10" y="3" />
-  <path d="M18 6h4" />
+  <path d="M14 11h-2a2 2 0 01-1.73-3 2 2 0 010-2A2 2 0 0112 3h2" />
+  <path d="M14 2v9.35a4 4 0 01-.205 1.266l-.59 1.768A4 4 0 0013 15.65V22" />
   <path d="M18 10h4" />
   <path d="M18 14h4" />
   <path d="M18 18h4" />
-  <path d="M18 2h2a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2h-2" />
+  <path d="M18 2h2a2 2 0 012 2v16a2 2 0 01-2 2h-2" />
+  <path d="M18 6h4" />
+  <path d="M2 3a1 1 0 011-1h2a1 1 0 011 1v6c0 .6.1 1.4.2 2L8 20.8v.2a1 1 0 01-1 1H3a1 1 0 01-1-1z" />
+  <path d="M2 6h4" />
 </svg>


### PR DESCRIPTION
Updated `bottle-toothbrush-comb` to better match the toothbrush style being introduced in #4755

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
