### PR TITLE
fix(icons): arcified flip icons & renamed them

### DIFF
--- a/icons/triangles-centerline-dashed-horizontal.json
+++ b/icons/triangles-centerline-dashed-horizontal.json
@@ -14,5 +14,12 @@
   "categories": [
     "design",
     "photography"
+  ],
+  "aliases": [
+    {
+      "name": "flip-horizontal-2",
+      "deprecated": true,
+      "deprecationReason": "alias.name"
+    }
   ]
 }

--- a/icons/triangles-centerline-dashed-horizontal.svg
+++ b/icons/triangles-centerline-dashed-horizontal.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m17 3-5 5-5-5h10" />
-  <path d="m17 21-5-5-5 5h10" />
-  <path d="M4 12H2" />
   <path d="M10 12H8" />
   <path d="M16 12h-2" />
   <path d="M22 12h-2" />
+  <path d="M4 12H2" />
+  <path d="M7.298 20.288A1 1 0 008 22h8a1 1 0 00.703-1.712l-3.991-3.99a1 1 0 00-1.424-.001z" />
+  <path d="M7.298 3.712A1 1 0 018 2h8a1 1 0 01.703 1.712l-3.991 3.99a1 1 0 01-1.424.001z" />
 </svg>

--- a/icons/triangles-centerline-dashed-vertical.json
+++ b/icons/triangles-centerline-dashed-vertical.json
@@ -15,5 +15,12 @@
   "categories": [
     "design",
     "photography"
+  ],
+  "aliases": [
+    {
+      "name": "flip-vertical-2",
+      "deprecated": true,
+      "deprecationReason": "alias.name"
+    }
   ]
 }

--- a/icons/triangles-centerline-dashed-vertical.svg
+++ b/icons/triangles-centerline-dashed-vertical.svg
@@ -9,10 +9,10 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="m3 7 5 5-5 5V7" />
-  <path d="m21 7-5 5 5 5V7" />
-  <path d="M12 20v2" />
   <path d="M12 14v2" />
-  <path d="M12 8v2" />
+  <path d="M12 20v2" />
   <path d="M12 2v2" />
+  <path d="M12 8v2" />
+  <path d="M20.288 16.703A1 1 0 0022 16V8a1 1 0 00-1.712-.703l-3.99 3.991a1 1 0 00-.001 1.424z" />
+  <path d="M3.712 16.703A1 1 0 012 16V8a1 1 0 011.712-.703l3.99 3.991a1 1 0 01.001 1.424z" />
 </svg>


### PR DESCRIPTION
## Description

- Arcified both icons
- Renamed
  - `flip-horizontal-2` => `triangles-centerline-dashed-horizontal`
  - `flip-vertical-2` => `triangles-centerline-dashed-vertical`

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
