### PR TITLE
feat(icons): add archive-save icon

### DIFF
--- a/icons/archive-save.json
+++ b/icons/archive-save.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "karsa-mistmere",
+    "ericfennis",
+    "danielbayley",
+    "bduffany"
+  ],
+  "use-cases": [
+    "Archiving email messages from an inbox",
+    "Saving files and records to an archive"
+  ],
+  "tags": [
+    "index",
+    "backup",
+    "box",
+    "storage",
+    "records",
+    "email",
+    "download"
+  ],
+  "categories": [
+    "files",
+    "mail"
+  ]
+}

--- a/icons/archive-save.svg
+++ b/icons/archive-save.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="5" x="2" y="3" rx="1" />
+  <path d="M4 8v11a2 2 0 0 0 2 2h2" />
+  <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
+  <path d="m9 15 3-3 3 3" />
+  <path d="M12 12v9" />
+</svg>

--- a/icons/archive-save.svg
+++ b/icons/archive-save.svg
@@ -10,8 +10,8 @@
   stroke-linejoin="round"
 >
   <rect width="20" height="5" x="2" y="3" rx="1" />
-  <path d="M4 8v11a2 2 0 0 0 2 2h2" />
-  <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
+  <path d="M4 8v11a2 2 0 0 0 2 2h1" />
+  <path d="M20 8v11a2 2 0 0 1-2 2h-1" />
   <path d="m9 18 3 3 3-3" />
   <path d="M12 12v9" />
 </svg>

--- a/icons/archive-save.svg
+++ b/icons/archive-save.svg
@@ -12,6 +12,6 @@
   <rect width="20" height="5" x="2" y="3" rx="1" />
   <path d="M4 8v11a2 2 0 0 0 2 2h2" />
   <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
-  <path d="m9 15 3-3 3 3" />
+  <path d="m9 18 3 3 3-3" />
   <path d="M12 12v9" />
 </svg>


### PR DESCRIPTION
Expands the `archive` icon set with an `archive-save` icon.

The existing `archive` icon feels like a representation of an "archival box" but (in my opinion) does not effectively communicate the *action* of archiving, which `archive-save` does more explicitly.

![Archive icons](https://github.com/user-attachments/assets/ee02572d-61bc-48eb-b6f1-3e4cd73b9c19)

## Alternative proposals

**Alternative 1**: Raise the arrow to more clearly communicate that the content to be archived currently exists *outside* of the archive and *enters into* the archive when the `archive-save` action is performed.

![Archive restore and alternative archive-save icons](https://github.com/user-attachments/assets/ff10ae06-b782-4daa-8e23-48b82cd46481)

- **Pro**: It might be nice to visually show that the content starts outside of the archival box, and is being entered into it.

- **Con**: The gap introduced in the lid removes some useful visual signal that clearly identifies the container as an archival box.

## Construction method

**Step 0** ([1a53935d](https://github.com/lucide-icons/lucide/pull/4853/commits/1a53935dcb73a0f3a3e26ca4fec31c32f7ceb441)): Copy the `archive-restore` icon.

![Copy the existing archive-restore icon](https://github.com/user-attachments/assets/48a2ca94-78a8-44dc-9659-20cd5e8fbbe6)

**Step 1** ([6e03e3f4](https://github.com/lucide-icons/lucide/pull/4853/commits/6e03e3f48585db695987fca1dbf057bf11fa7210)): Reverse the arrow direction.

![Reverse the arrowhead](https://github.com/user-attachments/assets/9b60f335-d90c-47fa-bddb-eac67a562ecb)

```patch
diff --git a/icons/archive-save.svg b/icons/archive-save.svg
index ef30071d..d00d09a0 100644
--- a/icons/archive-save.svg
+++ b/icons/archive-save.svg
@@ -12,6 +12,6 @@
   <rect width="20" height="5" x="2" y="3" rx="1" />
   <path d="M4 8v11a2 2 0 0 0 2 2h2" />
   <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
-  <path d="m9 15 3-3 3 3" />
+  <path d="m9 18 3 3 3-3" />
   <path d="M12 12v9" />
 </svg>
```

**Step 2** ([f514cfbb](https://github.com/lucide-icons/lucide/pull/4853/commits/f514cfbba4c65bbd665ea34e825e3573628d21c5)): Reduce bottom-edge stroke lengths by 1 unit each to make more room for the arrowhead. [^1]

![Widen the bottom gap](https://github.com/user-attachments/assets/2dc8931a-3c1b-473c-b03b-4f74689f041e)

```patch
diff --git a/icons/archive-save.svg b/icons/archive-save.svg
index d00d09a0..7a087a78 100644
--- a/icons/archive-save.svg
+++ b/icons/archive-save.svg
@@ -10,8 +10,8 @@
   stroke-linejoin="round"
 >
   <rect width="20" height="5" x="2" y="3" rx="1" />
-  <path d="M4 8v11a2 2 0 0 0 2 2h2" />
-  <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
+  <path d="M4 8v11a2 2 0 0 0 2 2h1" />
+  <path d="M20 8v11a2 2 0 0 1-2 2h-1" />
   <path d="m9 18 3 3 3-3" />
   <path d="M12 12v9" />
 </svg>
```

Metadata is added in [82efe424](https://github.com/lucide-icons/lucide/pull/4853/commits/82efe42426c669468714292bbfceba85397b3074).

[^1]: Note, the resulting diagonal gap is not precisely 1 unit, since the "widening" edit was to simply reduce the stroke length by 1 unit, rather than the exact amount needed to produce a 1 unit diagonal gap. You can see this issue more clearly in the X-ray, if you look at the intersecting margin regions in this area. I figured this was an OK tradeoff, since a more precise diagonal gap would require much longer floating point values for the stroke, and/or some math that also takes the stroke width into account (?) There may be a better way to accomplish this step - I'm open to ideas here!
