### PR TITLE
fix(icons): correct misspelled tags

### DIFF
--- a/icons/activity.json
+++ b/icons/activity.json
@@ -22,7 +22,7 @@
     "hospital",
     "defibrillator",
     "earthquake",
-    "siesmic",
+    "seismic",
     "magnitude",
     "richter scale",
     "aftershock",

--- a/icons/book-heart.json
+++ b/icons/book-heart.json
@@ -24,7 +24,7 @@
     "teens",
     "teenager",
     "therapy",
-    "theraputic",
+    "therapeutic",
     "therapist",
     "planner",
     "organizer",

--- a/icons/door-stairwell.json
+++ b/icons/door-stairwell.json
@@ -19,7 +19,7 @@
     "transition",
     "access",
     "structure",
-    "espiral",
+    "spiral",
     "building",
     "vertical",
     "movement",

--- a/icons/graduation-cap.json
+++ b/icons/graduation-cap.json
@@ -18,7 +18,7 @@
     "academic",
     "hat",
     "diploma",
-    "bachlor's",
+    "bachelor's",
     "master's",
     "doctorate"
   ],

--- a/icons/hard-hat.json
+++ b/icons/hard-hat.json
@@ -8,8 +8,7 @@
   "tags": [
     "helmet",
     "construction",
-    "safety",
-    "savety"
+    "safety"
   ],
   "categories": [
     "tools"

--- a/icons/square-activity.json
+++ b/icons/square-activity.json
@@ -21,7 +21,7 @@
     "hospital",
     "defibrillator",
     "earthquake",
-    "siesmic",
+    "seismic",
     "magnitude",
     "richter scale",
     "aftershock",


### PR DESCRIPTION
## Description

Follow-up to #4835: correct `theraputic`, `siesmic`, `bachlor's`, and `espiral` in icon tags. Remove `savety` from `hard-hat`, where `safety` is already present. This covers five misspellings across six metadata files.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
