### PR TITLE
feat(icons): added `soldering-iron` icon

### DIFF
--- a/icons/soldering-iron.json
+++ b/icons/soldering-iron.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "psjdev"
+  ],
+  "use-cases": [
+    "Identifying tools required for electronics assembly",
+    "Marking soldering steps in repair instructions",
+    "Locating electronics workstations in a makerspace",
+    "representing circuit-board repair or modification",
+    "selecting soldering equipment in tool inventories",
+    "marking soldering stations on workshop or makerspace maps",
+    "indicating soldering or hot-tip hazards in safety documentation",
+    "labeling diy electronics or hobbyist projects"
+  ],
+  "tags": [
+    "solder",
+    "electronics",
+    "repair",
+    "circuit",
+    "heat",
+    "workshop",
+    "assembly",
+    "pcb",
+    "flux",
+    "desolder",
+    "rework",
+    "smd",
+    "diy"
+  ],
+  "categories": [
+    "tools"
+  ]
+}

--- a/icons/soldering-iron.json
+++ b/icons/soldering-iron.json
@@ -4,14 +4,10 @@
     "psjdev"
   ],
   "use-cases": [
-    "Identifying tools required for electronics assembly",
+    "Representing electronics assembly and repair",
+    "Indicating circuit-board rework or modification",
     "Marking soldering steps in repair instructions",
-    "Locating electronics workstations in a makerspace",
-    "representing circuit-board repair or modification",
-    "selecting soldering equipment in tool inventories",
-    "marking soldering stations on workshop or makerspace maps",
-    "indicating soldering or hot-tip hazards in safety documentation",
-    "labeling diy electronics or hobbyist projects"
+    "Marking hot-tip hazards in safety documentation"
   ],
   "tags": [
     "solder",

--- a/icons/soldering-iron.svg
+++ b/icons/soldering-iron.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m10 9 1-1h2l4-4 3 3-4 4v2l-1 1Z" />
+  <path d="m11 10-6 6-2 5 5-2 6-6" />
+  <path d="M3 11c-3-3 3-5 0-8" />
+  <path d="m18.5 5.5 2.5-2.5q.5-.5 1 0" />
+</svg>


### PR DESCRIPTION
## Description

Adds a `soldering-iron` icon for representing soldering work, electronics assembly, and hardware repair. The design includes a pointed heated tip, a distinct handle, a short power cable, and a rising heat wisp.

### Icon use case

- Identifying tools required for electronics assembly
- Marking soldering steps in repair instructions
- Locating electronics workstations in a makerspace
- Representing circuit-board repair or modification
- Selecting soldering equipment in tool inventories

### Alternative icon designs

No alternative designs are included.

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] The icons are solely my own creation.
- [ ] The icons were originally created in #<issueNumber> by @<githubUser>
- [ ] I've based them on the following Lucide icons:
- [ ] I've based them on the following design:

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icons/naming-conventions).
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/[iconName].json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icons/design-principles).
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/40df4319-b136-4b49-987a-35f5c0450060" />
