### PR TITLE
feat(icons): added `user-round-shield` icon

### DIFF
--- a/icons/user-round-shield.json
+++ b/icons/user-round-shield.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "karsa-mistmere",
+    "jguddas"
+  ],
+  "use-cases": [],
+  "tags": [
+    "security",
+    "shield",
+    "account",
+    "safe",
+    "protection",
+    "privacy"
+  ],
+  "categories": [
+    "account",
+    "security"
+  ]
+}

--- a/icons/user-round-shield.svg
+++ b/icons/user-round-shield.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2 21a8 8 0 0 1 10.434-7.62" />
+  <circle cx="10" cy="8" r="5" />
+  <path d="M22 17.5c0 2.499-1.75 3.749-3.83 4.474a.5.5 0 0 1-.335-.005c-2.085-.72-3.835-1.97-3.835-4.47V14a.5.5 0 0 1 .5-.499c1 0 2.25-.6 3.12-1.36a.6.6 0 0 1 .76-.001c.875.765 2.12 1.36 3.12 1.36a.5.5 0 0 1 .5.5z" />
+</svg>


### PR DESCRIPTION
Closes #4717

## Description
Added the `user-round-shield` icon requested in #4717.

### Icon use case
- Representing account security status, verified users, or protected profiles in user management systems.
- Denoting user privacy controls and security settings in authentication and authorization flows.

### Alternative icon designs
Based on the agreed design in #4717.

## Icon Design Checklist

### Concept
- [x] I have provided valid use cases for each icon.
- [x] I have not added any brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license
- [x] The icons were originally created in #4717 by @karsa-mistmere and @jguddas
- [x] I've based them on the following Lucide icons: `user-shield`, `user-round`

### Naming
- [x] I've read and followed the naming conventions
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
- [x] I've read and followed the icon design guidelines
- [x] I've made sure that the icons don't already exist, including the Lab directory.
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the Contribution Guidelines.
- [x] I've checked if there was an existing PR that solves the same issue.