### PR TITLE
fix(packages/vue): fix generated icon declaration types for @lucide/vue

### DIFF
--- a/packages/vue/scripts/exportTemplate.mts
+++ b/packages/vue/scripts/exportTemplate.mts
@@ -8,7 +8,7 @@ export default defineExportTemplate(
 
     return `
 import createLucideIcon from '../createLucideIcon';
-import type { LucideIconData } from '../types';
+import type { LucideIcon, LucideIconData } from '../types';
 
 export const __iconData: LucideIconData = ${JSON.stringify(iconData)}
 
@@ -23,7 +23,7 @@ export const __iconData: LucideIconData = ${JSON.stringify(iconData)}
  * @returns {FunctionalComponent} Vue component
  * ${deprecated ? `@deprecated ${deprecationReason}` : ''}
  */
-const ${componentName} = createLucideIcon(__iconData);
+const ${componentName}: LucideIcon = createLucideIcon(__iconData);
 
 export default ${componentName};
 `;


### PR DESCRIPTION
closes #4837

## What changed

Fixes the bundled type declarations for `@lucide/vue` by explicitly typing generated icon components as `LucideIcon`.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
