### PR TITLE
ci(@lucide/lab): Create automatic release flow for `@lucide/lab`

### DIFF
--- a/.github/workflows/lucide-lab.yml
+++ b/.github/workflows/lucide-lab.yml
@@ -3,6 +3,7 @@ name: Lucide Lab checks
 on:
   pull_request:
     paths:
+      - lab/**
       - packages/lab/**
       - packages/shared/**
       - tools/build-icons/**

--- a/.github/workflows/release-lab.yml
+++ b/.github/workflows/release-lab.yml
@@ -1,0 +1,146 @@
+name: Release @lucide/lab
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - lab/**/*.svg
+
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: Release type
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions: {}
+
+jobs:
+  create-release:
+    if: github.repository == 'lucide-icons/lucide'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create the release and tag
+    outputs:
+      VERSION: ${{ steps.new-version.outputs.NEW_VERSION }}
+      SHOULD_RELEASE: ${{ steps.release-notes.outputs.SHOULD_RELEASE }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # Required to diff the lab icons against the previous tag
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: 'pnpm'
+          node-version-file: 'package.json'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Get latest tag
+        id: latest-tag
+        run: |
+          LATEST_TAG=$(git tag --list '@lucide/lab@*' --sort=-v:refname | head -n 1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::error::No @lucide/lab@* tag found to release from."
+            exit 1
+          fi
+
+          echo "Latest tag: $LATEST_TAG"
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Create new version
+        id: new-version
+        run: |
+          NEW_VERSION=$(pnpm semver "${LATEST_TAG#@lucide/lab@}" -i "$RELEASE_TYPE")
+
+          echo "New version: $NEW_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+        env:
+          LATEST_TAG: ${{ steps.latest-tag.outputs.LATEST_TAG }}
+          RELEASE_TYPE: ${{ inputs.release-type || 'minor' }}
+
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          NEW_TAG="@lucide/lab@$NEW_VERSION"
+
+          ADDED=$(git diff --name-only --diff-filter=A "$LATEST_TAG" HEAD -- 'lab/*.svg' \
+            | xargs -r -n1 basename | sed 's/\.svg$//' | sort)
+          REMOVED=$(git diff --name-only --diff-filter=D "$LATEST_TAG" HEAD -- 'lab/*.svg' \
+            | xargs -r -n1 basename | sed 's/\.svg$//' | sort)
+
+          if [ -z "$ADDED" ] && [ "$EVENT_NAME" != 'workflow_dispatch' ]; then
+            echo "::notice::No icons were added to ./lab since $LATEST_TAG, skipping release."
+            echo "SHOULD_RELEASE=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          {
+            if [ -n "$ADDED" ]; then
+              printf '## New icons\n\n'
+              printf '%s\n' "$ADDED" | sed 's|.*|- `&`|'
+              printf '\n'
+            fi
+
+            if [ -n "$REMOVED" ]; then
+              printf '## Removed icons\n\nThese graduated to the core icon set.\n\n'
+              printf '%s\n' "$REMOVED" | sed 's|.*|- `&`|'
+              printf '\n'
+            fi
+
+            printf '**Full changelog**: https://github.com/lucide-icons/lucide/compare/%s...%s\n' "$LATEST_TAG" "$NEW_TAG"
+          } > lab-release-notes.md
+
+          cat lab-release-notes.md
+          echo "SHOULD_RELEASE=true" >> $GITHUB_OUTPUT
+        env:
+          LATEST_TAG: ${{ steps.latest-tag.outputs.LATEST_TAG }}
+          NEW_VERSION: ${{ steps.new-version.outputs.NEW_VERSION }}
+          EVENT_NAME: ${{ github.event_name }}
+
+      - name: Create Release
+        if: steps.release-notes.outputs.SHOULD_RELEASE == 'true'
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
+        with:
+          tag_name: '@lucide/lab@${{ steps.new-version.outputs.NEW_VERSION }}'
+          name: '@lucide/lab@${{ steps.new-version.outputs.NEW_VERSION }}'
+          body_path: lab-release-notes.md
+          make_latest: 'false' # Never displace the core icon release as "Latest"
+
+  publish:
+    if: github.repository == 'lucide-icons/lucide' && needs.create-release.outputs.SHOULD_RELEASE == 'true'
+    runs-on: ubuntu-latest
+    needs: create-release
+    permissions:
+      id-token: write # Required for OIDC (npm provenance)
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: 'pnpm'
+          node-version-file: 'package.json'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set new version
+        run: pnpm version ${{ needs.create-release.outputs.VERSION }} --filter @lucide/lab --fail-if-no-match --no-git-tag-version
+
+      - name: Build
+        run: pnpm --filter @lucide/lab build
+
+      - name: Publish
+        run: pnpm --filter @lucide/lab publish --access public --no-git-checks --ignore-scripts --tag latest
+        env:
+          NPM_CONFIG_PROVENANCE: true

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -36,8 +36,7 @@
     "build:icons": "build-icons --input=../../lab --output=./src --templateSrc=./scripts/exportTemplate.mts --iconFileExtension=.ts --exportModuleNameCasing=camel --renderUniqueKey --exportFileName=index.ts",
     "build:lib": "node ./scripts/buildLib.mts",
     "build:bundle": "rollup -c rollup.config.mjs",
-    "clean": "rm -f src/icons/*.ts && rm -rf dist && rm -rf icons && rm -f icon-nodes.json",
-    "version": "pnpm version --git-tag-version=false"
+    "clean": "rm -f src/icons/*.ts && rm -rf dist && rm -rf icons && rm -f icon-nodes.json"
   },
   "devDependencies": {
     "@lucide/build-icons": "workspace:*",


### PR DESCRIPTION
Introduce automation to release the `@lucide/lab` package and improve workflow triggers related to the lab icons. The main changes are the addition of a dedicated release workflow for lab icons and a refinement of the pull request check triggers.

**Release automation and workflow improvements:**

- Added a new GitHub Actions workflow (`.github/workflows/release-lab.yml`) to automate the release process for the `@lucide/lab` package when SVG files in the `lab/` directory are changed or when manually triggered. This workflow handles version bumping, release notes generation, and publishing to npm.
- Updated the `Lucide Lab checks` workflow trigger to include changes in the `lab/` directory, ensuring that pull requests affecting lab icons are properly checked. (`.github/workflows/lucide-lab.yml`)