### PR TITLE
feat(icons): add `archive-arrow-down` icon

### DIFF
--- a/icons/archive-arrow-down.json
+++ b/icons/archive-arrow-down.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../icon.schema.json",
+  "contributors": [
+    "karsa-mistmere",
+    "ericfennis",
+    "danielbayley",
+    "bduffany"
+  ],
+  "use-cases": [
+    "Archiving email messages from an inbox",
+    "Saving files and records to an archive"
+  ],
+  "tags": [
+    "index",
+    "backup",
+    "box",
+    "storage",
+    "records",
+    "email",
+    "download",
+    "save"
+  ],
+  "categories": [
+    "files",
+    "mail"
+  ]
+}

--- a/icons/archive-arrow-down.svg
+++ b/icons/archive-arrow-down.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="5" x="2" y="3" rx="1" />
+  <path d="M4 8v11a2 2 0 0 0 2 2h2" />
+  <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
+  <path d="m9 15 3-3 3 3" />
+  <path d="M12 12v9" />
+</svg>

--- a/icons/archive-arrow-down.svg
+++ b/icons/archive-arrow-down.svg
@@ -10,8 +10,8 @@
   stroke-linejoin="round"
 >
   <rect width="20" height="5" x="2" y="3" rx="1" />
-  <path d="M4 8v11a2 2 0 0 0 2 2h2" />
-  <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
+  <path d="M4 8v11a2 2 0 0 0 2 2h.343" />
+  <path d="M20 8v11a2 2 0 0 1-2 2h-.343" />
   <path d="m9 18 3 3 3-3" />
   <path d="M12 12v9" />
 </svg>

--- a/icons/archive-arrow-down.svg
+++ b/icons/archive-arrow-down.svg
@@ -12,6 +12,6 @@
   <rect width="20" height="5" x="2" y="3" rx="1" />
   <path d="M4 8v11a2 2 0 0 0 2 2h2" />
   <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
-  <path d="m9 15 3-3 3 3" />
+  <path d="m9 18 3 3 3-3" />
   <path d="M12 12v9" />
 </svg>


### PR DESCRIPTION
## Description

Expands the `archive` icon set with an `archive-arrow-down` icon.

![Archive icons](https://github.com/user-attachments/assets/8ad50637-73e7-41fa-8ef8-e96766e377da)

Supersedes #4853.

### Icon use case

- Archiving email messages from an inbox
- Saving files and records to an archive

### Alternative icon designs

Here are several alternatives, where each one just changes the Y position of the arrow.

![Archive arrow placement alternatives A–J](https://github.com/user-attachments/assets/3c2306e7-a3e1-46dd-8c40-56430452936b)

Of these, my preference is for A, since it fully preserves the distinctive lid shape of the archive icon.

### Construction method

**Step 1** ([0606db4f](https://github.com/lucide-icons/lucide/pull/4854/commits/0606db4f453eea341fcef54d54be2343fddd9e25)): Copy the `archive-restore` icon.

![Copy the existing archive-restore icon](https://github.com/user-attachments/assets/48a2ca94-78a8-44dc-9659-20cd5e8fbbe6)

**Step 2** ([8e18a962](https://github.com/lucide-icons/lucide/pull/4854/commits/8e18a96214f8d88d94c8ae34ec86fa571f6579b5)): Reverse the arrow direction.

![Reverse the arrowhead](https://github.com/user-attachments/assets/9b60f335-d90c-47fa-bddb-eac67a562ecb)

**Step 3** ([576ab78a](https://github.com/lucide-icons/lucide/pull/4854/commits/576ab78a591b15881bb5d6362ca76d6ef3b45b7e)): Reduce bottom-edge stroke lengths by 1.657 units each to provide 2 units of visible diagonal clearance around the arrowhead. [^1]

![Widen the bottom gap](https://github.com/user-attachments/assets/409a88c0-0151-41b5-9a0c-b72af6feed78)

Metadata is added in [3ae3ef3b](https://github.com/lucide-icons/lucide/pull/4854/commits/3ae3ef3b173d0c253f37abf2a0a8e61aef6ed245).

## Icon Design Checklist

### Concept

- [x] I have provided valid use cases for each icon.
- [x] I have [not added any brand or logo icon](https://github.com/lucide-icons/lucide/blob/main/BRAND_LOGOS_STATEMENT.md).
- [x] I have not used any hate symbols.
- [x] I have not included any religious, war/violence related or political imagery.

### Author, credits & license

- [x] I've based them on the following Lucide icons: `archive-restore`.

### Naming

- [x] I've read and followed the [naming conventions](https://lucide.dev/contribute/icons/naming-conventions)
- [x] I've named icons by what they are rather than their use case.
- [x] I've provided meta JSON files in `icons/archive-arrow-down.json`.

### Design

- [x] I've read and followed the [icon design guidelines](https://lucide.dev/contribute/icons/specification)
- [x] I've made sure that the icons don't [already exist](https://lucide.dev/icons), including the [Lab directory](https://github.com/lucide-icons/lucide/tree/main/lab).
- [x] I've made sure that the icons look sharp on low DPI displays.
- [x] I've made sure that the icons look consistent with the icon set in size, optical volume and density.
- [x] I've made sure that the icons are visually centered.
- [x] I've correctly optimized all icons to three points of precision.

## Before Submitting

- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.

[^1]: With a 2-unit stroke, the visible diagonal clearance is `(12 - x) / sqrt(2) - 2`, where `x` is the left bottom endpoint. The symmetric endpoints `x = 6.343` and `x = 17.657` give approximately 2.0001 units of clearance after rounding coordinates to three decimals.
