### PR TITLE
fix(icons): changed `id-card` icon

### DIFF
--- a/icons/id-card.svg
+++ b/icons/id-card.svg
@@ -9,9 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M13 19a4 4 0 00-8 0" />
   <path d="M16 10h2" />
   <path d="M16 14h2" />
-  <path d="M6.17 15a3 3 0 0 1 5.66 0" />
-  <circle cx="9" cy="11" r="2" />
+  <circle cx="9" cy="12" r="3" />
   <rect x="2" y="5" width="20" height="14" rx="2" />
 </svg>


### PR DESCRIPTION
## Description

Replaced the user shape with the same one as in [file-user](https://lucide.dev/icons/file-user) / `id-card-lanyard` (see #4819) for better legibility and improved consistency.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
