### PR TITLE
feat(icons): add calendar-arrow-left and calendar-arrow-right (#4851)

### DIFF
--- a/icons/calendar-arrow-left.json
+++ b/icons/calendar-arrow-left.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "ryck"
+    "ryck",
+    "ishanbagra18"
   ],
+  "use-cases": [],
   "tags": [
     "date",
     "month",

--- a/icons/calendar-arrow-left.json
+++ b/icons/calendar-arrow-left.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "ryck"
+  ],
+  "tags": [
+    "date",
+    "month",
+    "year",
+    "event",
+    "previous",
+    "prior",
+    "earlier",
+    "reschedule",
+    "back",
+    "before"
+  ],
+  "categories": [
+    "time"
+  ]
+}

--- a/icons/calendar-arrow-left.svg
+++ b/icons/calendar-arrow-left.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m18 13-4 4 4 4" />
+  <path d="M16 2v3" />
+  <path d="M21 10.354V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h7.343" />
+  <path d="M22 17h-8" />
+  <path d="M3 9h18" />
+  <path d="M8 2v3" />
+</svg>

--- a/icons/calendar-arrow-right.json
+++ b/icons/calendar-arrow-right.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "ryck"
+  ],
+  "tags": [
+    "date",
+    "month",
+    "year",
+    "event",
+    "next",
+    "following",
+    "later",
+    "reschedule",
+    "forward",
+    "after"
+  ],
+  "categories": [
+    "time"
+  ]
+}

--- a/icons/calendar-arrow-right.json
+++ b/icons/calendar-arrow-right.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../icon.schema.json",
   "contributors": [
-    "ryck"
+    "ryck",
+    "ishanbagra18"
   ],
+  "use-cases": [],
   "tags": [
     "date",
     "month",

--- a/icons/calendar-arrow-right.svg
+++ b/icons/calendar-arrow-right.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14 17h8" />
+  <path d="M16 2v3" />
+  <path d="m18 13 4 4-4 4" />
+  <path d="M21 10.354V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h7.343" />
+  <path d="M3 9h18" />
+  <path d="M8 2v3" />
+</svg>


### PR DESCRIPTION
## Summary

Adds `calendar-arrow-left` and `calendar-arrow-right` icons to complement the existing directional calendar icons (`calendar-arrow-up` and `calendar-arrow-down`).

Closes #4851

---

## Added Icons

### 1. `calendar-arrow-left`

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=2.16uv3m18r3-4_4_4_4M21r0.354V5B0-2-2H5B0-o2v14B0o2h7.343M2o17h-8M3_9h18M8uv3&name=calendar-arrow-left"><img alt="calendar-arrow-left" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJtMTggMTMtNCA0IDQgNCIgLz4KICA8cGF0aCBkPSJNMTYgMnYzIiAvPgogIDxwYXRoIGQ9Ik0yMSAxMC4zNTRWNWEyIDIgMCAwMC0yLTJINWEyIDIgMCAwMC0yIDJ2MTRhMiAyIDAgMDAyIDJoNy4zNDMiIC8+CiAgPHBhdGggZD0iTTIyIDE3aC04IiAvPgogIDxwYXRoIGQ9Ik0zIDloMTgiIC8+CiAgPHBhdGggZD0iTTggMnYzIiAvPgo8L3N2Zz4=.svg"/><br/>Open in Lucide Studio</a>

### 2. `calendar-arrow-right`

<a title="Open lucide studio" target="_blank" href="https://studio.lucide.dev/edit?value=2.14r7h8M16uv3m18r3_4_4-4_4M21r0.354V5B0-2-2H5B0-o2v14B0o2h7.343M3_9h18M8uv3&name=calendar-arrow-right"><img alt="calendar-arrow-right" width="200px" src="https://lucide.dev/api/gh-icon/PHN2ZwogIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICB3aWR0aD0iMjQiCiAgaGVpZ2h0PSIyNCIKICB2aWV3Qm94PSIwIDAgMjQgMjQiCiAgZmlsbD0ibm9uZSIKICBzdHJva2U9ImN1cnJlbnRDb2xvciIKICBzdHJva2Utd2lkdGg9IjIiCiAgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIgogIHN0cm9rZS1saW5lam9pbj0icm91bmQiCj4KICA8cGF0aCBkPSJNMTQgMTdoOCIgLz4KICA8cGF0aCBkPSJNMTYgMnYzIiAvPgogIDxwYXRoIGQ9Im0xOCAxMyA4IDQtNCA0IiAvPgogIDxwYXRoIGQ9Ik0yMSAxMC4zNTRWNWEyIDIgMCAwMC0yLTJINWEyIDIgMCAwMC0yIDJ2MTRhMiAyIDAgMDAyIDJoNy4zNDMiIC8+CiAgPHBhdGggZD0iTTMgOWgxOCIgLz4KICA8cGF0aCBkPSJNOCAydjMiIC8+Cjwvc3ZnPg==.svg"/><br/>Open in Lucide Studio</a>

---

## Use Cases

- **`calendar-arrow-left`**: Rescheduling to an earlier date, navigating backward in date pickers/calendars, reverting date changes, jumping back in agenda timelines.
- **`calendar-arrow-right`**: Rescheduling to a later date, advancing forward in date pickers/calendars, pushing back event dates, navigating forward in agenda timelines.

---

## Icon Design Guidelines Checklist

- [x] Icons designed on a **24x24 pixels** canvas.
- [x] At least **1px padding** within the canvas.
- [x] Stroke width of **2 pixels**.
- [x] **Round joins** and **round caps** used.
- [x] **Centered strokes** without transforms, fills, or explicit strokes.
- [x] **2px border radius** on main shapes ≥ 8px.
- [x] **2px spacing** between distinct elements.
- [x] Optical volume and visual density matched with `calendar-arrow-up` / `calendar-arrow-down`.
- [x] Minified SVG path data tidied via Lucide Studio.
- [x] Matching JSON metadata files with schemas, tags, categories, and contributors.
