### PR TITLE
docs(icon-description): added old and empty tags/use case for ghost

### DIFF
--- a/icons/ghost.json
+++ b/icons/ghost.json
@@ -8,7 +8,7 @@
   "use-cases": [
     "Representing Halloween themes in seasonal content",
     "Indicating spooky or haunted themes",
-    "Marking invisible or hidden states in playful UIs",
+    "Marking invisible, old, empty or hidden states in playful UIs",
     "Showing ghosts or spirits in arcade-style games"
   ],
   "tags": [
@@ -23,7 +23,9 @@
     "shadow",
     "silhouette",
     "pac-man",
-    "spooky"
+    "spooky",
+    "old",
+    "empty"
   ],
   "categories": [
     "gaming"

--- a/icons/ghost.json
+++ b/icons/ghost.json
@@ -8,7 +8,8 @@
   "use-cases": [
     "Representing Halloween themes in seasonal content",
     "Indicating spooky or haunted themes",
-    "Marking invisible, old, empty or hidden states in playful UIs",
+    "Marking invisible or hidden states in playful UIs",
+    "Indicating dead links or obsolete content",
     "Showing ghosts or spirits in arcade-style games"
   ],
   "tags": [

--- a/icons/ghost.json
+++ b/icons/ghost.json
@@ -25,8 +25,14 @@
     "silhouette",
     "pac-man",
     "spooky",
-    "old",
-    "empty"
+    "halloween",
+    "haunted",
+    "invisible",
+    "hidden",
+    "empty",
+    "dead",
+    "obsolete",
+    "outdated"
   ],
   "categories": [
     "gaming"


### PR DESCRIPTION
<!-- Thank you for contributing! -->


<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->
## Description

Adds the old or empty use-case or tag for the ghost icon

### Author, credits & license<!-- ONLY for new icons. -->
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [x] The icons were originally created in #3533 by @jguddas 
- [ ] I've based them on the following Lucide icons: <!-- provide the list of icons -->
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming <!-- ONLY for new icons -->
<!-- All of these requirements must be fulfilled. -->
- [ ] I've read and followed the [naming conventions](https://lucide.dev/contribute/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.


## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
