### PR TITLE
fix(icons): deprecated swiss franc icons

### DIFF
--- a/icon.schema.json
+++ b/icon.schema.json
@@ -141,7 +141,7 @@
   "$defs": {
     "iconDeprecationReasons": {
       "type": "string",
-      "enum": ["icon.renamed"]
+      "enum": ["icon.design", "icon.obsolete"]
     },
     "aliasDeprecationReasons": {
       "type": "string",

--- a/icon.schema.json
+++ b/icon.schema.json
@@ -141,7 +141,7 @@
   "$defs": {
     "iconDeprecationReasons": {
       "type": "string",
-      "enum": ["icon.design", "icon.obsolete"]
+      "enum": ["icon.design", "icon.use-case"]
     },
     "aliasDeprecationReasons": {
       "type": "string",

--- a/icons/badge-swiss-franc.json
+++ b/icons/badge-swiss-franc.json
@@ -4,7 +4,7 @@
     "danielbayley"
   ],
   "deprecated": true,
-  "deprecationReason": "icon.obsolete",
+  "deprecationReason": "icon.use-case",
   "use-cases": [],
   "tags": [
     "discount",

--- a/icons/badge-swiss-franc.json
+++ b/icons/badge-swiss-franc.json
@@ -3,6 +3,8 @@
   "contributors": [
     "danielbayley"
   ],
+  "deprecated": true,
+  "deprecationReason": "icon.obsolete",
   "use-cases": [],
   "tags": [
     "discount",

--- a/icons/receipt-swiss-franc.json
+++ b/icons/receipt-swiss-franc.json
@@ -4,6 +4,8 @@
     "danielbayley",
     "karsa-mistmere"
   ],
+  "deprecated": true,
+  "deprecationReason": "icon.obsolete",
   "use-cases": [],
   "tags": [
     "bill",

--- a/icons/receipt-swiss-franc.json
+++ b/icons/receipt-swiss-franc.json
@@ -5,7 +5,7 @@
     "karsa-mistmere"
   ],
   "deprecated": true,
-  "deprecationReason": "icon.obsolete",
+  "deprecationReason": "icon.use-case",
   "use-cases": [],
   "tags": [
     "bill",

--- a/icons/swiss-franc.json
+++ b/icons/swiss-franc.json
@@ -4,6 +4,8 @@
     "ericfennis",
     "mittalyashu"
   ],
+  "deprecated": true,
+  "deprecationReason": "icon.obsolete",
   "use-cases": [],
   "tags": [
     "currency",

--- a/icons/swiss-franc.json
+++ b/icons/swiss-franc.json
@@ -5,7 +5,7 @@
     "mittalyashu"
   ],
   "deprecated": true,
-  "deprecationReason": "icon.obsolete",
+  "deprecationReason": "icon.use-case",
   "use-cases": [],
   "tags": [
     "currency",

--- a/lab/swiss-franc-circle.json
+++ b/lab/swiss-franc-circle.json
@@ -3,6 +3,8 @@
   "contributors": [
     "danielbayley"
   ],
+  "deprecated": true,
+  "deprecationReason": "icon.obsolete",
   "tags": [
     "monetization",
     "marketing",

--- a/lab/swiss-franc-circle.json
+++ b/lab/swiss-franc-circle.json
@@ -4,7 +4,7 @@
     "danielbayley"
   ],
   "deprecated": true,
-  "deprecationReason": "icon.obsolete",
+  "deprecationReason": "icon.use-case",
   "tags": [
     "monetization",
     "marketing",

--- a/lab/swiss-franc-square.json
+++ b/lab/swiss-franc-square.json
@@ -3,6 +3,8 @@
   "contributors": [
     "danielbayley"
   ],
+  "deprecated": true,
+  "deprecationReason": "icon.obsolete",
   "tags": [
     "monetization",
     "marketing",

--- a/lab/swiss-franc-square.json
+++ b/lab/swiss-franc-square.json
@@ -4,7 +4,7 @@
     "danielbayley"
   ],
   "deprecated": true,
-  "deprecationReason": "icon.obsolete",
+  "deprecationReason": "icon.use-case",
   "tags": [
     "monetization",
     "marketing",

--- a/tools/build-icons/types.ts
+++ b/tools/build-icons/types.ts
@@ -32,7 +32,7 @@ export type AliasDeprecation = {
   deprecationReason: AliasDeprecationReason;
 };
 
-export type IconDeprecationReason = 'icon.design' | 'icon.obsolete' | '';
+export type IconDeprecationReason = 'icon.design' | 'icon.use-case' | '';
 
 export type IconMetadataBase = {
   categories: string[];

--- a/tools/build-icons/types.ts
+++ b/tools/build-icons/types.ts
@@ -32,7 +32,7 @@ export type AliasDeprecation = {
   deprecationReason: AliasDeprecationReason;
 };
 
-export type IconDeprecationReason = 'icon.renamed' | '';
+export type IconDeprecationReason = 'icon.design' | 'icon.obsolete' | '';
 
 export type IconMetadataBase = {
   categories: string[];

--- a/tools/build-icons/utils/deprecationReasonTemplate.ts
+++ b/tools/build-icons/utils/deprecationReasonTemplate.ts
@@ -17,7 +17,7 @@ export default function deprecationReasonTemplate(
     case 'alias.name':
       return `The name of this icon was changed because it didn't meet our guidelines anymore, use {@link ${componentName}} instead.`;
     case 'icon.design':
-      return `Removed because the design didn't meet our guidelines anymore.`;
+      return `Removed because the icon didn't meet our design guidelines.`;
     case 'icon.obsolete':
       return `Removed because the depicted concept became obsolete and no longer had relevant use cases.`;
     default:

--- a/tools/build-icons/utils/deprecationReasonTemplate.ts
+++ b/tools/build-icons/utils/deprecationReasonTemplate.ts
@@ -18,7 +18,7 @@ export default function deprecationReasonTemplate(
       return `The name of this icon was changed because it didn't meet our guidelines anymore, use {@link ${componentName}} instead.`;
     case 'icon.design':
       return `Removed because the icon didn't meet our design guidelines.`;
-    case 'icon.obsolete':
+    case 'icon.use-case':
       return `Removed because the depicted concept became obsolete and no longer had relevant use cases.`;
     default:
       throw new Error(`Unknown deprecation reason: ${deprecationReason}`);

--- a/tools/build-icons/utils/deprecationReasonTemplate.ts
+++ b/tools/build-icons/utils/deprecationReasonTemplate.ts
@@ -16,6 +16,10 @@ export default function deprecationReasonTemplate(
       return `The icon was combined with another icon that shares the same use case, use {@link ${componentName}} instead.`;
     case 'alias.name':
       return `The name of this icon was changed because it didn't meet our guidelines anymore, use {@link ${componentName}} instead.`;
+    case 'icon.design':
+      return `Removed because the design didn't meet our guidelines anymore.`;
+    case 'icon.obsolete':
+      return `Removed because the depicted concept became obsolete and no longer had relevant use cases.`;
     default:
       throw new Error(`Unknown deprecation reason: ${deprecationReason}`);
   }


### PR DESCRIPTION
closes #4703

## Description

Marked all "Swiss franc" icons as deprecated. The depicted symbol is obsolete and it had never actually been used to signify the Swiss franc.

Also refined the icon deprecation reasons:
- removed `icon.renamed`: icons that had been renamed will result in deprecated aliases, not deprecated icons
- added
  - `icon.design`: for when a design is deemed so non-compliant, that it'd better be removed
  - `icon.use-case`: for when an icon depicts a concept that is obsolete and no longer has relevant use cases

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
