### PR TITLE
fix(lucide-react): add types for per-icon imports

### DIFF
--- a/integrations/lucide-react/vite/src/IconShowcase.tsx
+++ b/integrations/lucide-react/vite/src/IconShowcase.tsx
@@ -1,4 +1,6 @@
-import { Camera, Droplet, Edit2, House, LucideProvider, Pen } from 'lucide-react';
+import { Camera, House, LucideProvider, Pen } from 'lucide-react';
+import Droplet from 'lucide-react/dist/esm/icons/droplet.mjs';
+import Edit2 from 'lucide-react/dist/esm/icons/edit-2.mjs';
 import { DynamicIcon } from 'lucide-react/dynamic';
 
 export default function IconShowcase() {

--- a/integrations/lucide-react/vite/tests/icons.browser.spec.tsx
+++ b/integrations/lucide-react/vite/tests/icons.browser.spec.tsx
@@ -1,8 +1,12 @@
-import { expect, test } from 'vitest';
+import Droplet from 'lucide-react/dist/esm/icons/droplet.mjs';
+import type { LucideIcon } from 'lucide-react/dist/lucide-types';
+import { expect, expectTypeOf, test } from 'vitest';
 import { render } from 'vitest-browser-react';
 import App from '../src/App';
 
 test('renders Lucide public APIs in a real browser', async () => {
+  expectTypeOf(Droplet).toEqualTypeOf<LucideIcon>();
+
   const screen = await render(<App />);
 
   const staticIcon = screen.getByTestId('static-icon');

--- a/packages/lucide-react/package.json
+++ b/packages/lucide-react/package.json
@@ -26,6 +26,16 @@
   "main": "dist/cjs/lucide-react.js",
   "module": "dist/esm/lucide-react.mjs",
   "typings": "dist/lucide-react.d.ts",
+  "typesVersions": {
+    "*": {
+      "dist/esm/icons/*.mjs": [
+        "dist/lucide-icon.d.mts"
+      ],
+      "dist/lucide-types": [
+        "dist/lucide-types.d.ts"
+      ]
+    }
+  },
   "sideEffects": false,
   "files": [
     "dist",

--- a/packages/lucide-react/rollup.config.mjs
+++ b/packages/lucide-react/rollup.config.mjs
@@ -110,6 +110,16 @@ const configs = bundles
 
 export default [
   {
+    input: 'src/types.ts',
+    output: { file: 'dist/lucide-types.d.ts', format: 'es' },
+    plugins: [dts(dtsOptions)],
+  },
+  {
+    input: 'src/lucide-icon.d.ts',
+    output: { file: 'dist/lucide-icon.d.mts', format: 'es' },
+    plugins: [dts(dtsOptions)],
+  },
+  {
     input: 'src/dynamicIconImports.ts',
     output: [
       {

--- a/packages/lucide-react/src/lucide-icon.d.ts
+++ b/packages/lucide-react/src/lucide-icon.d.ts
@@ -1,0 +1,5 @@
+import type { LucideIcon } from './types';
+
+declare const icon: LucideIcon;
+
+export default icon;


### PR DESCRIPTION
## Description

Thanks for maintaining Lucide — we use it in an SSR app and wanted to avoid loading the whole icon barrel when only a few icons are needed.

The existing per-icon files work at runtime, but TypeScript reports TS7016 for this import:

```tsx
import Camera from 'lucide-react/dist/esm/icons/camera.mjs';
```

This adds a wildcard `typesVersions` entry for those `.mjs` files and generates a shared default-icon declaration from `src/types.ts`. It also publishes a lightweight `lucide-react/dist/lucide-types` entry, with an explicit mapping for NodeNext, so importing `LucideProps` does not pull in the full icon declaration bundle. Both outputs use the existing Rollup declaration settings, including the shared types.

I saw the concerns in #3354 and the rollback in #2814. This only adds type declarations: `main`, `module`, existing entry points and the emitted JavaScript stay unchanged.

The shared declaration covers the default component export. It does not include per-icon deprecation metadata or the named `__iconNode` / `__iconData` exports. A misspelled icon path still typechecks with the wildcard; the bundler reports the missing file.

In a minimal packed-package consumer, the Lucide declarations loaded by TypeScript dropped from 2.20 MB to 2.15 KB. The Vite fixture covers a canonical icon and an alias; its typecheck fails before the change and passes here. I also checked strict Bundler/NodeNext consumers and confirmed that the existing 4,184 JavaScript and sourcemap files match byte-for-byte when built from the same generated icon inputs.

The package build and lint pass, as do build, typecheck and Chromium tests in all five integration fixtures. The 33 unit tests pass with two workers. An initial run alongside other builds timed out in a dynamic-import test, and React Router’s first browser run hit a connection timeout; both passed when rerun separately.

Would you be open to this approach? Happy to adjust the shape if you would prefer a different way to expose these types.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
