### PR TITLE
fix(packages/svelte,solid): fix shared type imports in Solid and Svelte

### DIFF
--- a/packages/lucide-solid/package.json
+++ b/packages/lucide-solid/package.json
@@ -80,6 +80,7 @@
     "babel-preset-solid": "^1.9.15",
     "esbuild": "^0.28.2",
     "jest-serializer-html": "^7.1.0",
+    "rollup-plugin-dts": "^6.5.1",
     "rollup": "^4.63.1",
     "solid-js": "^1.9.15",
     "typescript": "^6.0.3",

--- a/packages/lucide-solid/rollup.config.mjs
+++ b/packages/lucide-solid/rollup.config.mjs
@@ -2,9 +2,14 @@ import path from 'path';
 import { babel } from '@rollup/plugin-babel';
 import esbuild from 'esbuild';
 import plugins from '@lucide/rollup-plugins';
-import ts from 'typescript';
+import dts from 'rollup-plugin-dts';
 
 import pkg from './package.json' with { type: 'json' };
+
+const dtsOptions = {
+  includeExternal: ['@lucide/shared/types'],
+  tsconfig: './tsconfig.json',
+};
 
 const packageName = 'LucideSolid';
 const outputFileName = 'lucide-solid';
@@ -92,21 +97,6 @@ const configs = bundles
                   ],
                   external: ['solid-js'],
                 });
-
-                // Generate types
-                const program = ts.createProgram([pkg.source], {
-                  target: ts.ScriptTarget.ESNext,
-                  module: ts.ModuleKind.ESNext,
-                  moduleResolution: ts.ModuleResolutionKind.NodeJs,
-                  jsx: ts.JsxEmit.Preserve,
-                  jsxImportSource: 'solid-js',
-                  allowSyntheticDefaultImports: true,
-                  esModuleInterop: true,
-                  declarationDir: `dist/types`,
-                  declaration: true,
-                  emitDeclarationOnly: true,
-                });
-                program.emit();
               },
             }
           : null,
@@ -132,4 +122,16 @@ const configs = bundles
   )
   .flat();
 
-export default configs;
+const typesConfig = {
+  input: inputs[0],
+  output: {
+    dir: `${outputDir}/types`,
+    format: 'es',
+    preserveModules: true,
+    preserveModulesRoot: 'src',
+    entryFileNames: '[name].d.ts',
+  },
+  plugins: [dts(dtsOptions)],
+};
+
+export default [...configs, typesConfig];

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -3,7 +3,7 @@ import type { Snippet, Component } from 'svelte';
 import type {
   LucideIconData as SharedLucideIconData,
   LucideIconNode as SharedLucideIconNode,
-} from '@lucide/shared/types';
+} from './utils/types.js';
 
 export type Attrs = Record<string, unknown> & SVGAttributes<SVGSVGElement>;
 type IconNodeElements =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -864,6 +864,9 @@ importers:
       rollup:
         specifier: ^4.63.1
         version: 4.63.1
+      rollup-plugin-dts:
+        specifier: ^6.5.1
+        version: 6.5.1(rollup@4.63.1)(typescript@6.0.3)
       solid-js:
         specifier: ^1.9.15
         version: 1.9.15


### PR DESCRIPTION
closes #4842 

## Description

Fixes published `lucide-solid` and `@lucide/svelte` declarations so they no longer reference unpublished `@lucide/shared` types.

- Solid now bundles declaration types with `rollup-plugin-dts` similar to other packages.
- Svelte imports its packaged local utility types from `copy:utils`.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
