### PR TITLE
fix(icons): correct "operater" typo to "operator" in equal-approximately

### DIFF
--- a/icons/equal-approximately.json
+++ b/icons/equal-approximately.json
@@ -8,7 +8,7 @@
     "about",
     "calculate",
     "math",
-    "operater"
+    "operator"
   ],
   "categories": [
     "math"


### PR DESCRIPTION
## Description

This PR fixes a typo in the `tags` for the `equal-approximately` icon. The tag `"operater"` was corrected to `"operator"`.

Related math/operator icons (`equal`, `equal-not`, `divide`, `minus`, etc.) already use the `"operator"` tag. `"operater"` appears only in `equal-approximately.json`.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.