### PR TITLE
fix(icons): changed `id-card-lanyard` icon

### DIFF
--- a/icons/id-card-lanyard.svg
+++ b/icons/id-card-lanyard.svg
@@ -10,8 +10,8 @@
   stroke-linejoin="round"
 >
   <path d="M13.5 8h-3" />
-  <path d="m15 2-1 2h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h3" />
-  <path d="M16.899 22A5 5 0 0 0 7.1 22" />
+  <path d="m15 2-1 2h3a2 2 0 012 2v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6a2 2 0 012-2h3" />
+  <path d="M16 22a4 4 0 00-8 0" />
   <path d="m9 2 3 6" />
   <circle cx="12" cy="15" r="3" />
 </svg>


### PR DESCRIPTION
## Description

Replaced the user shape with the same one as in [`file-user`](https://lucide.dev/icons/file-user) for better consistency and slightly lower density.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
