### PR TITLE
fix(icons): correct compromised tags in shield icons

### DIFF
--- a/icons/shield-alert.json
+++ b/icons/shield-alert.json
@@ -45,7 +45,7 @@
     "weakness",
     "infection",
     "infected",
-    "comprimised",
+    "compromised",
     "data leak",
     "audited",
     "admin",

--- a/icons/shield-ban.json
+++ b/icons/shield-ban.json
@@ -44,7 +44,7 @@
     "weakness",
     "infection",
     "infected",
-    "comprimised",
+    "compromised",
     "data leak",
     "audited",
     "admin",

--- a/icons/shield-off.json
+++ b/icons/shield-off.json
@@ -37,7 +37,7 @@
     "weakness",
     "infected",
     "infection",
-    "comprimised",
+    "compromised",
     "data leak",
     "unaudited",
     "admin",

--- a/icons/shield-question-mark.json
+++ b/icons/shield-question-mark.json
@@ -38,7 +38,7 @@
     "vulnerable",
     "weakness",
     "infection",
-    "comprimised",
+    "compromised",
     "data leak",
     "audit",
     "admin",

--- a/icons/shield-x.json
+++ b/icons/shield-x.json
@@ -45,7 +45,7 @@
     "weakness",
     "infection",
     "infected",
-    "comprimised",
+    "compromised",
     "data leak",
     "audited",
     "admin",


### PR DESCRIPTION
## Description

Correct `comprimised` to `compromised` in the tags for `shield-alert`, `shield-ban`, `shield-off`, `shield-question-mark`, and `shield-x`.

The tag is rendered verbatim on the icon detail page on lucide.dev, and both that page and the search index are generated from `icons/*.json`. The corrected tag also ships in the generated `lucide-static/tags.json`. Ordinary fuzzy search already tolerates the typo. The correction makes `=compromised` return all five icons instead of none and improves the fuzzy relevance score for `compromised` from 0.71 to 0.006.

The repo's existing CSpell job only checks icon filenames. Running CSpell over the tag values (14,888 entries) surfaces further, unrelated misspellings, including: `savety` (`hard-hat`), `theraputic` (`book-heart`), `siesmic` (`activity`, `square-activity`), `bachlor's` (`graduation-cap`). Keeping this PR to the single `comprimised` → `compromised` correction; happy to follow up with those corrections and a tag spellcheck separately.

Merged precedents include #2749 for correcting a misspelled tag and #4099 for updating tags across six icons in the search family. The latter was an external contribution approved by `ericfennis`.

## Validation

- `pnpm install`
- `pnpm lint`
- `pnpm build`
- `pnpm test`: 297 tests passed
- `pnpm checkIcons`
- Existing filename spellcheck for the five changed JSON files
- Verified exact matching with the repository's metadata and installed Fuse dependency, and checked the generated `lucide-static/tags.json`

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.

