### PR TITLE
fix(icons): improve legibility of credit card icons

### DIFF
--- a/icons/credit-card-check.svg
+++ b/icons/credit-card-check.svg
@@ -10,6 +10,7 @@
   stroke-linejoin="round"
 >
   <path d="M12.5 19H4a2 2 0 01-2-2V7a2 2 0 012-2h16a2 2 0 012 2v4" />
-  <path d="m16 17 2 2 4-4" />
   <path d="M2 10h20" />
+  <path d="M6 14h2" />
+  <path d="m16 17 2 2 4-4" />
 </svg>

--- a/icons/credit-card-minus.svg
+++ b/icons/credit-card-minus.svg
@@ -9,7 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M16 17h6" />
-  <path d="M22 10H2" />
   <path d="M22 13V7a2 2 0 00-2-2H4a2 2 0 00-2 2v10a2 2 0 002 2h8.536" />
+  <path d="M22 10H2" />
+  <path d="M6 14h2" />
+  <path d="M16 17h6" />
 </svg>

--- a/icons/credit-card-plus.svg
+++ b/icons/credit-card-plus.svg
@@ -9,8 +9,9 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
+  <path d="M22 11.354V7a2 2 0 00-2-2H4a2 2 0 00-2 2v10a2 2 0 002 2h8.536" />
+  <path d="M22 10H2" />
+  <path d="M6 14h2" />
   <path d="M16 17h6" />
   <path d="M19 14v6" />
-  <path d="M22 10H2" />
-  <path d="M22 11.354V7a2 2 0 00-2-2H4a2 2 0 00-2 2v10a2 2 0 002 2h8.536" />
 </svg>

--- a/icons/credit-card-x.svg
+++ b/icons/credit-card-x.svg
@@ -10,7 +10,8 @@
   stroke-linejoin="round"
 >
   <path d="M12.5 19H4a2 2 0 01-2-2V7a2 2 0 012-2h16a2 2 0 012 2v3.5" />
-  <path d="m16.5 14.5 5 5" />
   <path d="M2 10h20" />
+  <path d="M6 14h2" />
+  <path d="m16.5 14.5 5 5" />
   <path d="m21.5 14.5-5 5" />
 </svg>

--- a/icons/credit-card.svg
+++ b/icons/credit-card.svg
@@ -11,4 +11,5 @@
 >
   <rect width="20" height="14" x="2" y="5" rx="2" />
   <line x1="2" x2="22" y1="10" y2="10" />
+  <path d="M6 14h2" />
 </svg>


### PR DESCRIPTION
## Description

#4616 added a new `credit-card-reader` icon with a small additional detail compared to the existing credit card icons.

I think this small detail is an important and meaningful one, as it greatly improves the legibility of the icon and should be carried over to the existing set for consistency.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
