### PR TITLE
fix(icons): changed `piano` icon

### DIFF
--- a/icons/piano.json
+++ b/icons/piano.json
@@ -4,6 +4,7 @@
     "danielbayley",
     "karsa-mistmere"
   ],
+  "use-cases": [],
   "tags": [
     "music",
     "audio",

--- a/icons/piano.json
+++ b/icons/piano.json
@@ -4,7 +4,6 @@
     "danielbayley",
     "karsa-mistmere"
   ],
-  "use-cases": [],
   "tags": [
     "music",
     "audio",

--- a/icons/piano.svg
+++ b/icons/piano.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M18.5 8c-1.4 0-2.6-.8-3.2-2A6.87 6.87 0 0 0 2 9v11a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-8.5C22 9.6 20.4 8 18.5 8" />
-  <path d="M2 14h20" />
-  <path d="M6 14v4" />
-  <path d="M10 14v4" />
-  <path d="M14 14v4" />
-  <path d="M18 14v4" />
+  <path d="M10 13v4" />
+  <path d="M14 13v4" />
+  <path d="M18 13v4" />
+  <path d="M2 13h20" />
+  <path d="M22 11.5A3.5 3.5 0 0018.5 8a3.52 3.52 0 01-3.173-2A7 7 0 002 9v10a2 2 0 002 2h16a2 2 0 002-2z" />
+  <path d="M6 13v4" />
 </svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] Other: Icon update

### Description
decreases the optical volume of piano to better match square, see https://github.com/lucide-icons/lucide/pull/3974#issuecomment-3896661772

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.