### PR TITLE
feat(icons): added `monitor-pc` icon

### DIFF
--- a/icons/monitor-pc.json
+++ b/icons/monitor-pc.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "colebemis",
+    "ericfennis",
+    "danielbayley",
+    "jguddas",
+    "karsa-mistmere"
+  ],
+  "use-cases": [
+    "Representing desktop computer setups",
+    "Showing workstation or gaming PC devices",
+    "Identifying personal computers in device lists",
+    "Managing computer hardware in IT dashboards"
+  ],
+  "tags": [
+    "personal computer",
+    "desktop",
+    "screen",
+    "display",
+    "workstation",
+    "tower",
+    "chassis",
+    "hardware",
+    "setup",
+    "gaming"
+  ],
+  "categories": [
+    "devices",
+    "development",
+    "gaming"
+  ]
+}

--- a/icons/monitor-pc.svg
+++ b/icons/monitor-pc.svg
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 15H4a2 2 0 01-2-2V7a2 2 0 012-2h6" />
+  <path d="M10 19H5" />
+  <path d="M14 11h8" />
+  <path d="M14 7h8" />
+  <path d="M18 17h.01" />
+  <path d="M9 19v-4" />
+  <rect x="14" y="3" width="8" height="18" rx="1" />
+</svg>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Insert `closes #issueNumber` here if merging this PR will resolve an existing issue -->

## What is the purpose of this pull request?
- [x] New Icon

### Description
Added new `monitor-pc` icon.

### Icon use case
<!-- What is the purpose of this icon? For each icon added, please insert at least two real life use cases (the more the better). Text like "it's a car icon" is not accepted. -->

- Representing desktop computer setups
- Showing workstation or gaming PC devices
- Identifying personal computers in device lists
- Managing computer hardware in IT dashboards

## Alternative design ideas

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=1.LIRgLABCIBYBykiArACTAQwEwRwBgjxAFotSA1Adm10MJDKxhD0SgE5Vk3L5Q4ovAHRFg7DgDdiYANoyARACcApgGMALvIA0Ab3kAPeQC5wW%2BQE9jAZjMB3AJYATdTGNwzMZfYDmMTSfclQxMAXwBdMKA&name=computer&utm_source=lucide-studio&utm_medium=embed"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTQgMTFoOCIgLz4KICA8cGF0aCBkPSJNMTQgMTVINGEyIDIgMCAwMS0yLTJWN2EyIDIgMCAwMTItMmgxMCIgLz4KICA8cGF0aCBkPSJNMTQgMTlINSIgLz4KICA8cGF0aCBkPSJNMTQgN2g4IiAvPgogIDxwYXRoIGQ9Ik0xOCAxN2guMDEiIC8+CiAgPHBhdGggZD0iTTkgMTl2LTQiIC8+CiAgPHJlY3QgeD0iMTQiIHk9IjMiIHdpZHRoPSI4IiBoZWlnaHQ9IjE4IiByeD0iMSIgLz4KPC9zdmc+.svg"/><br/>Open lucide studio</a>

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=1.LIRgDABA7AEgLAQwEwRZMYC0KkDcBsyqE6YOAFvqHBCCOQBzXSOgO1TkB0YIw%2BqenGABODrjgBtSQCIATgFMAxgBcZAGgDeMgB4yAXCDjqZATwMBmEwHcAlgBMV5AwxPkFtgObk1h1-L1DAF8AXRCgA&name=computer&utm_source=lucide-studio&utm_medium=embed"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTAgN0g0YTIgMiAwIDAwLTIgMnY2YTIgMiAwIDAwMiAyaDYiIC8+CiAgPHBhdGggZD0iTTE0IDExaDgiIC8+CiAgPHBhdGggZD0iTTE0IDdoOCIgLz4KICA8cGF0aCBkPSJNMTggMTdoLjAxIiAvPgogIDxwYXRoIGQ9Ik02IDIxaDQiIC8+CiAgPHBhdGggZD0iTTkgMTd2NCIgLz4KICA8cmVjdCB4PSIxNCIgeT0iMyIgd2lkdGg9IjgiIGhlaWdodD0iMTgiIHJ4PSIxIiAvPgo8L3N2Zz4=.svg"/><br/>Open lucide studio</a>

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=1.LIRgDABAzAEgLAQwEwRZMYC0KkDdzKoTpg4AWAbKHBCCGQBzUQDsjoDtbAdGCMJyT0kAbREAiAE4BTAMYAXcQBoA3uIAe4gFwg4S8QE9tUfQHcAlgBN5ZbQ31lp5gOZlFO%2B1M06AvgF0-IA&name=computer&utm_source=lucide-studio&utm_medium=embed"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTAgM0g0YTIgMiAwIDAwLTIgMnYxMGEyIDIgMCAwMDIgMmg2IiAvPgogIDxwYXRoIGQ9Ik0xNCAxMWg4IiAvPgogIDxwYXRoIGQ9Ik0xNCA3aDgiIC8+CiAgPHBhdGggZD0iTTE4IDE3aC4wMSIgLz4KICA8cGF0aCBkPSJNOCAyMWgyIiAvPgogIDxyZWN0IHg9IjE0IiB5PSIzIiB3aWR0aD0iOCIgaGVpZ2h0PSIxOCIgcng9IjEiIC8+Cjwvc3ZnPg==.svg"/><br/>Open lucide studio</a>

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=1.LIRgLABCIBYBykgdnqOUUDoAMJgFZN8IAmEACRGwDcBafcsAQxNIm3ZFpO4DUA2Fmw64eJGPwDakgEQAnAKYBjAC4yANAG8ZADxkAucOpkBPAwGZjAdwCWAExUwDcYzAU2A5jDWGX8vYYAvgC6wUA&name=computer&utm_source=lucide-studio&utm_medium=embed"><img alt="icons" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTQgMTFoOCIgLz4KICA8cGF0aCBkPSJNMTQgN2g4IiAvPgogIDxwYXRoIGQ9Ik0xOCAxN2guMDEiIC8+CiAgPHBhdGggZD0iTTUuNSAyMUgxMHYtNUg0YTIgMiAwIDAxLTItMlY2YTIgMiAwIDAxMi0yaDYiIC8+CiAgPHJlY3QgeD0iMTQiIHk9IjMiIHdpZHRoPSI4IiBoZWlnaHQ9IjE4IiByeD0iMSIgLz4KPC9zdmc+.svg"/><br/>Open lucide studio</a>
## Icon Design Checklist

### Concept
<!-- All of these requirements must be fulfilled. -->
- [x] I have provided valid use cases for each icon.
- [x] I have not added any a brand or logo icon.
- [x] I have not used any hate symbols.
- [x] I have not included any religious or political imagery.

### Author, credits & license
<!-- Please choose one of the following, and put an "x" next to it. -->
- [ ] The icons are solely my own creation.
- [x] The icons were originally created in #<issueNumber> by @colebemis
- [x] I've based them on the following Lucide icons: `monitor`
- [ ] I've based them on the following design: <!-- provide source URL and license permitting use -->

### Naming
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [naming conventions](https://lucide.dev/guide/design/icon-design-guide#naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design
<!-- All of these requirements must be fulfilled. -->
- [x] I've read and followed the [icon design guidelines](https://lucide.dev/guide/design/icon-design-guide)
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.