### PR TITLE
feat(icons): added square-dashed-plus

### DIFF
--- a/icons/square-dashed-plus.json
+++ b/icons/square-dashed-plus.json
@@ -21,7 +21,12 @@
     "new",
     "placeholder",
     "marquee",
-    "box"
+    "box",
+    "dashed",
+    "plus",
+    "insert",
+    "frame",
+    "empty"
   ],
   "categories": [
     "design",

--- a/icons/square-dashed-plus.json
+++ b/icons/square-dashed-plus.json
@@ -12,7 +12,11 @@
   "use-cases": [
     "Prompting users to select content for an empty slot",
     "Adding an area to an existing selection",
-    "Indicating a placeholder for adding content"
+    "Indicating a placeholder for adding content",
+    "marking an empty card or tile that can accept content",
+    "representing the action to insert a new component in a page builder",
+    "showing where to add an image in an upload or gallery flow",
+    "indicating an editable region to add or extend a selection"
   ],
   "tags": [
     "selection",

--- a/icons/square-dashed-plus.json
+++ b/icons/square-dashed-plus.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "llaenowyd",
+    "mishkaio",
+    "ericfennis",
+    "karsa-mistmere",
+    "chessurisme",
+    "colebemis",
+    "psjdev"
+  ],
+  "use-cases": [
+    "Prompting users to select content for an empty slot",
+    "Adding an area to an existing selection",
+    "Indicating a placeholder for adding content"
+  ],
+  "tags": [
+    "selection",
+    "select",
+    "add",
+    "new",
+    "placeholder",
+    "marquee",
+    "box"
+  ],
+  "categories": [
+    "design",
+    "layout"
+  ]
+}

--- a/icons/square-dashed-plus.json
+++ b/icons/square-dashed-plus.json
@@ -30,6 +30,7 @@
   ],
   "categories": [
     "design",
-    "layout"
+    "layout",
+    "shapes"
   ]
 }

--- a/icons/square-dashed-plus.json
+++ b/icons/square-dashed-plus.json
@@ -11,12 +11,8 @@
   ],
   "use-cases": [
     "Prompting users to select content for an empty slot",
-    "Adding an area to an existing selection",
-    "Indicating a placeholder for adding content",
-    "marking an empty card or tile that can accept content",
-    "representing the action to insert a new component in a page builder",
-    "showing where to add an image in an upload or gallery flow",
-    "indicating an editable region to add or extend a selection"
+    "Adding an area to an existing selection in design editors",
+    "Marking a placeholder where users can add a block"
   ],
   "tags": [
     "selection",

--- a/icons/square-dashed-plus.svg
+++ b/icons/square-dashed-plus.svg
@@ -1,0 +1,26 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 3a2 2 0 0 0-2 2" />
+  <path d="M19 3a2 2 0 0 1 2 2" />
+  <path d="M21 19a2 2 0 0 1-2 2" />
+  <path d="M5 21a2 2 0 0 1-2-2" />
+  <path d="M9 3h1" />
+  <path d="M9 21h1" />
+  <path d="M14 3h1" />
+  <path d="M14 21h1" />
+  <path d="M3 9v1" />
+  <path d="M21 9v1" />
+  <path d="M3 14v1" />
+  <path d="M21 14v1" />
+  <path d="M8 12h8" />
+  <path d="M12 8v8" />
+</svg>


### PR DESCRIPTION
## Description

Adds `square-dashed-plus`, combining the existing `square-dashed` border with the centered plus from `square-plus`. The geometry, positioning, and stroke width of both elements are preserved.

Includes matching metadata with contributor credits, use cases, tags, and categories.

Related to #3010.

### Icon use case

- Prompting users to select content for an empty slot, such as choosing an image for a layout
- Adding an area to an existing selection in a design editor
- Indicating a placeholder where users can add a block or component

### Alternative icon designs

No alternative designs proposed. This variant reuses established Lucide geometry.

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] I've based them on the following Lucide icons: `square-dashed` and `square-plus`

All contributors from both base icons are credited in the metadata, along with myself (`psjdev`).

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icons/naming-conventions).
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icons/specification).
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Validation

- SVG formatting checks passed
- Metadata schema validation passed
- Metadata formatting checks passed
- Staged whitespace checks passed

Local Windows compatibility adjustments were used to run the formatter and lint scripts; those tooling changes are excluded from this contribution.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.

<img width="480" height="320" alt="square-dashed-plus" src="https://github.com/user-attachments/assets/87ed1d7d-83a6-45ec-b375-771072c772f8" />
